### PR TITLE
 U-MAP Visualization Technique for Interpretability 

### DIFF
--- a/bin/fastestimator
+++ b/bin/fastestimator
@@ -7,6 +7,7 @@ import sys
 from pyfiglet import Figlet
 
 from fastestimator.util.util import parse_cli_to_dictionary
+from fastestimator.visualization.layer_umap import umap_layers
 from fastestimator.visualization.parse_logs import parse_folder
 from fastestimator.visualization.saliency_masks import load_and_interpret
 
@@ -67,8 +68,8 @@ def configure_log_parser(subparsers):
     save_x_group = save_group.add_mutually_exclusive_group(required=False)
     save_x_group.add_argument('--save', nargs='?', metavar='<Save Dir>', dest='save', action=SaveAction,
                               default=False, help="Save the output image. May be accompanied by a directory into \
-                                              which the file is saved. If no output directory is specified, the log directory will \
-                                              be used")
+                                              which the file is saved. If no output directory is specified, the log \
+                                              directory will be used")
     save_x_group.add_argument('--display', dest='save', action='store_false',
                               help="Render the image to the UI (rather than saving it)", default=True)
     save_x_group.set_defaults(save_dir=None)
@@ -91,30 +92,80 @@ def configure_saliency_parser(subparsers):
     parser.add_argument('model', metavar='<Model Path>', type=str,
                         help="The path to a saved model file")
     parser.add_argument('inputs', metavar='Input', type=str, nargs='+',
-                        help="The paths to one or more inputs to visualize")
+                        help="The paths to one or more inputs to visualize (or the path to a folder which will be \
+                        recursively traversed to find image files)")
     parser.add_argument('--dictionary', metavar='<Dictionary Path>', type=str,
-                        help="The path to a {'class_id':'class_name} json file", default=None)
+                        help="The path to a {'class_id':'class_name'} json file", default=None)
     parser.add_argument('--smooth', metavar='N', type=int, default=7,
                         help="The number of samples to use when generating smoothed saliency masks")
     parser.add_argument('--type', metavar='T', type=str, default='float32',
                         help="The dtype of the inputs to the model")
     parser.add_argument('--baseline', metavar='B', type=str, default='-1',
-                        help="The value to use as a baseline for integrated gradient calculations. Can be \
-                                                        either a number or the path to an image. What would a 'blank' input look \
-                                                        like")
+                        help="The value to use as a baseline for integrated gradient calculations. Can be either a \
+                        number or the path to an image. What would a 'blank' input look like")
     parser.add_argument('--strip-alpha', action='store_true',
                         help="True if you want to convert RGBA images to RGB")
     save_group = parser.add_argument_group('output arguments')
     save_x_group = save_group.add_mutually_exclusive_group(required=False)
     save_x_group.add_argument('--save', nargs='?', metavar='<Save Dir>',
                               help="Save the output image. May be accompanied by a directory into which the \
-                                                    file is saved. If no output directory is specified, the model directory will be\
-                                                     used",
+                              file is saved. If no output directory is specified, the model directory will be used",
                               dest='save', action=SaveAction, default=False)
     save_x_group.add_argument('--display', dest='save', action='store_false',
                               help="Render the image to the UI (rather than saving it)", default=True)
     save_x_group.set_defaults(save_dir=None)
     parser.set_defaults(func=saliency)
