### PR TITLE
Add caricature visualization capability

### DIFF
--- a/bin/fastestimator
+++ b/bin/fastestimator
@@ -7,6 +7,7 @@ import sys
 from pyfiglet import Figlet
 
 from fastestimator.util.util import parse_cli_to_dictionary, get_gpu_count
+from fastestimator.visualization.caricature import load_and_caricature
 from fastestimator.visualization.layer_umap import umap_layers
 from fastestimator.visualization.parse_logs import parse_folder
 from fastestimator.visualization.saliency_masks import load_and_interpret
@@ -168,6 +169,67 @@ def configure_umap_parser(subparsers):
     parser.set_defaults(func=umap)
 
 
+def caricature(args, unknown):
+    if len(unknown) > 0:
+        print("error: unrecognized arguments: ", str.join(", ", unknown))
+        sys.exit(-1)
+    load_and_caricature(args['model'], args['inputs'], dictionary_path=args['dictionary'], save=args['save'],
+                        save_dir=args['save_dir'], strip_alpha=args['strip_alpha'], layer_ids=args['layers'],
+                        print_layers=args['print_layers'], n_steps=args['steps'], learning_rate=args['learning_rate'],
+                        blur=args['blur'], cossim_pow=args['cossim'], sd=args['stddev'], fft=not args['pixel_based'],
+                        decorrelate=not args['true_color'], sigmoid=not args['hard_clip'])
+
+
+def configure_caricature_parser(subparsers):
+    parser = subparsers.add_parser('caricature',
+                                   description='Plots caricatures for model layers over given inputs',
+                                   formatter_class=argparse.ArgumentDefaultsHelpFormatter, allow_abbrev=False)
+    parser.add_argument('model', metavar='<Model Path>', type=str,
+                        help="The path to a saved model file")
+    parser.add_argument('inputs', metavar='Input', type=str, nargs='+',
+                        help="The paths to one or more inputs to visualize (or the path to a folder which will be \
+                            recursively traversed to find image files)")
+    parser.add_argument('--print-layers', action='store_true',
+                        help="True if you only want to print a model's layers to the console. Useful for inspecting a \
+                            model to choose which layer indices to visualize.")
+    parser.add_argument('--layers', metavar='IDX', type=int, nargs='+',
+                        help='The indices of layers you want to visualize. If not provided then all layers will be \
+                                      analyzed, but that is likely to run out of memory on moderately sized models.')
+    parser.add_argument('--strip-alpha', action='store_true',
+                        help="True if you want to convert RGBA images to RGB")
+    parser.add_argument('--dictionary', metavar='<Dictionary Path>', type=str,
+                        help="The path to a {'class_id':'class_name'} json file", default=None)
+    parser.add_argument('--steps', metavar='N', type=int,
+                        help="How many optimization iterations to run", default=250)
+    parser.add_argument('--learning-rate', metavar='LR', type=float,
+                        help="Initial learning rate for the optimizer", default=0.05)
+    parser.add_argument('--blur', metavar='B', type=float,
+                        help="Strength of blurring used on image during processing (reduces high-frequency artifacts)",
+                        default=1.0)
+    parser.add_argument('--cossim', metavar='B', type=float,
+                        help="Strength of cosine similarity coefficient in loss function (higher value increases \
+                        similarity)", default=0.5)
+    parser.add_argument('--stddev', type=float,
+                        help="The standard deviation of the noise used to generate the seed image", default=0.01)
+    parser.add_argument('--pixel-based', action='store_true',
+                        help="Use pixel-based optimization rather than fft based. Individual steps will be faster but \
+                        convergence will be slower")
+    parser.add_argument('--true-color', action='store_true',
+                        help="Disable color decorrelation. You may want this if using non-imagenet style images")
+    parser.add_argument('--hard-clip', action='store_true',
+                        help="Use hard clipping instead of sigmoids to constrain pixel values")
+    save_group = parser.add_argument_group('output arguments')
+    save_x_group = save_group.add_mutually_exclusive_group(required=False)
+    save_x_group.add_argument('--save', nargs='?', metavar='<Save Dir>',
+                              help="Save the output image. May be accompanied by a directory into which the \
+                              file is saved. If no output directory is specified, the model directory will be used",
+                              dest='save', action=SaveAction, default=False)
+    save_x_group.add_argument('--display', dest='save', action='store_false',
+                              help="Render the image to the UI (rather than saving it)", default=True)
+    save_x_group.set_defaults(save_dir=None)
+    parser.set_defaults(func=caricature)
+
+
 def configure_visualization_parser(subparsers):
     visualization_parser = subparsers.add_parser('visualize', description='Generates various types of visualiztaions',
                                                  allow_abbrev=False)
