### PR TITLE
put all dollar sign back

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,27 +13,27 @@ FastEstimator is a high-level deep learning library built on TensorFlow2 and PyT
 ### 1. Install Dependencies:
 * Windows (CPU):
     ```
-    pip install torch==1.4.0+cpu torchvision==0.5.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+    $ pip install torch==1.4.0+cpu torchvision==0.5.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
     ```
 
 * Linux (CPU/GPU):
     ```
-    apt-get install libglib2.0-0 libsm6 libxrender1 libxext6
+    $ apt-get install libglib2.0-0 libsm6 libxrender1 libxext6
     ```
 
 * Mac (CPU):
     ```
-    echo No dependency needed ":)"
+    $ echo No dependency needed ":)"
     ```
 
 ### 2. Install FastEstimator:
 * Stable:
     ```
-    pip install fastestimator
+    $ pip install fastestimator
     ```
 * Most Recent:
     ```
-    pip install fastestimator-nightly
+    $ pip install fastestimator-nightly
     ```
 
 

--- a/apphub/README.md
+++ b/apphub/README.md
@@ -28,19 +28,19 @@ Each example contains three files:
 
 One can simply execute the python file of any example:
 ```
-python mnist_tf.py
+$ python mnist_tf.py
 ```
 
 Or use our Command-Line Interface (CLI):
 
 ```
-fastestimator train mnist_torch.py
+$ fastestimator train mnist_torch.py
 ```
 
 One benefit of the CLI is that it allows users to configure the input args of `get_estimator`:
 
 ```
-fastestimator train lenet_mnist.py --batch_size 64 --epochs 4
+$ fastestimator train lenet_mnist.py --batch_size 64 --epochs 4
 ```
 
 ## Table of Contents:

--- a/tutorial/beginner/t10_cli.md
+++ b/tutorial/beginner/t10_cli.md
@@ -20,13 +20,13 @@ In this section we will show the actual commands that we can use to train and te
   To call `estimator.fit()` and start the training on terminal:
 
 ```
-fastestimator train mnist_tf.py
+$ fastestimator train mnist_tf.py
 ```
 
 To call `estimator.test()` and start testing on terminal:
 
 ```
-fastestimator test mnist_tf.py
+$ fastestimator test mnist_tf.py
 ```
 
 <a id='t10args'></a>
@@ -44,7 +44,7 @@ Next, we try to change these arguments in two ways:
 To pass the arguments directly from the CLI we can use the `--arg` format. The following shows an example of how we can set the number of epochs to 3 and batch_size to 64:
 
 ```
-fastestimator train mnist_tf.py --epochs 3 --batch_size 64
+$ fastestimator train mnist_tf.py --epochs 3 --batch_size 64
 ```
 
 <a id='t10json'></a>
@@ -58,5 +58,5 @@ JSON:
 }
 ```
 ```
-fastestimator train mnist_tf.py --hyperparameters hp.json
+$ fastestimator train mnist_tf.py --hyperparameters hp.json
 ```


### PR DESCRIPTION
We manage to handle the dollar sign problem. 
In order to not confused the parser, the all singe dollar sign need to be trailed by a space to not get recognized as tex mathematic expression. This apply to all .md, .ipynb, and all docstring. 
ex: 
* $1/times1$  => tex 
* $ echo hello world  => not tex