+
+
+def umap(args, unknown):
+    hyperparameters = parse_cli_to_dictionary(unknown)
+    umap_layers(args['model'], args['input_dir'], print_layers=args['print_layers'], strip_alpha=args['strip_alpha'],
+                input_type=args['type'], layers=args['layers'], batch=args['batch'], use_cache=args['cache'],
+                cache_dir=args['cache_dir'], dictionary_path=args['dictionary'], legend_mode=args['legend'],
+                save=args['save'], save_dir=args['save_dir'], umap_parameters=hyperparameters)
+
+
+def configure_umap_parser(subparsers):
+    parser = subparsers.add_parser('umap',
+                                   description='Plots umaps for model layers over given inputs',
+                                   formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('model', metavar='<Model Path>', type=str,
+                        help="The path to a saved model file")
+    parser.add_argument('input_dir', metavar='Input', type=str,
+                        help="The path to a folder of folders containing inputs sorted by class")
+    parser.add_argument('--print-layers', action='store_true',
+                        help="True if you only want to print a model's layers to the console. Useful for inspecting a \
+                            model to choose which layer indices to visualize.")
+    parser.add_argument('--layers', metavar='IDX', type=int, nargs='+',
+                        help='The indices of layers you want to visualize. If not provided then all layers will be \
+                                      analyzed, but that is likely to run out of memory on moderately sized models.')
+    parser.add_argument('--strip-alpha', action='store_true',
+                        help="True if you want to convert RGBA images to RGB")
+    parser.add_argument('--type', metavar='T', type=str, default='float32',
+                        help="The dtype of the inputs to the model")
+    parser.add_argument('--batch', type=int, default=50,
+                        help="How many images to process at a time (set based on available RAM)")
+    parser.add_argument('--dictionary', metavar='<Dictionary Path>', type=str,
+                        help="The path to a {'class_id':'class_name'} json file", default=None)
+    parser.add_argument('--legend', choices=['on', 'off', 'shared'], default='shared',
+                        help='Whether to display legends or not.')
+    save_group = parser.add_argument_group('output arguments')
+    save_group.add_argument('--cache', metavar='<Cache Dir>', action=SaveAction, default=False,
+                            help="Enable caching of intermediate results. Highly recommended to reduce RAM \
+                            requirements. If no cache directory is specified, a sibling of the input directory will be \
+                            used")
+    save_group.set_defaults(cache_dir=None)
+    save_x_group = save_group.add_mutually_exclusive_group(required=False)
+    save_x_group.add_argument('--save', nargs='?', metavar='<Save Dir>', dest='save', action=SaveAction,
+                              default=False, help="Save the output image. May be accompanied by a directory into \
+                                                      which the file is saved. If no output directory is specified, \
+                                                      the model directory will be used")
+    save_x_group.add_argument('--display', dest='save', action='store_false',
+                              help="Render the image to the UI (rather than saving it)", default=True)
+    save_x_group.set_defaults(save_dir=None)
+    parser.add_argument_group('umap arguments', 'Arguments from the umap module may all be passed through. Examples \
+    include --n_neighbors <int>, --metric <str>, --n_epochs <int>, --min_dist <float>, --learning_rate <float>, etc...')
+    parser.set_defaults(func=umap)
 
 
 def configure_visualization_parser(subparsers):
@@ -126,6 +177,7 @@ def configure_visualization_parser(subparsers):
 
     configure_log_parser(visualization_subparsers)
     configure_saliency_parser(visualization_subparsers)
+    configure_umap_parser(visualization_subparsers)
 
 
 def train(args, unknown):

--- a/fastestimator/util/loader.py
+++ b/fastestimator/util/loader.py
@@ -1,0 +1,70 @@
+import math
+import os
+
+import numpy as np
+# noinspection PyPackageRequirements
+import tensorflow as tf
+
+from fastestimator.util.util import load_image
+
+
+class PathLoader(object):
+    def __init__(self, root_path, batch=10, input_extension=None):
+        """
+        Args:
+            root_path: The path the the root directory containing files to be read
+        """
+        if not os.path.isdir(root_path):
+            raise AssertionError("Provided path is not a directory")
+        self.root_path = root_path
+        if batch < 1:
+            raise AssertionError("Batch size must be positive")
+        self.batch = batch
+        self.input_extension = input_extension
+        self.current_idx = 0
+        self.path_pairs = self.get_file_paths()
+
+    def __iter__(self):
+        return self
+
+    def get_file_paths(self):
+        path_pairs = []
+        for root, dirs, files in os.walk(self.root_path):
+            for file_name in files:
+                if file_name.startswith(".") or (
+                        self.input_extension is not None and not file_name.endswith(self.input_extension)):
+                    continue
+                path_pairs.append((os.path.join(root, file_name), os.path.basename(root)))
+        return path_pairs
+
+    def __next__(self):
+        if self.current_idx >= len(self.path_pairs):
+            raise StopIteration
+        else:
+            result = self.path_pairs[self.current_idx:self.current_idx + self.batch]
+            self.current_idx += self.batch
+            return result
+
+    def __len__(self):
+        return math.ceil(len(self.path_pairs) / self.batch)
+
+
+class ImageLoader(PathLoader):
+    def __init__(self, root_path, batch=10, input_extension=None, strip_alpha=False, input_type='float32'):
+        super(ImageLoader, self).__init__(root_path, batch, input_extension)
+        self.strip_alpha = strip_alpha
+        self.input_type = input_type
+
+    def __next__(self):
+        paths = super(ImageLoader, self).__next__()
+        inputs = [load_image(paths[i][0], strip_alpha=self.strip_alpha) for i in range(len(paths))]
+        max_shapes = np.maximum.reduce([inp.shape for inp in inputs], axis=0)
+        max_shapes[
+            0] = 500  # problem: if different batches have different im size then the feature count will be different
+        max_shapes[1] = 500
+        batch_inputs = tf.stack([tf.image.resize_with_crop_or_pad(tf.convert_to_tensor(im, dtype=self.input_type),
+                                                                  max_shapes[0], max_shapes[1]) for im in inputs],
+                                axis=0)
+
+        batch_classes = [paths[i][1] for i in range(len(paths))]
+        return batch_inputs, batch_classes

--- a/fastestimator/visualization/layer_umap.py
+++ b/fastestimator/visualization/layer_umap.py
@@ -1,0 +1,212 @@
+import math
+import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+import seaborn as sns
+# noinspection PyPackageRequirements
+import tensorflow as tf
+# noinspection PyPackageRequirements
+import umap
+from matplotlib.lines import Line2D
+from mpl_toolkits.mplot3d import Axes3D
+# noinspection PyPackageRequirements
+from tensorflow.python import keras
+from tqdm import tqdm
+
+from fastestimator.util.loader import ImageLoader
+from fastestimator.util.util import load_dict
+
+assert Axes3D  # Axes3D is used to enable projection='3d', but will show up as unused without the assert
+
+
+def map_classes_to_colors(classifications):
+    classes = set(classifications)
+    num_classes = len(classes)
+    colors = sns.hls_palette(n_colors=num_classes, s=0.95) if num_classes > 10 else sns.color_palette(
+        "colorblind")
+    class_to_color = {clazz: idx for idx, clazz in enumerate(classes)}
+    return [colors[class_to_color[clazz]] for clazz in classifications], {clazz: colors[class_to_color[clazz]] for clazz
+                                                                          in classes}
+
+
+def draw_umaps(layer_outputs, classifications, dictionary=None, layers=None, layer_ids=None, save=False, save_path='.',
+               legend_mode='shared'):
+    color_list, color_map = map_classes_to_colors(classifications)
+
+    num_layers = len(layer_outputs)
+    n_components = len(layer_outputs[0][0])
+    num_cols = math.ceil(math.sqrt(num_layers))
+    num_rows = math.ceil(num_layers / num_cols)
+    layer_grid_location = {idx: (idx // num_cols, idx % num_cols) for idx in range(num_layers)}
+
+    sns.set_context('paper')
+    if n_components == 3:
+        fig, axs = plt.subplots(num_rows, num_cols, figsize=(4 * num_cols, 2.8 * num_rows),
+                                subplot_kw={'projection': '3d'})
+    else:
+        fig, axs = plt.subplots(num_rows, num_cols, figsize=(4 * num_cols, 2.8 * num_rows))
+
+    # If only one row, need to re-format the axs object for consistency. Likewise for columns
+    if num_rows == 1:
+        axs = [axs]
+        if num_cols == 1:
+            axs = [axs]
+
+    # some of the columns in the last row might be unused, so disable them
+    last_column_idx = num_cols - (num_rows * num_cols - num_layers) - 1
+    for i in range(last_column_idx + 1, num_cols):
+        axs[num_rows - 1][i].axis('off')
+
+    # Turn off axis since numeric values are not meaningful
+    for i in range(num_rows):
+        for j in range(num_cols):
+            axis = axs[i][j]
+            axis.set_yticks([], [])
+            axis.set_yticklabels([])
+            axis.set_xticks([], [])
+            axis.set_xticklabels([])
+
+    for idx, layer in enumerate(layer_outputs):
+        ax = axs[layer_grid_location[idx][0]][layer_grid_location[idx][1]]
+        layer_id = idx if layer_ids is None else layer_ids[idx]
+        layer_name = "" if layers is None else ": " + layers[layer_id].name
+        ax.set_title("Layer {}{}".format(layer_id, layer_name))
+        if n_components == 1:
+            ax.scatter(layer[:, 0], range(len(layer)), c=color_list, s=3)
+        if n_components == 2:
+            ax.scatter(layer[:, 0], layer[:, 1], c=color_list, s=3)
+        if n_components == 3:
+            ax.scatter(layer[:, 0], layer[:, 1], layer[:, 2], c=color_list, s=3)
+    plt.tight_layout()
+
+    if legend_mode != 'off':
+        legend_elements = [Line2D([0], [0], marker='o', color='w', markerfacecolor=color_map[clazz],
+                                  label=clazz if dictionary is None else dictionary[clazz],
+                                  markersize=7) for clazz in color_map]
+        if legend_mode == 'shared' and num_rows > 1:
+            if last_column_idx == num_cols - 1:
+                fig.subplots_adjust(bottom=0.15)
+                fig.legend(handles=legend_elements, loc='lower center', ncol=num_cols + 1)
+            else:
+                axs[num_rows - 1][last_column_idx + 1].legend(handles=legend_elements, loc='center', fontsize='large')
+        else:
+            for i in range(num_rows):
+                for j in range(num_cols):
+                    if i == num_rows - 1 and j > last_column_idx:
+                        break
+                    axs[i][j].legend(handles=legend_elements, loc='best', fontsize='small')
+
+    if not save:
+        plt.show()
+    else:
+        os.makedirs(os.path.dirname(save_path), exist_ok=True)
+        save_file = os.path.join(os.path.dirname(save_path), 'umaps.png')
+        print("Saving to {}".format(save_file))
+        plt.savefig(save_file, dpi=300)
+
+
+class Evaluator(object):
+    def __init__(self, model, layers=None):
+        """
+        Args:
+            model: The ML model to generate outputs from
+            layers: The layer indices to be investigated by the evaluator. If not provided then all layers will be used
+        """
+        self.model = model
+        self.layers = layers if layers is not None and len(layers) > 0 else [i for i in range(model.layers)]
+        self.num_layers = len(self.layers)
+        self.functor = tf.keras.backend.function([self.model.input], [self.model.layers[i].output for i in self.layers])
+
+    def evaluate(self, x):
+        layer_outputs = self.functor([x])
+        return [np.reshape(layer, [x.shape[0], -1]) for layer in layer_outputs]
+
+
+class FileCache(object):
+    def __init__(self, root_path, layers, umap_parameters):
+        self.root_path = root_path
+        print("Saving cache files to {}".format(self.root_path))
+        os.makedirs(self.root_path, exist_ok=True)
+        self.idx = 0
+        self.layers = layers
+        self.num_layers = len(self.layers)
+        self.fit = umap.UMAP(**umap_parameters)
+
+    def save(self, data, classes):
+        if len(data) != self.num_layers:
+            raise IndexError("Inconsistent Layer Count Detected")
+        [np.save(os.path.join(self.root_path, "layer{}-batch{}.npy".format(self.layers[layer], self.idx)), data[layer])
+         for layer in range(self.num_layers)]
+        np.save(os.path.join(self.root_path, "class{}.npy".format(self.idx)), classes)
+        self.idx += 1
+
+    def batch_cached(self, batch_id):
+        return os.path.isfile(os.path.join(self.root_path, "class{}.npy".format(batch_id))) and all(
+            [os.path.isfile(os.path.join(self.root_path, "layer{}-batch{}.npy".format(self.layers[layer], batch_id)))
+             for layer in range(self.num_layers)])
+
+    def load_and_transform(self, batches=None):
+        if batches is None:
+            batches = self.idx
+        data = [None for _ in range(self.num_layers)]
+        for layer in range(self.num_layers):
+            layer_data = None
+            for batch in range(batches):
+                dat = np.load(os.path.join(self.root_path, "layer{}-batch{}.npy".format(self.layers[layer], batch)),
+                              allow_pickle=True)
+                layer_data = dat if layer_data is None else np.concatenate((layer_data, dat), axis=0)
+            data[layer] = self.fit.fit_transform(layer_data)
+
+        classes = []
+        for batch in range(batches):
+            clazz = np.load(os.path.join(self.root_path, "class{}.npy".format(batch)), allow_pickle=True)
+            classes.extend(clazz)
+
+        return data, classes
+
+
+def umap_layers(model_path, input_root_path, print_layers=False, strip_alpha=False, input_type='float32', layers=None,
+                input_extension='JPEG', batch=10, use_cache=True, cache_dir=None, dictionary_path=None, save=False,
+                save_dir=None, legend_mode='shared', umap_parameters=None):
+    if umap_parameters is None:
+        umap_parameters = {}
+    if save_dir is None:
+        save_dir = os.path.dirname(model_path)
+    if cache_dir is None:
+        cache_dir = os.path.join(os.path.dirname(input_root_path),
+                                 os.path.basename(input_root_path) + "__layer_outputs")
+
+    network = keras.models.load_model(model_path)
+    if print_layers:
+        for idx, layer in enumerate(network.layers):
+            print("{}: {} --- output shape: {}".format(idx, layer.name, layer.output_shape))
+        return
+
+    evaluator = Evaluator(network, layers=layers)
+    loader = ImageLoader(input_root_path, batch=batch, input_extension=input_extension, strip_alpha=strip_alpha,
+                         input_type=input_type)
+    cache = FileCache(cache_dir, evaluator.layers, umap_parameters) if use_cache else None
+
+    classes = []
+    layer_outputs = None
+    for batch_id, (batch_inputs, batch_classes) in enumerate(tqdm(loader, desc='Computing Outputs', unit='batch')):
+        if use_cache and cache.batch_cached(batch_id):
+            continue
+        batch_layer_outputs = evaluator.evaluate(batch_inputs)
+        if use_cache:
+            cache.save(batch_layer_outputs, batch_classes)
+        else:
+            if layer_outputs is None:
+                layer_outputs = batch_layer_outputs
+            else:
+                for i, (layer, batch_layer) in enumerate(zip(layer_outputs, batch_layer_outputs)):
+                    layer_outputs[i] = np.concatenate((layer, batch_layer), axis=0)
+            classes.extend(batch_classes)
+    if use_cache:
+        layer_outputs, classes = cache.load_and_transform(len(loader))
+    else:
+        fit = umap.UMAP(**umap_parameters)
+        layer_outputs = [fit.fit_transform(layer) for layer in layer_outputs]
+    draw_umaps(layer_outputs, classes, layer_ids=layers, layers=network.layers, save=save, save_path=save_dir,
+               dictionary=load_dict(dictionary_path, True),  legend_mode=legend_mode)

--- a/fastestimator/visualization/layer_umap.py
+++ b/fastestimator/visualization/layer_umap.py
@@ -100,8 +100,8 @@ def draw_umaps(layer_outputs, classifications, dictionary=None, layers=None, lay
     if not save:
         plt.show()
     else:
-        os.makedirs(os.path.dirname(save_path), exist_ok=True)
-        save_file = os.path.join(os.path.dirname(save_path), 'umaps.png')
+        os.makedirs(save_path, exist_ok=True)
+        save_file = os.path.join(save_path, 'umaps.png')
         print("Saving to {}".format(save_file))
         plt.savefig(save_file, dpi=300)
 

--- a/fastestimator/visualization/parse_logs.py
+++ b/fastestimator/visualization/parse_logs.py
@@ -9,6 +9,7 @@ import seaborn as sns
 from scipy.ndimage.filters import gaussian_filter1d
 
 from fastestimator.util.util import prettify_metric_name, remove_blacklist_keys, strip_suffix
+from fastestimator.util.loader import PathLoader
 
 
 def parse_file(file_path):
@@ -159,7 +160,8 @@ def parse_files(file_paths, log_extension='.txt', smooth_factor=0, save=False, s
     Returns:
         None
     """
-    assert len(file_paths) > 0, "must provide at least one log file"
+    if file_paths is None or len(file_paths) < 1:
+        raise AssertionError("must provide at least one log file")
 
     files_metrics = {}
     for file_path in file_paths:
@@ -188,14 +190,7 @@ def parse_folder(dir_path, log_extension='.txt', smooth_factor=1, save=False, sa
     Returns:
         None
     """
-    assert os.path.isdir(dir_path), "provided path is not a directory"
-
-    file_paths = []
-    for file_name in os.listdir(dir_path):
-        file_name = os.fsdecode(file_name)
-        file_path = os.path.join(dir_path, file_name)
-
-        if file_name.endswith(log_extension):
-            file_paths.append(file_path)
+    loader = PathLoader(dir_path, input_extension=log_extension)
+    file_paths = [x[0] for x in loader.path_pairs]
 
     parse_files(file_paths, log_extension, smooth_factor, save, save_path, ignore_metrics, share_legend, pretty_names)

--- a/fastestimator/visualization/parse_logs_test.py
+++ b/fastestimator/visualization/parse_logs_test.py
@@ -143,14 +143,14 @@ class TestParser(TestCase):
         mock_dir = '/good/'
         parse_mock = MagicMock()
         is_dir_mock = MagicMock(return_value=True)
-        list_mock = MagicMock(return_value=['/good/file1.log', '/good/file2.log', '/good/file3.txt', '/good/file4'])
+        walk_mock = MagicMock(return_value=[('/good', (), ('file1.log', 'file2.log', 'file3.txt', 'file4'))])
         with patch('fastestimator.visualization.parse_logs.parse_files', parse_mock), patch(
-                'fastestimator.visualization.parse_logs.os.path.isdir', is_dir_mock), patch(
-                'fastestimator.visualization.parse_logs.os.listdir', list_mock):
+                'fastestimator.util.loader.os.path.isdir', is_dir_mock), patch(
+                'fastestimator.util.loader.os.walk', walk_mock):
             parse_folder(mock_dir, log_extension='.log', smooth_factor=2, save=True, save_path=None,
                          ignore_metrics=['lr'])
         is_dir_mock.assert_called_once_with(mock_dir)
-        list_mock.assert_called_once_with(mock_dir)
+        walk_mock.assert_called_once_with(mock_dir)
         parse_mock.assert_called_once_with(['/good/file1.log', '/good/file2.log'], '.log', 2, True, None, ['lr'],
                                            True,
                                            False)
@@ -159,10 +159,10 @@ class TestParser(TestCase):
         mock_dir = '/bad/'
         parse_mock = MagicMock()
         is_dir_mock = MagicMock(return_value=False)
-        list_mock = MagicMock(return_value=['/good/file1.log', '/good/file2.log', '/good/file3.txt', '/good/file4'])
+        walk_mock = MagicMock(return_value=[('/good', (), ('file1.log', 'file2.log', 'file3.txt', 'file4'))])
         with patch('fastestimator.visualization.parse_logs.parse_files', parse_mock), patch(
-                'fastestimator.visualization.parse_logs.os.path.isdir', is_dir_mock), patch(
-                'fastestimator.visualization.parse_logs.os.listdir', list_mock):
+                'fastestimator.util.loader.os.path.isdir', is_dir_mock), patch(
+                'fastestimator.util.loader.os.walk', walk_mock):
             self.assertRaises(AssertionError, parse_folder, mock_dir)
         is_dir_mock.assert_called_once_with(mock_dir)
 
@@ -170,14 +170,14 @@ class TestParser(TestCase):
         mock_dir = '/good/'
         parse_mock = MagicMock()
         is_dir_mock = MagicMock(return_value=True)
-        list_mock = MagicMock(return_value=[])
+        walk_mock = MagicMock(return_value=[('/good', (), ())])
         with patch('fastestimator.visualization.parse_logs.parse_files', parse_mock), patch(
-                'fastestimator.visualization.parse_logs.os.path.isdir', is_dir_mock), patch(
-                'fastestimator.visualization.parse_logs.os.listdir', list_mock):
+                'fastestimator.util.loader.os.path.isdir', is_dir_mock), patch(
+                'fastestimator.util.loader.os.walk', walk_mock):
             parse_folder(mock_dir, log_extension='.log', smooth_factor=2, save=True, save_path=None,
                          ignore_metrics=['lr'])
         is_dir_mock.assert_called_once_with(mock_dir)
-        list_mock.assert_called_once_with(mock_dir)
+        walk_mock.assert_called_once_with(mock_dir)
         parse_mock.assert_called_once_with([], '.log', 2, True, None, ['lr'], True,
                                            False)
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,9 @@ setup(name="fastestimator",
           'pytest',
           'pytest-cov',
           'opencv-python',
-          'tensorflow-addons'
+          'tensorflow-addons',
+          'umap-learn',
+          'tqdm'
       ],
       # Declare extra set for installation
       extras_require={


### PR DESCRIPTION
Provide layer-by-layer umap visualization of given inputs. Example usage:

fastestimator visualize umap ./inceptionV3.h5 ./val10 --dictionary ./imagenet_class_index.json --cache --layers 1 150 310 --save

![umaps](https://user-images.githubusercontent.com/8201565/60474813-19166100-9c29-11e9-8c49-ad852db79211.png)



allow saliency vis to take a folder of inputs instead of only a list of files (+3 squashed commits)

Squashed commits:
[e00494f] display layer names
[a306357] update log parser to use the new pathloader
[7b1d1da] cache layer idx correctly (+16 squashed commits)
Squashed commits:
[1fc2298] fix import
[7d38e6b] separate loader class in preparation for multi-process loading
[bb7a6ef] fix an issue when batch size > num samples
[ff7ac8b] code smell cleanup
[5dadf62] switch to os.walk() for better input flexibility
[fd14c92] further argument cleanup
[01aeb10] extra help message
[a7e9bc9] pass-through umap settings
[250f099] add umap functionality to FE script
[4cafca8] legend and cache restarts
[cfb5268] cache the batch results
[7904c88] cleaned-up graph
[9e65d34] put layers in subplots
[257f0d4] generates maps, still heavily RAM bound
[1aad710] folder-based parsing
[c88fef2] start of umap efforts