### PR TITLE
remove dollar sign and add plot section in docstring of Trace

### DIFF
--- a/apphub/README.md
+++ b/apphub/README.md
@@ -28,19 +28,19 @@ Each example contains three files:
 
 One can simply execute the python file of any example:
 ```
-$ python mnist_tf.py
+python mnist_tf.py
 ```
 
 Or use our Command-Line Interface (CLI):
 
 ```
-$ fastestimator train mnist_torch.py
+fastestimator train mnist_torch.py
 ```
 
 One benefit of the CLI is that it allows users to configure the input args of `get_estimator`:
 
 ```
-$ fastestimator train lenet_mnist.py --batch_size 64 --epochs 4
+fastestimator train lenet_mnist.py --batch_size 64 --epochs 4
 ```
 
 ## Table of Contents:

--- a/fastestimator/trace/trace.py
+++ b/fastestimator/trace/trace.py
@@ -30,6 +30,8 @@ class Trace:
     Traces are invoked by the fe.Estimator periodically as it runs. In addition to the current data dictionary, they are
     also given a pointer to the current `System` instance which allows access to more information as well as giving the
     ability to modify or even cancel training. The order of function invocations is as follows:
+
+    ``` plot
             Training:                                       Testing:
 
         on_begin                                            on_begin
@@ -51,6 +53,7 @@ class Trace:
         on_epoch_end (eval) >----------^
             |
         on_end
+    ```
 
     Args:
         inputs: A set of keys that this trace intends to read from the state dictionary as inputs.

--- a/tutorial/beginner/t10_cli.md
+++ b/tutorial/beginner/t10_cli.md
@@ -20,13 +20,13 @@ In this section we will show the actual commands that we can use to train and te
   To call `estimator.fit()` and start the training on terminal:
 
 ```
-$ fastestimator train mnist_tf.py
+fastestimator train mnist_tf.py
 ```
 
 To call `estimator.test()` and start testing on terminal:
 
 ```
-$ fastestimator test mnist_tf.py
+fastestimator test mnist_tf.py
 ```
 
 <a id='t10args'></a>
@@ -44,7 +44,7 @@ Next, we try to change these arguments in two ways:
 To pass the arguments directly from the CLI we can use the `--arg` format. The following shows an example of how we can set the number of epochs to 3 and batch_size to 64:
 
 ```
-$ fastestimator train mnist_tf.py --epochs 3 --batch_size 64
+fastestimator train mnist_tf.py --epochs 3 --batch_size 64
 ```
 
 <a id='t10json'></a>
@@ -58,5 +58,5 @@ JSON:
 }
 ```
 ```
-$ fastestimator train mnist_tf.py --hyperparameters hp.json
+fastestimator train mnist_tf.py --hyperparameters hp.json
 ```


### PR DESCRIPTION
1. cuurently our website pluging cannot support render the $ in the markdown. (it will get confused with Katex mathmetical expression). Therefore before we finish working on that plugin issue, we need to temporarily don't use $

2. For the illustration of Trace docstring, we need to put a ```plot ``` coding block around it.