@@ -179,6 +241,7 @@ def configure_visualization_parser(subparsers):
     configure_log_parser(visualization_subparsers)
     configure_saliency_parser(visualization_subparsers)
     configure_umap_parser(visualization_subparsers)
+    configure_caricature_parser(visualization_subparsers)
 
 
 def train(args, unknown):

--- a/fastestimator/util/color_util.py
+++ b/fastestimator/util/color_util.py
@@ -1,0 +1,69 @@
+# Copyright 2019 The FastEstimator Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import numpy as np
+import tensorflow as tf
+
+# Empirical (ImageNet) color correlation matrix, from https://github.com/tensorflow/lucid
+color_correlation_svd_sqrt = np.asarray([[0.26, 0.09, 0.02],
+                                         [0.27, 0.00, -0.05],
+                                         [0.27, -0.09, 0.03]]).astype("float32")
+max_norm_svd_sqrt = np.max(np.linalg.norm(color_correlation_svd_sqrt, axis=0))
+color_correlation_normalized = color_correlation_svd_sqrt / max_norm_svd_sqrt
+color_correlation_normalized_transpose = color_correlation_normalized.T
+
+color_mean = [0.48, 0.46, 0.41]
+
+
+@tf.function
+def linear_decorelate_color(image):
+    """Multiply input by sqrt of empirical color correlation matrix.
+
+    If you interpret an image's innermost dimension as describing colors in a
+    decorrelated version of the color space (which is a very natural way to
+    describe colors -- see discussion in Feature Visualization article) the way
+    to map back to normal colors is multiply the square root of your color
+    correlations.
+    """
+    # TODO: check that inner dimension is 3
+    t_flat = tf.reshape(image, [-1, 3])
+    t_flat = tf.matmul(t_flat, color_correlation_normalized_transpose)
+    image = tf.reshape(t_flat, tf.shape(image))
+    return image
+
+
+@tf.function
+def to_valid_rgb(image, decorrelate=False, sigmoid=True):
+    """Transform inner dimension of image to valid rgb colors.
+
+    In practice this consists of two parts:
+    (1) If requested, transform the colors from a decorrelated color space to RGB.
+    (2) Constrain the color channels to be in [-1,1], either using a sigmoid
+        function or clipping.
+    Args:
+        image: input tensor, innermost dimension will be interpreted as colors and transformed/constrained.
+        decorrelate: should the input tensor's colors be interpreted as coming from a whitened space or not?
+        sigmoid: should the colors be constrained using sigmoid (if True) or clipping (if False).
+    Returns:
+      'image' with the innermost dimension transformed.
+    """
+    # TODO let the user specify / infer the data range instead of forcing [-1,1]
+    if decorrelate:
+        image = linear_decorelate_color(image)
+    if decorrelate and not sigmoid:
+        image += color_mean
+    if sigmoid:
+        return 2.0 * tf.nn.sigmoid(image) - 1.0
+    else:
+        return tf.clip_by_value(image, -1.0, 1.0)

--- a/fastestimator/util/util.py
+++ b/fastestimator/util/util.py
@@ -232,6 +232,29 @@ def is_number(s):
         return False
 
 
