### PR TITLE
Adversarial and Mixup showcases

### DIFF
--- a/bin/fastestimator
+++ b/bin/fastestimator
@@ -36,8 +36,8 @@ def logs(args, unknown):
     if len(unknown) > 0:
         print("error: unrecognized arguments: ", str.join(", ", unknown))
         sys.exit(-1)
-    parse_folder(args['log_dir'], args['extension'], args['smooth'], args['save'], args['save_dir'], args['ignore'],
-                 args['share_legend'], args['pretty_names'])
+    parse_folder(args['log_dir'], args['extension'], args['recursive'], args['smooth'], args['save'], args['save_dir'],
+                 args['ignore'], args['share_legend'], args['pretty_names'])
 
 
 def configure_log_parser(subparsers):
@@ -49,6 +49,7 @@ def configure_log_parser(subparsers):
     parser.add_argument('--extension', metavar='E', type=str,
                         help="The file type / extension of your logs",
                         default=".txt")
+    parser.add_argument('--recursive', action='store_true', help="Recursively search sub-directories for log files")
     parser.add_argument('--ignore', metavar='I', type=str, nargs='+',
                         help="The names of metrics to ignore though they may be present in the log files")
     parser.add_argument('--smooth', metavar='<float>', type=float,

--- a/fastestimator/architecture/lenet.py
+++ b/fastestimator/architecture/lenet.py
@@ -1,7 +1,8 @@
-from tensorflow.keras import layers, models
+from tensorflow.python.keras import layers, Sequential
 
-def LeNet(input_shape=(28,28,1), classes=10):
-    model = models.Sequential()
+
+def LeNet(input_shape=(28, 28, 1), classes=10):
+    model = Sequential()
     model.add(layers.Conv2D(32, (3, 3), activation='relu', input_shape=input_shape))
     model.add(layers.MaxPooling2D((2, 2)))
     model.add(layers.Conv2D(64, (3, 3), activation='relu'))

--- a/fastestimator/architecture/lenet.py
+++ b/fastestimator/architecture/lenet.py
@@ -1,4 +1,4 @@
-from tensorflow.python.keras import layers, Sequential
+from tensorflow.keras import layers, Sequential
 
 
 def LeNet(input_shape=(28, 28, 1), classes=10):

--- a/fastestimator/util/loader.py
+++ b/fastestimator/util/loader.py
@@ -8,10 +8,13 @@ from fastestimator.util.util import load_image
 
 
 class PathLoader(object):
-    def __init__(self, root_path, batch=10, input_extension=None):
+    def __init__(self, root_path, batch=10, input_extension=None, recursive_search=True):
         """
         Args:
             root_path: The path the the root directory containing files to be read
+            batch: The batch size to use when loading paths. Must be positive
+            input_extension: A file extension to limit what sorts of paths are returned
+            recursive_search: Whether to search within subdirectories for files
         """
         if not os.path.isdir(root_path):
             raise AssertionError("Provided path is not a directory")
@@ -20,6 +23,7 @@ class PathLoader(object):
             raise AssertionError("Batch size must be positive")
         self.batch = batch
         self.input_extension = input_extension
+        self.recursive_search = recursive_search
         self.current_idx = 0
         self.path_pairs = self.get_file_paths()
 
@@ -34,6 +38,8 @@ class PathLoader(object):
                         self.input_extension is not None and not file_name.endswith(self.input_extension)):
                     continue
                 path_pairs.append((os.path.join(root, file_name), os.path.basename(root)))
+            if not self.recursive_search:
+                break
         return path_pairs
 
     def __next__(self):

--- a/fastestimator/util/util.py
+++ b/fastestimator/util/util.py
@@ -9,6 +9,8 @@ import numpy as np
 # noinspection PyPackageRequirements
 import tensorflow as tf
 import sys
+from contextlib import ContextDecorator
+import time
 
 
 def load_image(file_path, strip_alpha=False, channels=3):
@@ -229,10 +231,32 @@ class Suppressor(object):
         sys.stdout = self
         sys.stderr = self
 
-    def __exit__(self, type, value, traceback):
+    def __exit__(self, exc_type, exc_val, exc_tb):
         sys.stdout = self.stdout
         sys.stderr = self.stderr
-        if type is not None:
+        if exc_type is not None:
             raise
 
     def write(self, x): pass
+
+
+class Timer(ContextDecorator):
+    """
+    A class that can be used to time things:
+    with Timer():
+        func(args)
+
+    @Timer()
+    def func(args)
+    """
+    def __init__(self, name="Task"):
+        self.name = name
+
+    def __enter__(self):
+        self.start = time.time()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.end = time.time()
+        self.interval = self.end - self.start
+        tf.print("{} took {} seconds".format(self.name, self.interval))

