### PR TITLE
add bash coding block decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,27 +12,27 @@ FastEstimator is a high-level deep learning library built on TensorFlow2 and PyT
 ## Installation:
 ### 1. Install Dependencies:
 * Windows (CPU):
-    ```
+    ``` bash
     $ pip install torch==1.4.0+cpu torchvision==0.5.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
     ```
 
 * Linux (CPU/GPU):
-    ```
+    ``` bash
     $ apt-get install libglib2.0-0 libsm6 libxrender1 libxext6
     ```
 
 * Mac (CPU):
-    ```
+    ``` bash
     $ echo No dependency needed ":)"
     ```
 
 ### 2. Install FastEstimator:
 * Stable:
-    ```
+    ``` bash
     $ pip install fastestimator
     ```
 * Most Recent:
-    ```
+    ``` bash
     $ pip install fastestimator-nightly
     ```
 
@@ -40,8 +40,14 @@ FastEstimator is a high-level deep learning library built on TensorFlow2 and PyT
 ## Docker Hub
 Docker containers create isolated virtual environments that share resources with a host machine. Docker provides an easy way to set up a FastEstimator environment. You can simply pull our image from [Docker Hub](https://hub.docker.com/r/fastestimator/fastestimator/tags) and get started:
 
-* GPU: `docker pull fastestimator/fastestimator:latest-gpu`
-* CPU: `docker pull fastestimator/fastestimator:latest-cpu`
+* GPU:
+``` bash
+docker pull fastestimator/fastestimator:latest-gpu
+```
+* CPU:
+``` bash
+docker pull fastestimator/fastestimator:latest-cpu
+```
 
 
 

--- a/README.md
+++ b/README.md
@@ -41,13 +41,13 @@ FastEstimator is a high-level deep learning library built on TensorFlow2 and PyT
 Docker containers create isolated virtual environments that share resources with a host machine. Docker provides an easy way to set up a FastEstimator environment. You can simply pull our image from [Docker Hub](https://hub.docker.com/r/fastestimator/fastestimator/tags) and get started:
 
 * GPU:
-``` bash
-docker pull fastestimator/fastestimator:latest-gpu
-```
+    ``` bash
+    docker pull fastestimator/fastestimator:latest-gpu
+    ```
 * CPU:
-``` bash
-docker pull fastestimator/fastestimator:latest-cpu
-```
+    ``` bash
+    docker pull fastestimator/fastestimator:latest-cpu
+    ```
 
 
 

--- a/apphub/README.md
+++ b/apphub/README.md
@@ -27,19 +27,19 @@ Each example contains three files:
 ## How do I run each example
 
 One can simply execute the python file of any example:
-```
+``` bash
 $ python mnist_tf.py
 ```
 
 Or use our Command-Line Interface (CLI):
 
-```
+``` bash
 $ fastestimator train mnist_torch.py
 ```
 
 One benefit of the CLI is that it allows users to configure the input args of `get_estimator`:
 
-```
+``` bash
 $ fastestimator train lenet_mnist.py --batch_size 64 --epochs 4
 ```
 

--- a/tutorial/beginner/t10_cli.md
+++ b/tutorial/beginner/t10_cli.md
@@ -19,13 +19,13 @@ In this section we will show the actual commands that we can use to train and te
 
   To call `estimator.fit()` and start the training on terminal:
 
-```
+``` bash
 $ fastestimator train mnist_tf.py
 ```
 
 To call `estimator.test()` and start testing on terminal:
 
-```
+``` bash
 $ fastestimator test mnist_tf.py
 ```
 
@@ -43,7 +43,7 @@ Next, we try to change these arguments in two ways:
 ### Using --arg
 To pass the arguments directly from the CLI we can use the `--arg` format. The following shows an example of how we can set the number of epochs to 3 and batch_size to 64:
 
-```
+``` bash
 $ fastestimator train mnist_tf.py --epochs 3 --batch_size 64
 ```
 
@@ -57,6 +57,6 @@ JSON:
     "batch_size": 64
 }
 ```
-```
+``` bash
 $ fastestimator train mnist_tf.py --hyperparameters hp.json
 ```


### PR DESCRIPTION
Our website will take all coding block without language specification as output coding block (the return cell in jupyter notebook file). That means all our coding block need to have one language specified. 

Here I add "bash" tag in all commad-like coding block.

