### PR TITLE
flexible op inputs / outputs (+1 squashed commit)

### DIFF
--- a/fastestimator/dataset/csv_dataset.py
+++ b/fastestimator/dataset/csv_dataset.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 import os
-from copy import deepcopy
 from typing import Dict, Iterable, List, Any, Sequence
 
 import pandas as pd
@@ -40,7 +39,7 @@ class CSVDataset(FEDataset):
         return len(self.data)
 
     def __getitem__(self, index: int) -> Dict:
-        return deepcopy(self.data[index])
+        return self.data[index]
 
     @classmethod
     def _skip_init(cls, data: Dict[int, Dict[str, Any]], parent_path: str) -> 'CSVDataset':

--- a/fastestimator/dataset/generator_dataset.py
+++ b/fastestimator/dataset/generator_dataset.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 # ==============================================================================
 import warnings
-from copy import deepcopy
 from typing import Any, Dict, Generator, Sequence, Iterable, List, Sized
 
 from fastestimator.dataset.fe_dataset import FEDataset
@@ -29,7 +28,7 @@ class GeneratorDataset(FEDataset):
         return self.samples_per_epoch
 
     def __getitem__(self, index: int):
-        return deepcopy(self.generator.send(index))
+        return self.generator.send(index)
 
     def _do_split(self, splits: Sequence[Iterable[int]]) -> List['GeneratorDataset']:
         warnings.warn("You probably don't actually want to split a generator dataset")

--- a/fastestimator/dataset/labeled_dir_dataset.py
+++ b/fastestimator/dataset/labeled_dir_dataset.py
@@ -82,11 +82,11 @@ class LabeledDirDataset(FEDataset):
         return deepcopy(self.data[index])
 
     def get_mapping(self) -> Dict[str, Union[str, int, np.ndarray]]:
-        return deepcopy(self.mapping)
+        return self.mapping
 
     @classmethod
-    def _skip_init(cls, data: Dict[int, Dict[str, Any]], mapping: Dict[str, Union[str, int,
-                                                                                  np.ndarray]]) -> 'LabeledDirDataset':
+    def _skip_init(cls, data: Dict[int, Dict[str, Any]],
+                   mapping: Dict[str, Union[str, int, np.ndarray]]) -> 'LabeledDirDataset':
         obj = cls.__new__(cls)
         obj.data = data
         obj.mapping = mapping

--- a/fastestimator/dataset/numpy_dataset.py
+++ b/fastestimator/dataset/numpy_dataset.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from copy import deepcopy
 from typing import List, Iterable, Dict, Any, Sequence
 
 import numpy as np
@@ -37,7 +36,7 @@ class NumpyDataset(FEDataset):
         return len(self.data)
 
     def __getitem__(self, index):
-        return deepcopy(self.data[index])
+        return self.data[index]
 
     @classmethod
     def _skip_init(cls, data: Dict[int, Dict[str, Any]]) -> 'NumpyDataset':

--- a/fastestimator/dataset/op_dataset.py
+++ b/fastestimator/dataset/op_dataset.py
@@ -12,11 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
+from copy import deepcopy
 from typing import List
 
 from torch.utils.data import Dataset
+
+from fastestimator.op import get_inputs_by_op, write_outputs_by_op
 from fastestimator.op.op import NumpyOp
-from fastestimator.op import get_inputs_by_op, write_outputs_by_key
 
 
 class OpDataset(Dataset):
@@ -26,13 +28,13 @@ class OpDataset(Dataset):
         self.mode = mode
 
     def __getitem__(self, index):
-        item = self.dataset[index]
+        item = deepcopy(self.dataset[index])  # Deepcopy to prevent ops from overwriting values in datasets
         op_data = None
         for op in self.ops:
             op_data = get_inputs_by_op(op, item, op_data)
             op_data = op.forward(op_data, {"mode": self.mode})
             if op.outputs:
-                write_outputs_by_key(item, op_data, op.outputs)
+                write_outputs_by_op(op, item, op_data)
         return item
 
     def __len__(self):

--- a/fastestimator/network.py
+++ b/fastestimator/network.py
@@ -13,12 +13,12 @@
 # limitations under the License.
 # ==============================================================================
 from collections import ChainMap
