### PR TITLE
add data_dir as parameter

### DIFF
--- a/apphub/one_shot_learning/siamese_network/siamese.ipynb
+++ b/apphub/one_shot_learning/siamese_network/siamese.ipynb
@@ -77,7 +77,7 @@
    "source": [
     "from fastestimator.dataset.data import omniglot\n",
     "\n",
-    "train_data, eval_data = omniglot.load_data()\n",
+    "train_data, eval_data = omniglot.load_data(root_dir=data_dir)\n",
     "test_data = eval_data.split(0.5)"
    ]
   },


### PR DESCRIPTION
1. add data_dir parameter such that it can support nightly-test script to set data loading path if needed 
2. check all apphub notebook example has data_dir parameter except some example using cifar10, mnist, imdb_review, breas_cancer dataset that load_data api doesn't have root_dir argument