### PR TITLE
clean the first and last space for tex expression

### DIFF
--- a/apphub/multi_task_learning/uncertainty_weighted_loss/uncertainty_loss.ipynb
+++ b/apphub/multi_task_learning/uncertainty_weighted_loss/uncertainty_loss.ipynb
@@ -8,12 +8,12 @@
     "\n",
     "Multi-task learning is popular in many deep learning applications, for example, in object detection, the network performs both classification and localization for each object. As a result, the final loss will be a combination of classification loss and regression loss. The most frequent way of combining two losses is by simply adding them together. \n",
     "\n",
-    "$ loss_{total} = loss_1 + loss_2 $\n",
+    "$loss_{total} = loss_1 + loss_2$\n",
     "\n",
     "\n",
     "However, problem emerges when the two losses are on different numerical scale. To resolve this issue, people usually manually design/experiemnt the best weight, which is very time consuming and computationally expensive.\n",
     "\n",
-    "$ loss_{total} = w_1loss_1 + w_2loss_2 $\n",
+    "$loss_{total} = w_1loss_1 + w_2loss_2$\n",
     "\n",
     "[This paper](https://arxiv.org/abs/1705.07115) presents an interesting idea of making the weight w1 and w2 as trainable parameters based on uncertainty of each task, such that the network can dynamically focus more on the task with higher uncertainty."
    ]


### PR DESCRIPTION
our fe website take tex expression without starting space right after first dollar sign.

$ 1/times/1 $ => wrong
$1/times/1 $ => ok
$1/times/1$ => ok 