-from typing import Any, Dict, List, Mapping, Set, Union, Iterable
+from typing import Any, Dict, List, MutableMapping, Set, Union, Iterable
 
 import tensorflow as tf
 import torch
 
-from fastestimator.op import TensorOp, get_current_ops, get_inputs_by_op, write_outputs_by_key
+from fastestimator.op import TensorOp, get_current_ops, get_inputs_by_op, write_outputs_by_op
 from fastestimator.op.tensorop.model import ModelOp, UpdateOp
 from fastestimator.schedule import EpochScheduler, RepeatScheduler, Scheduler
 from fastestimator.util.util import NonContext, lcms, to_list
@@ -52,10 +52,10 @@ class BaseNetwork:
             if isinstance(op, Scheduler):
                 for epoch_op in op.get_all_values():
                     if isinstance(epoch_op, UpdateOp):
-                        loss_keys.update(to_list(epoch_op.inputs))
+                        loss_keys.update(epoch_op.inputs)
             else:
                 if isinstance(op, UpdateOp):
-                    loss_keys.update(to_list(op.inputs))
+                    loss_keys.update(op.inputs)
         return loss_keys
 
     def get_effective_input_keys(self, mode: str, total_epochs: int) -> Set[str]:
@@ -63,15 +63,15 @@ class BaseNetwork:
         produced_keys = set()
         for epoch in self.get_signature_epochs(total_epochs):
             for op in get_current_ops(self.ops, mode, epoch):
-                input_keys.update(set(key for key in to_list(op.inputs) if key not in produced_keys))
-                produced_keys.update(to_list(op.outputs))
+                input_keys.update(set(key for key in op.inputs if key not in produced_keys))
+                produced_keys.update(op.outputs)
         return input_keys
 
     def get_all_output_keys(self, mode: str, total_epochs: int) -> Set[str]:
         output_keys = set()
         for epoch in self.get_signature_epochs(total_epochs):
             for op in get_current_ops(self.ops, mode, epoch):
-                output_keys.update(to_list(op.outputs))
+                output_keys.update(op.outputs)
         return output_keys
 
     def get_signature_epochs(self, total_epochs: int):
@@ -94,13 +94,13 @@ class BaseNetwork:
         return signature_epochs
 
     @staticmethod
-    def _forward_batch(batch: Mapping[str, Any], state: Dict[str, Any], ops: List[TensorOp]):
+    def _forward_batch(batch: MutableMapping[str, Any], state: Dict[str, Any], ops: List[TensorOp]):
         data = None
         for op in ops:
             data = get_inputs_by_op(op, batch, data)
             data = op.forward(data, state)
             if op.outputs:
-                write_outputs_by_key(batch, data, op.outputs)
+                write_outputs_by_op(op, batch, data)
 
     def run_step(self, batch: Dict[str, Any], state: Dict[str, Any]) -> Dict[str, Any]:
         raise NotImplementedError

--- a/fastestimator/op/__init__.py
+++ b/fastestimator/op/__init__.py
@@ -12,5 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from fastestimator.op.op import NumpyOp, TensorOp, get_current_ops, get_inputs_by_key, get_inputs_by_op, \
-    write_outputs_by_key
+from fastestimator.op.op import NumpyOp, TensorOp, get_current_ops, get_inputs_by_op, write_outputs_by_op

--- a/fastestimator/op/numpyop/base_augmentations.py
+++ b/fastestimator/op/numpyop/base_augmentations.py
@@ -34,15 +34,11 @@ class ImageOnlyAlbumentation(NumpyOp):
         self.func = Compose(transforms=[func])
         self.replay_func = ReplayCompose(transforms=[deepcopy(func)])
 
-    def forward(self, data: Union[np.ndarray, List[np.ndarray]],
-                state: Dict[str, Any]) -> Union[np.ndarray, List[np.ndarray]]:
-        if isinstance(data, List):
-            results = [self.replay_func(image=data[0])]
-            for i in range(1, len(data)):
-                results.append(self.replay_func.replay(results[0]['replay'], image=data[i]))
-            return [result["image"] for result in results]
-        else:
-            return self.func(image=data)["image"]
+    def forward(self, data: List[np.ndarray], state: Dict[str, Any]) -> List[np.ndarray]:
+        results = [self.replay_func(image=data[0])]
+        for i in range(1, len(data)):
+            results.append(self.replay_func.replay(results[0]['replay'], image=data[i]))
+        return [result["image"] for result in results]
 
 
 class MultiVariateAlbumentation(NumpyOp):

