### PR TITLE
Trace BugFix

### DIFF
--- a/fastestimator/estimator/trace.py
+++ b/fastestimator/estimator/trace.py
@@ -44,8 +44,8 @@ class Trace:
         """
         self.network = None
         self.mode = mode
-        self.inputs = set() if inputs is None else set(inputs) if not isinstance(inputs, str) else {inputs}
-        self.outputs = set() if outputs is None else set(outputs) if not isinstance(outputs, str) else {outputs}
+        self.inputs = set(filter(None, inputs or {})) if not isinstance(inputs, str) else {inputs}
+        self.outputs = set(filter(None, outputs or {})) if not isinstance(outputs, str) else {outputs}
 
     def on_begin(self, state):
         """Runs once at the beginning of training

--- a/fastestimator/estimator/trace.py
+++ b/fastestimator/estimator/trace.py
@@ -44,8 +44,8 @@ class Trace:
         """
         self.network = None
         self.mode = mode
-        self.inputs = set() if inputs is None else set(inputs)
-        self.outputs = set() if outputs is None else set(outputs)
+        self.inputs = set() if inputs is None else set(inputs) if not isinstance(inputs, str) else {inputs}
+        self.outputs = set() if outputs is None else set(outputs) if not isinstance(outputs, str) else {outputs}
 
     def on_begin(self, state):
         """Runs once at the beginning of training


### PR DESCRIPTION
bug was introduced since calling set('string') returns {'s', 't', 'r', 'i', 'n', 'g'} instead of the desired {'string'}. Also, the Trace sorting needs all output keys defined in the network graph, not just the loss keys. 