### PR TITLE
change to use tf.is_tensor() as instance type examination approach 

### DIFF
--- a/fastestimator/backend/abs.py
+++ b/fastestimator/backend/abs.py
@@ -51,7 +51,7 @@ def abs(tensor: Tensor) -> Tensor:
     Raises:
         ValueError: If `tensor` is an unacceptable data type.
     """
-    if isinstance(tensor, tf.Tensor):
+    if tf.is_tensor(tensor):
         return tf.abs(tensor)
     elif isinstance(tensor, torch.Tensor):
         return torch.abs(tensor)

--- a/fastestimator/backend/argmax.py
+++ b/fastestimator/backend/argmax.py
@@ -55,7 +55,7 @@ def argmax(tensor: Tensor, axis: int = 0) -> Tensor:
     Raises:
         ValueError: If `tensor` is an unacceptable data type.
     """
-    if isinstance(tensor, tf.Tensor):
+    if tf.is_tensor(tensor):
         return tf.argmax(tensor, axis=axis)
     elif isinstance(tensor, torch.Tensor):
         return tensor.max(dim=axis, keepdim=False)[1]

--- a/fastestimator/backend/binary_crossentropy.py
+++ b/fastestimator/backend/binary_crossentropy.py
@@ -58,9 +58,9 @@ def binary_crossentropy(y_pred: Tensor, y_true: Tensor, from_logits: bool = Fals
         AssertionError: If `y_true` or `y_pred` are unacceptable data types.
     """
     assert type(y_pred) is type(y_true), "y_pred and y_true must be same tensor type"
-    assert isinstance(y_pred, (tf.Tensor, torch.Tensor)), "only support tf.Tensor or torch.Tensor as y_pred"
-    assert isinstance(y_true, (tf.Tensor, torch.Tensor)), "only support tf.Tensor or torch.Tensor as y_true"
-    if isinstance(y_pred, tf.Tensor):
+    assert isinstance(y_pred, torch.Tensor) or tf.is_tensor(y_pred), "only support tf.Tensor or torch.Tensor as y_pred"
+    assert isinstance(y_true, torch.Tensor) or tf.is_tensor(y_true), "only support tf.Tensor or torch.Tensor as y_true"
+    if tf.is_tensor(y_pred):
         ce = tf.losses.binary_crossentropy(y_pred=y_pred,
                                            y_true=tf.reshape(y_true, y_pred.shape),
                                            from_logits=from_logits)

--- a/fastestimator/backend/cast.py
+++ b/fastestimator/backend/cast.py
@@ -67,7 +67,7 @@ def cast(data: Union[Collection, Tensor], dtype: str) -> Union[Collection, Tenso
         return tuple([cast(val, dtype) for val in data])
     elif isinstance(data, set):
         return set([cast(val, dtype) for val in data])
-    elif isinstance(data, tf.Tensor):
+    elif tf.is_tensor(data):
         return tf.cast(data, STRING_TO_TF_DTYPE[dtype])
     elif isinstance(data, torch.Tensor):
         return data.type(STRING_TO_TORCH_DTYPE[dtype])

--- a/fastestimator/backend/categorical_crossentropy.py
+++ b/fastestimator/backend/categorical_crossentropy.py
@@ -62,7 +62,7 @@ def categorical_crossentropy(y_pred: Tensor, y_true: Tensor, from_logits: bool =
     assert type(y_pred) == type(y_true), "y_pred and y_true must be same tensor type"
     assert isinstance(y_pred, (tf.Tensor, torch.Tensor)), "only support tf.Tensor or torch.Tensor as y_pred"
     assert isinstance(y_true, (tf.Tensor, torch.Tensor)), "only support tf.Tensor or torch.Tensor as y_true"
-    if isinstance(y_pred, tf.Tensor):
+    if tf.is_tensor(y_pred):
         ce = tf.losses.categorical_crossentropy(y_pred=y_pred, y_true=y_true, from_logits=from_logits)
     else:
         y_true = y_true.to(torch.float)

--- a/fastestimator/backend/clip_by_value.py
+++ b/fastestimator/backend/clip_by_value.py
@@ -53,7 +53,7 @@ def clip_by_value(tensor: Tensor, min_value: Union[int, float, Tensor], max_valu
     Raises:
         ValueError: If `tensor` is an unacceptable data type.
     """
-    if isinstance(tensor, tf.Tensor):
+    if tf.is_tensor(tensor):
         return tf.clip_by_value(tensor, clip_value_min=min_value, clip_value_max=max_value)
     elif isinstance(tensor, torch.Tensor):
         if isinstance(min_value, torch.Tensor):

--- a/fastestimator/backend/concat.py
+++ b/fastestimator/backend/concat.py
@@ -57,7 +57,7 @@ def concat(tensors: List[Tensor], axis: int = 0) -> Optional[Tensor]:
     """
     if len(tensors) == 0:
         return None
-    if isinstance(tensors[0], tf.Tensor):
+    if tf.is_tensor(tensors[0]):
         return tf.concat(tensors, axis=axis)
     elif isinstance(tensors[0], torch.Tensor):
         return torch.cat(tensors, dim=axis)

--- a/fastestimator/backend/expand_dims.py
+++ b/fastestimator/backend/expand_dims.py
@@ -55,7 +55,7 @@ def expand_dims(tensor: Tensor, axis: int = 1) -> Tensor:
     Raises:
         ValueError: If `tensor` is an unacceptable data type.
     """
-    if isinstance(tensor, tf.Tensor):
+    if tf.is_tensor(tensor):
         return tf.expand_dims(tensor, axis=axis)
     elif isinstance(tensor, torch.Tensor):
         return torch.unsqueeze(tensor, dim=axis)

--- a/fastestimator/backend/feed_forward.py
+++ b/fastestimator/backend/feed_forward.py
@@ -55,7 +55,7 @@ def feed_forward(model: Union[tf.keras.Model, torch.nn.Module], x: Union[Tensor,
         ValueError: If `model` is an unacceptable data type.
     """
     if isinstance(model, tf.keras.Model):
-        if not isinstance(x, tf.Tensor):
+        if not tf.is_tensor(x):
             x = to_tensor(x, "tf")
         x = model(x, training=training)
     elif isinstance(model, torch.nn.Module):

--- a/fastestimator/backend/gather_from_batch.py
+++ b/fastestimator/backend/gather_from_batch.py
@@ -68,7 +68,7 @@ def gather_from_batch(tensor: Tensor, indices: Tensor) -> Tensor:
     Raises:
         ValueError: If `tensor` is an unacceptable data type.
     """
-    if isinstance(tensor, tf.Tensor):
+    if tf.is_tensor(tensor):
         indices = to_tensor(indices, 'tf')
         indices = tf.cast(indices, tf.int64)
         if len(indices.shape) == 1:  # Indices not batched

--- a/fastestimator/backend/get_gradient.py
+++ b/fastestimator/backend/get_gradient.py
@@ -67,7 +67,7 @@ def get_gradient(target: Tensor,
     Raises:
         ValueError: If `target` is an unacceptable data type.
     """
-    if isinstance(target, tf.Tensor):
+    if tf.is_tensor(target):
         with NonContext() if higher_order else tape.stop_recording():
             gradients = tape.gradient(target, sources)
     elif isinstance(target, torch.Tensor):

--- a/fastestimator/backend/mean_squared_error.py
+++ b/fastestimator/backend/mean_squared_error.py
@@ -59,7 +59,7 @@ def mean_squared_error(y_true: Tensor, y_pred: Tensor) -> Tensor:
     assert type(y_pred) == type(y_true), "y_pred and y_true must be of the same tensor type"
     assert y_pred.shape == y_true.shape, \
         f"MSE requires y_true and y_pred to have the same shape, but found {y_true.shape} and {y_pred.shape}"
-    if isinstance(y_pred, tf.Tensor):
+    if tf.is_tensor(y_pred):
         mse = tf.losses.MSE(y_true, y_pred)
     elif isinstance(y_pred, torch.Tensor):
         mse = reduce_mean(

--- a/fastestimator/backend/percentile.py
+++ b/fastestimator/backend/percentile.py
@@ -70,7 +70,7 @@ def percentile(tensor: Tensor,
     Raises:
         ValueError: If `tensor` is an unacceptable data type.
     """
-    if isinstance(tensor, tf.Tensor):
+    if tf.is_tensor(tensor):
         if isinstance(percentiles, List):
             percentiles = tf.convert_to_tensor(percentiles)
         return tfp.stats.percentile(tensor, percentiles, axis=axis, keep_dims=keepdims, interpolation='lower')

--- a/fastestimator/backend/permute.py
+++ b/fastestimator/backend/permute.py
@@ -55,7 +55,7 @@ def permute(tensor: Tensor, permutation: List[int]) -> Tensor:
     Raises:
         ValueError: If `tensor` is an unacceptable data type.
     """
-    if isinstance(tensor, tf.Tensor):
+    if tf.is_tensor(tensor):
         return tf.transpose(tensor, perm=permutation)
     elif isinstance(tensor, torch.Tensor):
         return tensor.permute(*permutation)

--- a/fastestimator/backend/random_normal_like.py
+++ b/fastestimator/backend/random_normal_like.py
@@ -61,7 +61,7 @@ def random_normal_like(tensor: Tensor, mean: float = 0.0, std: float = 1.0,
     Raises:
         ValueError: If `tensor` is an unacceptable data type.
     """
-    if isinstance(tensor, tf.Tensor):
+    if tf.is_tensor(tensor):
         return tf.random.normal(shape=tensor.shape, mean=mean, stddev=std, dtype=dtype)
     elif isinstance(tensor, torch.Tensor):
         return torch.randn_like(tensor, dtype=STRING_TO_TORCH_DTYPE[dtype]) * std + mean

--- a/fastestimator/backend/reduce_max.py
+++ b/fastestimator/backend/reduce_max.py
@@ -64,7 +64,7 @@ def reduce_max(tensor: Tensor, axis: Union[None, int, Sequence[int]] = None, kee
     Raises:
         ValueError: If `tensor` is an unacceptable data type.
     """
-    if isinstance(tensor, tf.Tensor):
+    if tf.is_tensor(tensor):
         return tf.reduce_max(tensor, axis=axis, keepdims=keepdims)
     elif isinstance(tensor, torch.Tensor):
         if axis is None:

--- a/fastestimator/backend/reduce_mean.py
+++ b/fastestimator/backend/reduce_mean.py
@@ -64,7 +64,7 @@ def reduce_mean(tensor: Tensor, axis: Union[None, int, Sequence[int]] = None, ke
     Raises:
         ValueError: If `tensor` is an unacceptable data type.
     """
-    if isinstance(tensor, tf.Tensor):
+    if tf.is_tensor(tensor):
         return tf.reduce_mean(tensor, axis=axis, keepdims=keepdims)
     elif isinstance(tensor, torch.Tensor):
         if axis is None:

--- a/fastestimator/backend/reduce_min.py
+++ b/fastestimator/backend/reduce_min.py
@@ -64,7 +64,7 @@ def reduce_min(tensor: Tensor, axis: Union[None, int, Sequence[int]] = None, kee
     Raises:
         ValueError: If `tensor` is an unacceptable data type.
     """
-    if isinstance(tensor, tf.Tensor):
+    if tf.is_tensor(tensor):
         return tf.reduce_min(tensor, axis=axis, keepdims=keepdims)
     elif isinstance(tensor, torch.Tensor):
         if axis is None:

--- a/fastestimator/backend/reduce_sum.py
+++ b/fastestimator/backend/reduce_sum.py
@@ -62,7 +62,7 @@ def reduce_sum(tensor: Tensor, axis: Union[None, int, Sequence[int]] = None, kee
     Raises:
         ValueError: If `tensor` is an unacceptable data type.
     """
-    if isinstance(tensor, tf.Tensor):
+    if tf.is_tensor(tensor):
         return tf.reduce_sum(tensor, axis=axis, keepdims=keepdims)
     elif isinstance(tensor, torch.Tensor):
         if axis is None:

--- a/fastestimator/backend/reshape.py
+++ b/fastestimator/backend/reshape.py
@@ -62,7 +62,7 @@ def reshape(tensor: Tensor, shape: List[int]) -> Tensor:
     Raises:
         ValueError: If `tensor` is an unacceptable data type.
     """
-    if isinstance(tensor, tf.Tensor):
+    if tf.is_tensor(tensor):
         return tf.reshape(tensor, shape=shape)
     elif isinstance(tensor, torch.Tensor):
         return torch.reshape(tensor, shape=shape)

--- a/fastestimator/backend/sign.py
+++ b/fastestimator/backend/sign.py
@@ -51,7 +51,7 @@ def sign(tensor: Tensor) -> Tensor:
     Raises:
         ValueError: If `tensor` is an unacceptable data type.
     """
-    if isinstance(tensor, tf.Tensor):
+    if tf.is_tensor(tensor):
         return tf.sign(tensor)
     elif isinstance(tensor, torch.Tensor):
         return tensor.sign()

--- a/fastestimator/backend/sparse_categorical_crossentropy.py
+++ b/fastestimator/backend/sparse_categorical_crossentropy.py
@@ -64,7 +64,7 @@ def sparse_categorical_crossentropy(y_pred: Tensor,
     assert type(y_pred) == type(y_true), "y_pred and y_true must be same tensor type"
     assert isinstance(y_pred, (tf.Tensor, torch.Tensor)), "only support tf.Tensor or torch.Tensor as y_pred"
     assert isinstance(y_true, (tf.Tensor, torch.Tensor)), "only support tf.Tensor or torch.Tensor as y_true"
-    if isinstance(y_pred, tf.Tensor):
+    if tf.is_tensor(y_pred):
         ce = tf.losses.sparse_categorical_crossentropy(y_pred=y_pred, y_true=y_true, from_logits=from_logits)
     else:
         y_true = y_true.view(-1)

--- a/fastestimator/backend/squeeze.py
+++ b/fastestimator/backend/squeeze.py
@@ -58,7 +58,7 @@ def squeeze(tensor: Tensor, axis: Optional[int] = None) -> Tensor:
     Raises:
         ValueError: If `tensor` is an unacceptable data type.
     """
-    if isinstance(tensor, tf.Tensor):
+    if tf.is_tensor(tensor):
         return tf.squeeze(tensor, axis=axis)
     elif isinstance(tensor, torch.Tensor):
         if axis is None:

--- a/fastestimator/backend/to_number.py
+++ b/fastestimator/backend/to_number.py
@@ -48,7 +48,7 @@ def to_number(data: Union[tf.Tensor, torch.Tensor, np.ndarray, int, float]) -> n
     Returns:
         An ndarray corresponding to the given `data`.
     """
-    if isinstance(data, tf.Tensor):
+    if tf.is_tensor(data):
         data = data.numpy()
     elif isinstance(data, torch.Tensor):
         if data.requires_grad:

--- a/fastestimator/backend/watch.py
+++ b/fastestimator/backend/watch.py
@@ -47,7 +47,7 @@ def watch(tensor: Tensor, tape: Optional[tf.GradientTape] = None) -> Tensor:
     Raises:
         ValueError: If `tensor` is an unacceptable data type.
     """
-    if isinstance(tensor, tf.Tensor):
+    if tf.is_tensor(tensor):
         tape.watch(tensor)
         return tensor
     elif isinstance(tensor, torch.Tensor):

--- a/fastestimator/backend/zeros_like.py
+++ b/fastestimator/backend/zeros_like.py
@@ -57,7 +57,7 @@ def zeros_like(tensor: Tensor, dtype: Union[None, str] = None) -> Tensor:
     Raises:
         ValueError: If `tensor` is an unacceptable data type.
     """
-    if isinstance(tensor, tf.Tensor):
+    if tf.is_tensor(tensor):
         return tf.zeros_like(tensor, dtype=dtype)
     elif isinstance(tensor, torch.Tensor):
         return torch.zeros_like(tensor, dtype=STRING_TO_TORCH_DTYPE[dtype])

--- a/fastestimator/op/tensorop/gather.py
+++ b/fastestimator/op/tensorop/gather.py
@@ -59,7 +59,7 @@ class Gather(TensorOp):
         results = []
         for idx, tensor in enumerate(inputs):
             # Check len(indices[0]) since an empty indices element is used to trigger the else
-            if isinstance(indices[0], tf.Tensor) or isinstance(indices[0], torch.Tensor):
+            if tf.is_tensor(indices[0]) or isinstance(indices[0], torch.Tensor):
                 elem_len = indices[0].shape[0]
             else:
                 elem_len = len(indices[0])

--- a/fastestimator/op/tensorop/reshape.py
+++ b/fastestimator/op/tensorop/reshape.py
@@ -46,7 +46,7 @@ class Reshape(TensorOp):
         self.in_list, self.out_list = False, False
 
     def forward(self, data: Tensor, state: Dict[str, Any]) -> Tensor:
-        if isinstance(data, tf.Tensor):
+        if tf.is_tensor(data):
             return tf.reshape(data, self.shape)
         elif isinstance(data, torch.Tensor):
             return data.view(self.shape)

--- a/fastestimator/test/unittest_util.py
+++ b/fastestimator/test/unittest_util.py
@@ -48,7 +48,7 @@ def is_equal(obj1: Any, obj2: Any, assert_type: bool = True) -> bool:
     elif type(obj1) == np.ndarray:
         return np.array_equal(obj1, obj2)
 
-    elif tf.is_tensor(obj1)::
+    elif tf.is_tensor(obj1):
         obj1 = obj1.numpy()
         obj2 = obj2.numpy()
         return np.array_equal(obj1, obj2)

--- a/fastestimator/test/unittest_util.py
+++ b/fastestimator/test/unittest_util.py
@@ -48,7 +48,7 @@ def is_equal(obj1: Any, obj2: Any, assert_type: bool = True) -> bool:
     elif type(obj1) == np.ndarray:
         return np.array_equal(obj1, obj2)
 
-    elif isinstance(obj1, tf.Tensor) or isinstance(obj1, tf.Variable):
+    elif tf.is_tensor(obj1)::
         obj1 = obj1.numpy()
         obj2 = obj2.numpy()
         return np.array_equal(obj1, obj2)


### PR DESCRIPTION
1. change to use tf.is_tensor() as instance type examination approach instead of isinstance(..., 
    tf.Tensor). Because it can cover the instance type tf.Variable