--- a/fastestimator/op/numpyop/meta/one_of.py
+++ b/fastestimator/op/numpyop/meta/one_of.py
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Union, Dict, Any, List
+import random
+from typing import Dict, Any, List, Union
 
 import numpy as np
-import random
+
 from fastestimator.op import NumpyOp
 
 
@@ -26,12 +27,12 @@ class OneOf(NumpyOp):
             numpy_ops: A list of ops to choose between
     """
     def __init__(self, *numpy_ops: NumpyOp):
-        inputs = list(numpy_ops[0].inputs)
-        outputs = list(numpy_ops[0].outputs)
+        inputs = numpy_ops[0].inputs
+        outputs = numpy_ops[0].outputs
         mode = numpy_ops[0].mode
         for op in numpy_ops[1:]:
-            assert inputs == list(op.inputs), "All ops within a OneOf must share the same inputs"
-            assert outputs == list(op.outputs), "All ops within a OneOf must share the same outputs"
+            assert inputs == op.inputs, "All ops within a OneOf must share the same inputs"
+            assert outputs == op.outputs, "All ops within a OneOf must share the same outputs"
             assert mode == op.mode, "All ops within a OneOf must share the same mode"
         super().__init__(inputs=inputs, outputs=outputs, mode=mode)
         self.numpy_ops = numpy_ops

--- a/fastestimator/op/numpyop/meta/sometimes.py
+++ b/fastestimator/op/numpyop/meta/sometimes.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Union, Dict, Any, List
+from typing import Dict, Any, List, Union
 
 import numpy as np
 

--- a/fastestimator/op/numpyop/univariate/channel_transpose.py
+++ b/fastestimator/op/numpyop/univariate/channel_transpose.py
@@ -35,10 +35,7 @@ class ChannelTranspose(NumpyOp):
                  axes: List[int] = (2, 0, 1)):
         super().__init__(inputs=inputs, outputs=outputs, mode=mode)
         self.axes = axes
+        self.in_list, self.out_list = True, True
 
-    def forward(self, data: Union[np.ndarray, List[np.ndarray]],
-                state: Dict[str, Any]) -> Union[np.ndarray, List[np.ndarray]]:
-        if isinstance(data, list):
-            return [np.transpose(elem, self.axes) for elem in data]
-        else:
-            return np.transpose(data, self.axes)
+    def forward(self, data: List[np.ndarray], state: Dict[str, Any]) -> List[np.ndarray]:
+        return [np.transpose(elem, self.axes) for elem in data]

--- a/fastestimator/op/numpyop/univariate/expand_dims.py
+++ b/fastestimator/op/numpyop/univariate/expand_dims.py
@@ -35,10 +35,7 @@ class ExpandDims(NumpyOp):
                  axis: int = -1):
         super().__init__(inputs=inputs, outputs=outputs, mode=mode)
         self.axis = axis
+        self.in_list, self.out_list = True, True
 
-    def forward(self, data: Union[np.ndarray, List[np.ndarray]],
-                state: Dict[str, Any]) -> Union[np.ndarray, List[np.ndarray]]:
-        if isinstance(data, list):
-            return [np.expand_dims(elem, self.axis) for elem in data]
-        else:
-            return np.expand_dims(data, self.axis)
+    def forward(self, data: List[np.ndarray], state: Dict[str, Any]) -> List[np.ndarray]:
+        return [np.expand_dims(elem, self.axis) for elem in data]

--- a/fastestimator/op/numpyop/univariate/minmax.py
+++ b/fastestimator/op/numpyop/univariate/minmax.py
@@ -21,7 +21,7 @@ from fastestimator.op import NumpyOp
 
 class Minmax(NumpyOp):
     """Normalize data using the minmax method
-    
+
     Args:
             inputs: Key(s) of images to be normalized
             outputs: Key(s) of images to be normalized
@@ -35,13 +35,10 @@ class Minmax(NumpyOp):
                  epsilon: float = 1e-7):
         super().__init__(inputs=inputs, outputs=outputs, mode=mode)
         self.epsilon = epsilon