--- a/fastestimator/visualization/parse_logs.py
+++ b/fastestimator/visualization/parse_logs.py
@@ -172,14 +172,15 @@ def parse_files(file_paths, log_extension='.txt', smooth_factor=0, save=False, s
                   save_path if save_path is not None else file_paths[0], share_legend, pretty_names)
 
 
-def parse_folder(dir_path, log_extension='.txt', smooth_factor=1, save=False, save_path=None, ignore_metrics=None,
-                 share_legend=True, pretty_names=False):
+def parse_folder(dir_path, log_extension='.txt', recursive_search=False, smooth_factor=1, save=False, save_path=None,
+                 ignore_metrics=None, share_legend=True, pretty_names=False):
     """
     A function which will gather all log files within a given folder and pass them along for visualization
 
     Args:
         dir_path: The path to a directory containing log files
         log_extension: The extension of the log files
+        recursive_search: Whether to recursively search sub-directories for log files
         smooth_factor: A non-negative float representing the magnitude of gaussian smoothing to apply(zero for none)
         save: Whether to save (true) or display (false) the generated graph
         save_path: Where to save the image if save is true. Defaults to dir_path if not provided
@@ -190,7 +191,7 @@ def parse_folder(dir_path, log_extension='.txt', smooth_factor=1, save=False, sa
     Returns:
         None
     """
-    loader = PathLoader(dir_path, input_extension=log_extension)
+    loader = PathLoader(dir_path, input_extension=log_extension, recursive_search=recursive_search)
     file_paths = [x[0] for x in loader.path_pairs]
 
     parse_files(file_paths, log_extension, smooth_factor, save, save_path, ignore_metrics, share_legend, pretty_names)

--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(name="fastestimator",
           'pytest-cov',
           'opencv-python',
           'tensorflow-addons',
+          'tensorflow-probability',
           'umap-learn',
           'tqdm'
       ],

--- a/showcase/image_classification/lenet_cifar10_adversarial.py
+++ b/showcase/image_classification/lenet_cifar10_adversarial.py
@@ -1,0 +1,70 @@
+import tensorflow as tf
+import tensorflow_probability as tfp
+
+from fastestimator.architecture.lenet import LeNet
+from fastestimator.estimator.estimator import Estimator
+from fastestimator.estimator.trace import Accuracy, ConfusionMatrix
+from fastestimator.pipeline.pipeline import Pipeline
+from fastestimator.pipeline.static.preprocess import Minmax
+
+
+class Network:
+    def __init__(self, shape, num_classes, alpha=1.0, epsilon=0.1):
+        self.model = LeNet(input_shape=shape, classes=num_classes)
+        self.optimizer = tf.optimizers.Adam()
+        self.loss = tf.losses.SparseCategoricalCrossentropy()
+        self.epsilon = tf.constant(epsilon)
+        self.alpha = tf.constant(alpha)
+        self.beta = tfp.distributions.Beta(alpha, alpha)
+
+    def train_op(self, batch):
+        if self.alpha <= 0:
+            with tf.GradientTape() as tape:
+                predictions = self.model(batch["x"])
+                loss = self.loss(batch["y"], predictions)
+            gradients = tape.gradient(loss, self.model.trainable_variables)
+            self.optimizer.apply_gradients(zip(gradients, self.model.trainable_variables))
+            return predictions, loss
+
+        lam = self.beta.sample()
+        x_clean = batch['x']
+
+        with tf.GradientTape(persistent=True) as tape:
+            tape.watch(x_clean)
+            predictions_clean = self.model(x_clean)
+            loss_clean = self.loss(batch["y"], predictions_clean)
+            with tape.stop_recording():
+                grad_clean = tape.gradient(loss_clean, x_clean)
+                x_dirty = tf.clip_by_value(x_clean + self.epsilon * tf.sign(grad_clean), tf.reduce_min(x_clean),
+                                           tf.reduce_max(x_clean))
+            predictions_dirty = self.model(x_dirty)
+            loss = lam * loss_clean + (1 - lam) * self.loss(batch["y"], predictions_dirty)
+        gradients = tape.gradient(loss, self.model.trainable_variables)
+        del tape
+        self.optimizer.apply_gradients(zip(gradients, self.model.trainable_variables))
+        return predictions_clean, loss
+
+    def eval_op(self, batch):
+        predictions = self.model(batch["x"], training=False)
+        loss = self.loss(batch["y"], predictions)
+        return predictions, loss
+
+
+def get_estimator(epochs=2, batch_size=32, alpha=1.0, epsilon=0.1):
+    (x_train, y_train), (x_eval, y_eval) = tf.keras.datasets.cifar10.load_data()
+    num_classes = 10
+
+    pipeline = Pipeline(batch_size=batch_size,
+                        feature_name=["x", "y"],
+                        train_data={"x": x_train, "y": y_train},
+                        validation_data={"x": x_eval, "y": y_eval},
+                        transform_train=[[Minmax()], []])
+
+    traces = [Accuracy(y_true_key="y"), ConfusionMatrix(y_true_key="y", num_classes=num_classes)]
+
+    estimator = Estimator(
+        network=Network(shape=x_train.shape[1:], num_classes=num_classes, alpha=alpha, epsilon=epsilon),
+        pipeline=pipeline,
+        epochs=epochs,
+        traces=traces)
+    return estimator