+def decode_predictions(predictions, top=3, dictionary=None):
+    """
+    Args:
+        predictions: A batched numpy array of class prediction scores (Batch X Predictions)
+        top: How many of the highest predictions to capture
+        dictionary: {"<class_idx>" -> "<class_name>"}
+    Returns:
+        A right-justified newline-separated array of the top classes and their associated probabilities.
+        There is one entry in the results array per batch in the input
+    """
+    results = []
+    for prediction in predictions:
+        top_indices = prediction.argsort()[-top:][::-1]
+        if dictionary is None:
+            result = ["Class {:d}: {:.4f}".format(i, prediction[i]) for i in top_indices]
+        else:
+            result = ["{:s}: {:.4f}".format(dictionary[str(i)], prediction[i]) for i in top_indices]
+        max_width = len(max(result, key=lambda s: len(s)))
+        result = str.join("\n", [s.rjust(max_width) for s in result])
+        results.append(result)
+    return results
+
+
 class Suppressor(object):
     """
     A class which can be used to silence output of function calls. example:

--- a/fastestimator/util/vis_util.py
+++ b/fastestimator/util/vis_util.py
@@ -1,0 +1,210 @@
+# Copyright 2019 The FastEstimator Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import matplotlib.pyplot as plt
+import numpy as np
+import tensorflow as tf
+import tensorflow_probability as tfp
+
+
+def show_text(axis, background, text, title=None):
+    """
+    Plots a given image onto an axis
+
+    Args:
+        axis: The matplotlib axis to plot on
+        background: A background image to display behind the text (useful for sizing the plot correctly)
+        text: The text to display
+        title: A title for the image
+    """
+    # matplotlib doesn't support (x,y,1) images, so convert them to (x,y)
+    if len(background.shape) == 3 and background.shape[2] == 1:
+        background = np.reshape(background, (background.shape[0], background.shape[1]))
+
+    axis.axis('off')
+    axis.imshow(background, cmap=plt.get_cmap(name="Greys_r"), vmin=0, vmax=1)
+    axis.text(0.5, 0.5, text,
+              ha='center', va='center', transform=axis.transAxes, wrap=False, family='monospace')
+    if title is not None:
+        axis.set_title(title)
+
+
+def show_image(axis, im, title=None):
+    """
+    Plots a given image onto an axis
+
+    Args:
+        axis: The matplotlib axis to plot on
+        im: The image to display (width X height)
+        title: A title for the image
+    """
+    if axis is None:
+        fig, axis = plt.subplots(1, 1)
+    axis.axis('off')
+    im = ((np.asarray(im) + 1) * 127.5).astype(np.uint8)
+    # matplotlib doesn't support (x,y,1) images, so convert them to (x,y)
+    if len(im.shape) == 3 and im.shape[2] == 1:
+        im = np.reshape(im, (im.shape[0], im.shape[1]))
+    axis.imshow(im)
+    if title is not None:
+        axis.set_title(title)
+
+
+def show_gray_image(axis, im, title=None, color_map="inferno"):
+    """
+    Plots a given image onto an axis
+
+    Args:
+        axis: The matplotlib axis to plot on
+        im: The image to display (width X height)
+        title: A title for the image
+        color_map: The color set to be used (since the image is gray scale)
+    """
+    axis.axis('off')
+    axis.imshow(im, cmap=plt.get_cmap(name=color_map), vmin=0, vmax=1)
+    if title is not None:
+        axis.set_title(title)
+
+
+@tf.function
+def gaussian_kernel(mean, std):
+    """
+    Args:
+        mean: The center of the normal distribution
+        std: The standard deviation of the normal distribution
+    Returns:
+        A gaussian kernel defined by the specified normal distribution, expanded for multiplication against a
+        3-channel image
+    """
+    # kernel size should be 6x the std in order to be similar to global op
+    size = tf.maximum(2.0, tf.math.ceil(3 * std))
+    d = tfp.distributions.Normal(mean, std)
+    vals = d.prob(tf.range(start=-size, limit=size + 1, dtype=tf.float32))
+    kernel = tf.einsum('i,j->ij', vals, vals)
+    kernel = kernel / tf.reduce_sum(kernel)
+    # Convert the kernel to 3 channel TODO make dynamic
+    kernel = tf.stack([kernel, kernel, kernel], axis=2)
+    # Expand kernel shape to match conv2d spec
+    kernel = kernel[:, :, :, tf.newaxis]
+    return kernel
+
+
+@tf.function
+def blur_image(image, std):
+    """
+    Args:
+        image: A 3 channel input image
+        std: The standard deviation of the gaussian filter to be applied
+    Returns:
+        'image' blurred by a gaussian filter
+    """
+    kernel = gaussian_kernel(0, std)
+    return tf.nn.depthwise_conv2d(image, kernel, strides=[1, 1, 1, 1], padding="SAME")
+
+
+@tf.function
+def blur_image_fft(image, std):
+    """
+    This method is equivalent to blur_image(), but is slower right now due to a bug in tensorflow related to graph
+    construction for the irfft2d function. TODO re-evaluate performance trade-off as new version of TF2 are released
+    Args:
+        image: An n-channel input image
+        std: The standard deviation of the gaussian filter to be applied
+    Returns:
+        'image' blurred by a gaussian filter
+    """
+    mean = 0
+    # Wiki article on gaussian blurring indicates that a 6s * 6s filter is basically equivalent to global kernel
+    half_kernel_size = tf.maximum(2.0, tf.math.ceil(3.0 * std))
+
+    kernel_size = 2 * half_kernel_size + 1  # Kernel size will always be odd
+    b, h, w, c = image.shape
+    # Convert to batch-channel-h-w
+    tf_image = tf.transpose(image, [0, 3, 1, 2])
+    fft_length = [h, w]
+    # Need to pad the fft size based on the kernel size. Also, the last axis needs to be padded by one if it ends up
+    # being odd. The extra pixel will get cropped off at the end
+    fft_length_padded = [fft_length[0] + kernel_size, fft_length[1] + kernel_size + (1 + w) % 2]
+    ft_image = tf.signal.rfft2d(tf_image, fft_length=fft_length_padded)
+
+    d = tfp.distributions.Normal(mean, std)
+    vals = d.prob(tf.range(start=-half_kernel_size, limit=half_kernel_size + 1, dtype=tf.float32))
+    kernel = tf.einsum('i,j->ij', vals, vals)
+    kernel = kernel / tf.reduce_sum(kernel)
+
+    big_kernel = tf.eye(num_rows=kernel_size, num_columns=kernel_size, batch_shape=[b, c], dtype=kernel.dtype)
+    kernel = tf.matmul(big_kernel, kernel)
+    ft_kernel = tf.signal.rfft2d(kernel, fft_length=fft_length_padded)
+
+    ft_image = ft_image * ft_kernel
+
+    tf_image = tf.signal.irfft2d(ft_image)
+    # Convert to batch-dim1-dim2-channel
+    tf_image = tf.transpose(tf_image, [0, 2, 3, 1])
+    # Cast to int for indexing
+    half_kernel_size = tf.cast(half_kernel_size, dtype=tf.int32)
+    # Crop the extra pixels
+    tf_image = tf_image[:, half_kernel_size:h + half_kernel_size, half_kernel_size:w + half_kernel_size, :]
+    return tf_image
+
+
+def rfft2d_freqs(h, w):
+    """
+    Args:
+        h: height of an image
+        w: width of an image
+    Returns:
+        A 2d fourier spectrum corresponding to the given image dimensions
+    """
+    fy = np.fft.fftfreq(h)[:, None]
+    # when we have an odd input dimension we need to keep one additional
+    # frequency and later cut off 1 pixel
+    fx = np.fft.fftfreq(w)[: w // 2 + 1 + w % 2]
+    return np.sqrt(fx * fx + fy * fy)
+
+
+@tf.function
+def fft_vars_to_whitened_im(fft_vars, scale, width):
+    """
+    Args:
+        fft_vars: A tensor of dimension: real/imaginary X batch X channel X height X width
+        scale: A matrix which normalizes the energy of an image
+        width: The true width of the pixel image (needed to resolve ambiguity introduced by the fourier transform)
+    Returns:
+        A pixel-space image corresponding to the given input variables, after applying a normalization by 'scale'
+    """
+    spectrum = tf.complex(fft_vars[0], fft_vars[1])
+    spectrum = scale * spectrum  # whiten the fft domain image (de-correlates adjacent pixels)
+    image = tf.signal.irfft2d(spectrum)
+    image = tf.transpose(image, (0, 2, 3, 1))  # fft domain required width and height to be the last dimensions
+    image = image[:, :, :width, :]  # Crop the extra pixel that results if width is odd
+    image = image / 4.0  # Make the image develop more slowly / controlled. Not sure why 4 vs any other factor
+    return image
+
+
+@tf.function
+def fft_vars_to_im(fft_vars, width):
+    """
+        Args:
+            fft_vars: A tensor of dimension: real/imaginary X batch X channel X height X width
+            width: The true width of the pixel image (needed to resolve ambiguity introduced by the fourier transform)
+        Returns:
+            A pixel-space image corresponding to the given input variables
+        """
+    spectrum = tf.complex(fft_vars[0], fft_vars[1])
+    image = tf.signal.irfft2d(spectrum)
+    image = tf.transpose(image, (0, 2, 3, 1))
+    image = image[:, :, :width, :]
+    image = image / 4.0  # Make the image develop more slowly / controlled. Not sure why 4 vs any other factor
+    return image

--- a/fastestimator/visualization/caricature.py
+++ b/fastestimator/visualization/caricature.py
@@ -1,0 +1,180 @@
+# Copyright 2019 The FastEstimator Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import os
+
+import matplotlib.pyplot as plt
+import numpy as np
+import tensorflow as tf
+from tensorflow import keras
+from tqdm import trange
+
+from fastestimator.pipeline.augmentation import Augmentation2D
+from fastestimator.util.color_util import to_valid_rgb
+from fastestimator.util.loader import PathLoader
+from fastestimator.util.util import load_dict, load_image, decode_predictions
+from fastestimator.util.vis_util import show_text, show_image, blur_image, fft_vars_to_whitened_im, rfft2d_freqs
+
+
+@tf.function
+def dot_loss(true, pred, cossim_pow):
+    reduce_axis = tf.range(1, len(true.shape))  # Reductions should keep the batch axis (zero) separated
+    # reduce_axis = tf.range(len(true.shape))  # TODO - it seems empirically like this doesn't matter. why???
+    dot = tf.reduce_sum(true * pred, axis=reduce_axis)
+    mag = tf.sqrt(tf.reduce_sum(true ** 2, axis=reduce_axis)) * tf.sqrt(tf.reduce_sum(pred ** 2, axis=reduce_axis))
+    cossim = dot / (1e-6 + mag)
+    cossim = tf.maximum(0.1, cossim)
+    result = dot * cossim ** cossim_pow
+    # Negative value since we actually want to maximize this objective
+    return -1. * result
+
+
+@tf.function
+def compute_gradients(model, aug, target_input, source_input, cossim_pow, decorrelate, sigmoid, fft, scale):
+    aug.setup()
+    transformed = tf.stack([aug.forward(target_input[i]) for i in range(target_input.shape[0])], axis=0)
+    target = model(transformed)
+    with tf.GradientTape() as tape:
+        transformed = source_input
+        if fft:
+            transformed = fft_vars_to_whitened_im(transformed, scale, target_input.shape[2])
+        transformed = to_valid_rgb(transformed, decorrelate=decorrelate, sigmoid=sigmoid)
+        transformed = tf.stack([aug.forward(transformed[i]) for i in range(transformed.shape[0])], axis=0)
+        layer_outputs = model(transformed)
+        loss = dot_loss(target, layer_outputs, cossim_pow)
+    return tape.gradient(loss, source_input)
+
+
+def generate_variable_image(model_input, sd=0.01, fft=False, decay_power=1):
+    sd = sd or 0.01
+    if not fft:
+        return tf.Variable(
+            tf.random.normal(shape=model_input.shape, mean=tf.reduce_mean(model_input), stddev=sd),
+            trainable=True), None
+    batch, h, w, ch = model_input.shape
+    init_val_size = (2, batch, ch, h, w // 2 + 1 + (w % 2))  # zeroth index is for real/imaginary
+    caricatures_freq = tf.Variable(tf.random.normal(shape=init_val_size, mean=0, stddev=sd))
+
+    freqs = rfft2d_freqs(h, w)
+    scale = 1.0 / np.maximum(freqs, 1.0 / max(w, h)) ** decay_power
+    scale *= np.sqrt(w * h)
+    big_kernel = tf.eye(num_rows=scale.shape[0], num_columns=scale.shape[0], batch_shape=[batch, ch], dtype=scale.dtype)
+    scale = tf.matmul(big_kernel, scale)
+    scale = tf.cast(scale, tf.complex64)
+    return caricatures_freq, scale
+
+
+def generate_caricatures(model, model_input, layer_id, n_steps=100, learning_rate=0.05, blur=1, cossim_pow=0.5, sd=0.01,
+                         fft=True, decorrelate=True, sigmoid=True):
+    small_model = tf.keras.models.Model(inputs=model.input, outputs=model.layers[layer_id].output)
+
+    caricatures, scale = generate_variable_image(model_input, sd, fft, blur)
+
+    optimizer = tf.optimizers.Adam(learning_rate=learning_rate, amsgrad=True)
+
+    h = model_input.shape[1]
+    w = model_input.shape[2]
+    aug = Augmentation2D(rotation_range=5, zoom_range=0.05, shear_range=5, width_shift_range=5 / w,
+                         height_shift_range=5 / h)
+    aug.height = h
+    aug.width = w
+
+    for i in trange(n_steps, desc="Layer {}".format(layer_id)):
+        gradients = compute_gradients(small_model, aug, model_input, caricatures, cossim_pow, decorrelate, sigmoid, fft,
+                                      scale)
+        # Optimizer call cannot be in tf.function b/c calling it on a newly instantiated object generates variables:
+        # https://github.com/tensorflow/tensorflow/issues/27120
+        optimizer.apply_gradients(zip([gradients], [caricatures]))
+        if not fft:
+            caricatures.assign(blur_image(caricatures, tf.constant(blur - blur * (i / n_steps))))
+
+    if fft:
+        caricatures = fft_vars_to_whitened_im(caricatures, scale, w)
+    return to_valid_rgb(caricatures, decorrelate=decorrelate, sigmoid=sigmoid)
+
+
+def caricature(model, model_input, layer_ids=None, decode_dictionary=None, save=False, save_path=".", n_steps=512,
+               learning_rate=0.05, blur=1, cossim_pow=0.5, sd=0.01, fft=True, decorrelate=True, sigmoid=True):
+    if layer_ids is None or len(layer_ids) == 0:
+        layer_ids = [i for i in range(len(model.layers))]
+
+    predictions = np.asarray(model(model_input))
+    decoded = decode_predictions(predictions, top=3, dictionary=decode_dictionary)
+
+    caricatures = [generate_caricatures(model, model_input, layer, n_steps=n_steps, learning_rate=learning_rate,
+                                        blur=blur, cossim_pow=cossim_pow, sd=sd, fft=fft, decorrelate=decorrelate,
+                                        sigmoid=sigmoid) for layer in layer_ids]
+
+    num_rows = model_input.shape[0]
+    num_cols = len(layer_ids) + 2
+    dpi = 96.0
+
+    box_width = max(220, model_input.shape[2])
+    box_height = max(220, model_input.shape[1])
+    fig, axs = plt.subplots(num_rows, num_cols, figsize=(num_cols * (box_width / dpi), num_rows * (box_height / dpi)),
+                            dpi=dpi)
+
+    if num_rows == 1:
+        axs = [axs]  # axs object not wrapped if there's only one row
+    for i in range(num_rows):
+        show_text(axs[i][0], np.ones_like(model_input[i]), decoded[i], title="Predictions" if i == 0 else None)
+        show_image(axs[i][1], model_input[i], title="Raw" if i == 0 else None)
+        for j in range(len(layer_ids)):
+            layer_id = layer_ids[j]
+            layer_name = ": " + model.layers[layer_id].name
+            show_image(axs[i][2 + j], caricatures[j][i],
+                       title="Layer {}{}".format(layer_id, layer_name) if i == 0 else None)
+
+    plt.subplots_adjust(top=0.95, bottom=0.01, left=0.01, right=0.99, hspace=0.03, wspace=0.03)
+    if not save:
+        plt.show()
+    else:
+        if save_path is None or save_path == "":
+            save_path = "."
+        os.makedirs(save_path, exist_ok=True)
+        save_file = os.path.join(save_path, 'caricature.png')
+        print("Saving to %s" % save_file)
+        plt.savefig(save_file, dpi=300, bbox_inches="tight")
+
+
+def load_and_caricature(model_path, input_paths, dictionary_path=None, save=False, save_dir=None, strip_alpha=False,
+                        layer_ids=None, print_layers=False, n_steps=512, learning_rate=0.05, blur=1, cossim_pow=0.5,
+                        sd=0.01, fft=True, decorrelate=True, sigmoid=True):
+    model_dir = os.path.dirname(model_path)
+    if save_dir is None:
+        save_dir = model_dir
+    network = keras.models.load_model(model_path)
+    input_type = network.input.dtype
+    input_shape = network.input.shape
+    n_channels = 0 if len(input_shape) == 3 else input_shape[3]
+    input_height = input_shape[1] or 224  # If the model doesn't specify width and height, just guess 224
+    input_width = input_shape[2] or 224
+
+    if print_layers:
+        for idx, layer in enumerate(network.layers):
+            print("{}: {} --- output shape: {}".format(idx, layer.name, layer.output_shape))
+        return
+
+    dic = load_dict(dictionary_path)
+    if len(input_paths) == 1 and os.path.isdir(input_paths[0]):
+        loader = PathLoader(input_paths[0])
+        input_paths = [path[0] for path in loader.path_pairs]
+    inputs = [load_image(input_paths[i], strip_alpha=strip_alpha, channels=n_channels) for i in range(len(input_paths))]
+    tf_image = tf.stack([tf.image.resize_with_pad(tf.convert_to_tensor(im, dtype=input_type), input_height, input_width,
+                                                  method='lanczos3') for im in inputs])
+    tf_image = tf.clip_by_value(tf_image, -1, 1)
+
+    caricature(network, tf_image, layer_ids=layer_ids, decode_dictionary=dic, save=save, save_path=save_dir,
+               n_steps=n_steps, learning_rate=learning_rate, blur=blur, cossim_pow=cossim_pow, sd=sd, fft=fft,
+               decorrelate=decorrelate, sigmoid=sigmoid)


### PR DESCRIPTION
An interpretability module as described here, adapted for TF2: https://github.com/tensorflow/lucid/issues/121


![plantdog](https://user-images.githubusercontent.com/8201565/62404560-11a8e700-b54a-11e9-9d43-e85be39e22fc.png)



add caricature into FE bash (+3 squashed commits)
Squashed commits:
[e6a10e3] cleaning
[b087313] merge cleanup
[abc32e1] more cleanup (+6 squashed commits)
Squashed commits:
[fb147c4] clean up / consolidate code
[da87600] fft space optimization is working
[d528cd3] add image smoothing to generate cleaner reconstructions
[a8dd0b3] fix static augmentation to work within gradient tapes / graph mode (seems there may be a bug with boolean tensors at the moment)
[4ff1fda] system is starting to work better - results still don't seem consistent with google publication though. augmentation module doesn't work inside gradient tape due to an issue with boolean member variables. still investigating.
[c6b3656] layer-based image generation. doesn't seem to be working the way it does in the papers though yet. theirs may be neuron or channel specific