### PR TITLE
updated install dependencies in test

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Docker container creates isolated virtual environment that shares resources with
 
 ### Pull Image from Docker Hub
 * GPU: `docker pull fastestimator/fastestimator:latest-gpu`
+* CPU: `docker pull fastestimator/fastestimator:latest-cpu`
 
 ## Running your first FastEstimator training
 * macOS/Linux:

--- a/test/install_dependencies.sh
+++ b/test/install_dependencies.sh
@@ -5,5 +5,5 @@ if [ ! -d "venv"  ]; then
 fi
 . venv/bin/activate
 
-pip3 install tensorflow==1.13.1 pytest numpy nibabel pydicom horovod
+pip3 install tensorflow==1.12.0 pytest numpy nibabel pydicom
 pip3 install -e .


### PR DESCRIPTION
r0.2 version requires tensorflow 1.12.0 version instead of 1.13.1.

there is no need to install horovod for unit test (at least for cpu or single gpu)


Now here's the problem:
we may need different install dependency script for cpu, gpu, multi-gpu because their dependencies are different.       