--- a/showcase/image_classification/lenet_cifar10_mixup.py
+++ b/showcase/image_classification/lenet_cifar10_mixup.py
@@ -1,0 +1,65 @@
+import tensorflow as tf
+import tensorflow_probability as tfp
+
+from fastestimator.architecture.lenet import LeNet
+from fastestimator.estimator.estimator import Estimator
+from fastestimator.estimator.trace import Accuracy, ConfusionMatrix
+from fastestimator.pipeline.pipeline import Pipeline
+from fastestimator.pipeline.static.preprocess import Minmax
+
+
+class Network:
+    def __init__(self, shape, num_classes, alpha=1.0):
+        self.model = LeNet(input_shape=shape, classes=num_classes)
+        self.optimizer = tf.optimizers.Adam()
+        self.loss = tf.losses.SparseCategoricalCrossentropy()
+        self.alpha = tf.constant(alpha)
+        self.beta = tfp.distributions.Beta(alpha, alpha)
+
+    def train_op(self, batch):
+        if self.alpha <= 0:
+            with tf.GradientTape() as tape:
+                predictions = self.model(batch["x"])
+                loss = self.loss(batch["y"], predictions)
+            gradients = tape.gradient(loss, self.model.trainable_variables)
+            self.optimizer.apply_gradients(zip(gradients, self.model.trainable_variables))
+            return predictions, loss
+
+        lam = self.beta.sample()
+
+        # Could do random mix-up using tf.gather() on a shuffled index list, but batches are already randomly ordered,
+        # so just need to roll by 1 to get a random combination of inputs
+        x_mix = lam * batch['x'] + (1 - lam) * tf.roll(batch['x'], shift=1, axis=0)
+        y_mix = tf.roll(batch['y'], shift=1, axis=0)
+
+        with tf.GradientTape() as tape:
+            predictions = self.model(x_mix)
+            loss = lam * self.loss(batch["y"], predictions) + (1 - lam) * self.loss(y_mix, predictions)
+        gradients = tape.gradient(loss, self.model.trainable_variables)
+        self.optimizer.apply_gradients(zip(gradients, self.model.trainable_variables))
+        return predictions, loss
+
+    def eval_op(self, batch):
+        predictions = self.model(batch["x"], training=False)
+        loss = self.loss(batch["y"], predictions)
+        return predictions, loss
+
+
+def get_estimator(epochs=2, batch_size=32, alpha=1.0):
+    (x_train, y_train), (x_eval, y_eval) = tf.keras.datasets.cifar10.load_data()
+    num_classes = 10
+
+    pipeline = Pipeline(batch_size=batch_size,
+                        feature_name=["x", "y"],
+                        train_data={"x": x_train, "y": y_train},
+                        validation_data={"x": x_eval, "y": y_eval},
+                        transform_train=[[Minmax()], []])
+
+    traces = [Accuracy(y_true_key="y"), ConfusionMatrix(y_true_key="y", num_classes=num_classes)]
+
+    estimator = Estimator(
+        network=Network(shape=x_train.shape[1:], num_classes=num_classes, alpha=alpha),
+        pipeline=pipeline,
+        epochs=epochs,
+        traces=traces)
+    return estimator

--- a/showcase/image_classification/lenet_mnist.py
+++ b/showcase/image_classification/lenet_mnist.py
@@ -27,7 +27,8 @@ class Network:
         loss = self.loss(batch["y"], predictions)
         return predictions, loss
 
-def get_estimator(epochs=2, batch_size=32, optimizer="adam"):
+
+def get_estimator(epochs=2, batch_size=32):
 
     (x_train, y_train), (x_eval, y_eval) = tf.keras.datasets.mnist.load_data()
     x_train = np.expand_dims(x_train, -1)


### PR DESCRIPTION
New showcase examples on the CIFAR10 dataset

remove time axis from training (+1 squashed commit)
Squashed commits:
[c64ea68] time dimension (+8 squashed commits)
Squashed commits:
[61d4f71] cleanup
[69f3fc4] improve mixup efficiency
[56c3cfb] cleanup
[7387f58] disable recursive search by default for log visualization
[3bf7a77] remove dataset hack
[5efb29b] back to relu
[c4f63f1] rule around 2k example/sec, swish around 1.3k
[475167c] first pass: 95 examples / sec