### PR TITLE
add max_to_keep argument to ModelSaver

### DIFF
--- a/fastestimator/trace/io/model_saver.py
+++ b/fastestimator/trace/io/model_saver.py
@@ -12,7 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Union
+import os
+import queue
+from typing import Optional, Union
 
 import tensorflow as tf
 import torch
@@ -31,12 +33,20 @@ class ModelSaver(Trace):
         model: A model instance compiled with fe.build.
         save_dir: Folder path into which to save the `model`.
         frequency: Model saving frequency in epoch(s).
+        max_to_keep: Maximum number of latest saved files to keep.
     """
-    def __init__(self, model: Union[tf.keras.Model, torch.nn.Module], save_dir: str, frequency: int = 1) -> None:
+    def __init__(self,
+                 model: Union[tf.keras.Model, torch.nn.Module],
+                 save_dir: str,
+                 frequency: int = 1,
+                 max_to_keep: Optional[int] = None) -> None:
         super().__init__(mode="train")
         self.model = model
         self.save_dir = save_dir
         self.frequency = frequency
+        self.max_to_keep = max_to_keep
+        if max_to_keep:
+            self.file_queue = queue.Queue()
 
     def on_epoch_end(self, data: Data) -> None:
         # No model will be saved when save_dir is None, which makes smoke test easier.
@@ -44,3 +54,17 @@ class ModelSaver(Trace):
             model_name = "{}_epoch_{}".format(self.model.model_name, self.system.epoch_idx)
             model_path = save_model(self.model, self.save_dir, model_name)
             print("FastEstimator-ModelSaver: Saved model to {}".format(model_path))
+
+            if self.max_to_keep:
+                if self.file_queue.qsize() == self.max_to_keep:
+                    removed_name = self.file_queue.get()
+                    if isinstance(self.model, tf.keras.Model):
+                        removed_name = "{}.h5".format(removed_name)
+                    elif isinstance(self.model, torch.nn.Module):
+                        removed_name = "{}.pt".format(removed_name)
+                    else:
+                        raise ValueError("Unrecognized model instance {}".format(type(model)))
+                    os.remove(os.path.join(self.save_dir, removed_name))
+                    print("FastEstimator-ModelSaver: Removed model {} due to file number exceeding max_to_keep".format(
+                        model_path))
+                self.file_queue.put(model_name)

--- a/fastestimator/trace/io/model_saver.py
+++ b/fastestimator/trace/io/model_saver.py
@@ -33,7 +33,7 @@ class ModelSaver(Trace):
         model: A model instance compiled with fe.build.
         save_dir: Folder path into which to save the `model`.
         frequency: Model saving frequency in epoch(s).
-        max_to_keep: Maximum number of latest saved files to keep.
+        max_to_keep: Maximum number of latest saved files to keep. If None, all models will be saved.
     """
     def __init__(self,
                  model: Union[tf.keras.Model, torch.nn.Module],
@@ -57,14 +57,8 @@ class ModelSaver(Trace):
 
             if self.max_to_keep:
                 if self.file_queue.qsize() == self.max_to_keep:
-                    removed_name = self.file_queue.get()
-                    if isinstance(self.model, tf.keras.Model):
-                        removed_name = "{}.h5".format(removed_name)
-                    elif isinstance(self.model, torch.nn.Module):
-                        removed_name = "{}.pt".format(removed_name)
-                    else:
-                        raise ValueError("Unrecognized model instance {}".format(type(model)))
-                    os.remove(os.path.join(self.save_dir, removed_name))
+                    removed_path = self.file_queue.get()
+                    os.remove(os.path.join(self.save_dir, removed_path))
                     print("FastEstimator-ModelSaver: Removed model {} due to file number exceeding max_to_keep".format(
                         model_path))
-                self.file_queue.put(model_name)
+                self.file_queue.put(model_path)

--- a/test/PR_test/integration_test/trace/io/test_model_saver.py
+++ b/test/PR_test/integration_test/trace/io/test_model_saver.py
@@ -40,7 +40,7 @@ class TestModelSaver(unittest.TestCase):
         model_saver.system = sample_system_object()
         model_saver.on_epoch_end(data={})
         model_name = "{}_epoch_{}".format(model_saver.model.model_name, model_saver.system.epoch_idx)
-        tf_model_path = os.path.join(self.save_dir, model_name+'.h5')
+        tf_model_path = os.path.join(self.save_dir, model_name + '.h5')
         with self.subTest('Check if model is saved'):
             self.assertTrue(os.path.exists(tf_model_path))
         with self.subTest('Validate model weights'):
@@ -53,7 +53,7 @@ class TestModelSaver(unittest.TestCase):
         model_saver = ModelSaver(model=model, save_dir=self.save_dir)
         model_saver.system = sample_system_object()
         model_name = model_name = "{}_epoch_{}".format(model_saver.model.model_name, model_saver.system.epoch_idx)
-        torch_model_path = os.path.join(self.save_dir, model_name+'.pt')
+        torch_model_path = os.path.join(self.save_dir, model_name + '.pt')
         if os.path.exists(torch_model_path):
             os.remove(torch_model_path)
         model_saver.on_epoch_end(data={})
@@ -63,3 +63,50 @@ class TestModelSaver(unittest.TestCase):
             m2 = fe.build(model_fn=MultiLayerTorchModelWithoutWeights, optimizer_fn='adam')
             fe.backend.load_model(m2, torch_model_path)
             self.assertTrue(is_equal(list(m2.parameters()), list(model.parameters())))
+
+    def test_max_to_keep_tf(self):
+        save_dir = tempfile.mkdtemp()
+        model = fe.build(model_fn=one_layer_tf_model, optimizer_fn='adam')
+        model_saver = ModelSaver(model=model, save_dir=save_dir, max_to_keep=2)
+        model_saver.system = sample_system_object()
+        model_saver.on_epoch_end(data={})
+        model_saver.system.epoch_idx += 1
+        model_saver.on_epoch_end(data={})
+        model_name = "{}_epoch_{}".format(model_saver.model.model_name, model_saver.system.epoch_idx)
+        tf_model_path1 = os.path.join(save_dir, model_name + '.h5')
+
+        model_saver.system.epoch_idx += 1
+        model_saver.on_epoch_end(data={})
+        model_name = "{}_epoch_{}".format(model_saver.model.model_name, model_saver.system.epoch_idx)
+        tf_model_path2 = os.path.join(save_dir, model_name + '.h5')
+
+        with self.subTest('Check only two file are kept'):
+            self.assertEqual(len(os.listdir(save_dir)), 2)
+
+        with self.subTest('Check two latest model are kept'):
+            self.assertTrue(os.path.exists(tf_model_path1))
+            self.assertTrue(os.path.exists(tf_model_path2))
+
+    def test_max_to_keep_torch(self):
+        save_dir = tempfile.mkdtemp()
+        model = fe.build(model_fn=MultiLayerTorchModel, optimizer_fn='adam')
+        model_saver = ModelSaver(model=model, save_dir=save_dir, max_to_keep=2)
+        model_saver.system = sample_system_object()
+        model_saver.on_epoch_end(data={})
+        model_saver.system.epoch_idx += 1
+        model_saver.on_epoch_end(data={})
+        model_name = "{}_epoch_{}".format(model_saver.model.model_name, model_saver.system.epoch_idx)
+        torch_model_path1 = os.path.join(save_dir, model_name + '.pt')
+
+        model_saver.system.epoch_idx += 1
+        model_saver.on_epoch_end(data={})
+        model_name = "{}_epoch_{}".format(model_saver.model.model_name, model_saver.system.epoch_idx)
+        torch_model_path2 = os.path.join(save_dir, model_name + '.pt')
+
+        with self.subTest('Check only two file are kept'):
+            print(os.listdir(save_dir))
+            self.assertEqual(len(os.listdir(save_dir)), 2)
+
+        with self.subTest('Check two latest model are kept'):
+            self.assertTrue(os.path.exists(torch_model_path1))
+            self.assertTrue(os.path.exists(torch_model_path2))

--- a/test/PR_test/integration_test/trace/io/test_model_saver.py
+++ b/test/PR_test/integration_test/trace/io/test_model_saver.py
@@ -109,3 +109,15 @@ class TestModelSaver(unittest.TestCase):
         with self.subTest('Check two latest model are kept'):
             self.assertTrue(os.path.exists(torch_model_path1))
             self.assertTrue(os.path.exists(torch_model_path2))
+
+    def test_max_to_keep_invalid_value(self):
+        model = fe.build(model_fn=MultiLayerTorchModel, optimizer_fn='adam')
+        save_dir = "dummy"
+        
+        with self.subTest('Check max_to_keep < 0'):
+            with self.assertRaises(ValueError):
+                model_saver = ModelSaver(model=model, save_dir=save_dir, max_to_keep=-2)
+
+        with self.subTest('Check max_to_keep = 0'):
+            with self.assertRaises(ValueError):
+                model_saver = ModelSaver(model=model, save_dir=save_dir, max_to_keep=0)

--- a/test/PR_test/integration_test/trace/io/test_model_saver.py
+++ b/test/PR_test/integration_test/trace/io/test_model_saver.py
@@ -104,7 +104,6 @@ class TestModelSaver(unittest.TestCase):
         torch_model_path2 = os.path.join(save_dir, model_name + '.pt')
 
         with self.subTest('Check only two file are kept'):
-            print(os.listdir(save_dir))
             self.assertEqual(len(os.listdir(save_dir)), 2)
 
         with self.subTest('Check two latest model are kept'):


### PR DESCRIPTION
1. add a new argument to ModelSaver: max_to_keep.
    It allows users to set an upper bound of file number to keep that generated from the trace

2. add new unit test for this feature