+        self.in_list, self.out_list = True, True
 
-    def forward(self, data: Union[np.ndarray, List[np.ndarray]],
-                state: Dict[str, Any]) -> Union[np.ndarray, List[np.ndarray]]:
-        if isinstance(data, list):
-            return [self._apply_minmax(elem) for elem in data]
-        else:
-            return self._apply_minmax(data)
+    def forward(self, data: List[np.ndarray], state: Dict[str, Any]) -> List[np.ndarray]:
+        return [self._apply_minmax(elem) for elem in data]
 
     def _apply_minmax(self, data):
         data_max = np.max(data)

--- a/fastestimator/op/numpyop/univariate/read_image.py
+++ b/fastestimator/op/numpyop/univariate/read_image.py
@@ -13,13 +13,12 @@
 # limitations under the License.
 # ==============================================================================
 import os
+from typing import Union, Iterable, Callable, Any, Dict, List
 
 import cv2
 import numpy as np
 
 from fastestimator.op import NumpyOp
-from typing import Union, Iterable, Callable, Any, Dict, List
-from fastestimator.util.util import to_list
 
 
 class ReadImage(NumpyOp):
@@ -45,12 +44,11 @@ class ReadImage(NumpyOp):
         self.grey_scale = grey_scale
         if grey_scale:
             self.color_flag = cv2.IMREAD_GRAYSCALE
+        self.in_list, self.out_list = True, True
 
-    def forward(self, data: Union[str, List[str]], state: Dict[str, Any]) -> Union[np.ndarray, List[np.ndarray]]:
-        is_list = isinstance(data, list)
-        paths = to_list(data)
+    def forward(self, data: List[str], state: Dict[str, Any]) -> List[np.ndarray]:
         results = []
-        for path in paths:
+        for path in data:
             path = os.path.normpath(os.path.join(self.parent_path, path))
             img = cv2.imread(path, self.color_flag)
             if not self.grey_scale:
@@ -60,4 +58,4 @@ class ReadImage(NumpyOp):
             if self.grey_scale:
                 img = np.expand_dims(img, -1)
             results.append(img)
-        return results if is_list else results[0]
+        return results

--- a/fastestimator/pipeline.py
+++ b/fastestimator/pipeline.py
@@ -146,5 +146,5 @@ class Pipeline:
             output_keys = output_keys.union(set(data.keys()))
             if isinstance(loader, DataLoader) and isinstance(loader.dataset, OpDataset):
                 for op in loader.dataset.ops:
-                    output_keys.update(to_list(op.outputs))
+                    output_keys.update(op.outputs)
         return output_keys

--- a/fastestimator/util/system.py
+++ b/fastestimator/util/system.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Optional, Union
-
-import tensorflow as tf
-from torch.utils.data import DataLoader
+from typing import Optional
 
 from fastestimator.util.util import get_num_devices
 
@@ -30,12 +27,14 @@ class System:
     batch_idx: int  # The current batch index within an epoch (starting from 0)
     stop_training: bool  # A flag to signal that training should abort before 'epochs' has been reached
     network: Optional[object]  # A reference to the network being used this epoch  # TODO - circular reference
+    max_steps_per_epoch: Optional[int]  # Training epoch will complete after n steps even if loader is not yet exhausted
 
     def __init__(self,
                  mode: str = "train",
                  num_devices: int = get_num_devices(),
                  log_steps: Optional[int] = None,
-                 epochs: int = 0):
+                 epochs: int = 0,
+                 max_steps_per_epoch: Optional[int] = None):
         self.mode = mode
         self.global_step = 0
         self.num_devices = num_devices
@@ -43,6 +42,7 @@ class System:
         self.epochs = epochs
         self.epoch_idx = 0
         self.batch_idx = 0
+        self.max_steps_per_epoch = max_steps_per_epoch
         self.stop_training = False
 
     def update_global_step(self):


### PR DESCRIPTION
Squashed commits:
[a0caa44] move deepcopy into op_dataset so that future dataset implementations don't have to worry about it (+1 squashed commit)
Squashed commits:
[d228f15] steps_per_epoch -> max_steps_per_epoch (+2 squashed commits)
Squashed commits:
[4da8158] ops are allowed to return single values rather than lists
[a30649c] all ops now store inputs and outputs as lists always