### PR TITLE
pass shell argument to its invoking sub-command 

### DIFF
--- a/test/apphub_scripts/NLP/imdb/run_nb.sh
+++ b/test/apphub_scripts/NLP/imdb/run_nb.sh
@@ -20,4 +20,4 @@ stderr_file="${dir_path}/run_nb_stderr.txt"
 nb_out="${dir_path}/${example_name}_out.ipynb"
 nb_in="${source_dir}/${example_name}.ipynb"
 
-papermill $nb_in $nb_out $train_info -k nightly_build 2> $stderr_file
+papermill $nb_in $nb_out $train_info $@ -k nightly_build 2> $stderr_file

--- a/test/apphub_scripts/NLP/imdb/run_tf.sh
+++ b/test/apphub_scripts/NLP/imdb/run_tf.sh
@@ -21,9 +21,9 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_tf_stderr.txt"
 py_file="${source_dir}/${example_name}_tf.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
     echo 'run test'
 fi

--- a/test/apphub_scripts/NLP/imdb/run_torch.sh
+++ b/test/apphub_scripts/NLP/imdb/run_torch.sh
@@ -24,8 +24,8 @@ py_file="${source_dir}/${example_name}_torch.py"
 echo $py_file
 
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
 fi

--- a/test/apphub_scripts/NLP/named_entity_recognition/run_nb.sh
+++ b/test/apphub_scripts/NLP/named_entity_recognition/run_nb.sh
@@ -20,4 +20,4 @@ stderr_file="${dir_path}/run_nb_stderr.txt"
 nb_out="${dir_path}/${example_name}_out.ipynb"
 nb_in="${source_dir}/${example_name}.ipynb"
 
-papermill $nb_in $nb_out $train_info -k nightly_build 2> $stderr_file
+papermill $nb_in $nb_out $train_info $@ -k nightly_build 2> $stderr_file

--- a/test/apphub_scripts/NLP/named_entity_recognition/run_tf.sh
+++ b/test/apphub_scripts/NLP/named_entity_recognition/run_tf.sh
@@ -21,9 +21,9 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_tf_stderr.txt"
 py_file="${source_dir}/${example_name}_tf.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
     echo 'run test'
 fi

--- a/test/apphub_scripts/NLP/named_entity_recognition/run_torch.sh
+++ b/test/apphub_scripts/NLP/named_entity_recognition/run_torch.sh
@@ -20,8 +20,8 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_torch_stderr.txt"
 py_file="${source_dir}/${example_name}_torch.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
 fi

--- a/test/apphub_scripts/adversarial_training/ecc/run_nb.sh
+++ b/test/apphub_scripts/adversarial_training/ecc/run_nb.sh
@@ -20,4 +20,4 @@ stderr_file="${dir_path}/run_nb_stderr.txt"
 nb_out="${dir_path}/${example_name}_out.ipynb"
 nb_in="${source_dir}/${example_name}.ipynb"
 
-papermill $nb_in $nb_out $train_info -k nightly_build 2> $stderr_file
+papermill $nb_in $nb_out $train_info $@ -k nightly_build 2> $stderr_file

--- a/test/apphub_scripts/adversarial_training/ecc/run_tf.sh
+++ b/test/apphub_scripts/adversarial_training/ecc/run_tf.sh
@@ -21,9 +21,9 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_tf_stderr.txt"
 py_file="${source_dir}/${example_name}_tf.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
     echo 'run test'
 fi

--- a/test/apphub_scripts/adversarial_training/ecc/run_torch.sh
+++ b/test/apphub_scripts/adversarial_training/ecc/run_torch.sh
@@ -20,8 +20,8 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_torch_stderr.txt"
 py_file="${source_dir}/${example_name}_torch.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
 fi

--- a/test/apphub_scripts/adversarial_training/ecc_hinge/run_nb.sh
+++ b/test/apphub_scripts/adversarial_training/ecc_hinge/run_nb.sh
@@ -20,4 +20,4 @@ stderr_file="${dir_path}/run_nb_stderr.txt"
 nb_out="${dir_path}/${example_name}_out.ipynb"
 nb_in="${source_dir}/${example_name}.ipynb"
 
-papermill $nb_in $nb_out $train_info -k nightly_build 2> $stderr_file
+papermill $nb_in $nb_out $train_info $@ -k nightly_build 2> $stderr_file

--- a/test/apphub_scripts/adversarial_training/ecc_hinge/run_tf.sh
+++ b/test/apphub_scripts/adversarial_training/ecc_hinge/run_tf.sh
@@ -21,9 +21,9 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_tf_stderr.txt"
 py_file="${source_dir}/${example_name}_tf.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
     echo 'run test'
 fi

--- a/test/apphub_scripts/adversarial_training/ecc_hinge/run_torch.sh
+++ b/test/apphub_scripts/adversarial_training/ecc_hinge/run_torch.sh
@@ -20,8 +20,8 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_torch_stderr.txt"
 py_file="${source_dir}/${example_name}_torch.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
 fi

--- a/test/apphub_scripts/adversarial_training/fgsm/run_nb.sh
+++ b/test/apphub_scripts/adversarial_training/fgsm/run_nb.sh
@@ -20,4 +20,4 @@ stderr_file="${dir_path}/run_nb_stderr.txt"
 nb_out="${dir_path}/${example_name}_out.ipynb"
 nb_in="${source_dir}/${example_name}.ipynb"
 
-papermill $nb_in $nb_out $train_info -k nightly_build 2> $stderr_file
+papermill $nb_in $nb_out $train_info $@ -k nightly_build 2> $stderr_file

--- a/test/apphub_scripts/adversarial_training/fgsm/run_tf.sh
+++ b/test/apphub_scripts/adversarial_training/fgsm/run_tf.sh
@@ -21,9 +21,9 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_tf_stderr.txt"
 py_file="${source_dir}/${example_name}_tf.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
     echo 'run test'
 fi

--- a/test/apphub_scripts/adversarial_training/fgsm/run_torch.sh
+++ b/test/apphub_scripts/adversarial_training/fgsm/run_torch.sh
@@ -20,8 +20,8 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_torch_stderr.txt"
 py_file="${source_dir}/${example_name}_torch.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
 fi

--- a/test/apphub_scripts/image_classification/cifar10_fast/run_nb.sh
+++ b/test/apphub_scripts/image_classification/cifar10_fast/run_nb.sh
@@ -20,4 +20,4 @@ stderr_file="${dir_path}/run_nb_stderr.txt"
 nb_out="${dir_path}/${example_name}_out.ipynb"
 nb_in="${source_dir}/${example_name}.ipynb"
 
-papermill $nb_in $nb_out $train_info -k nightly_build 2> $stderr_file
+papermill $nb_in $nb_out $train_info $@ -k nightly_build 2> $stderr_file

--- a/test/apphub_scripts/image_classification/cifar10_fast/run_tf.sh
+++ b/test/apphub_scripts/image_classification/cifar10_fast/run_tf.sh
@@ -21,9 +21,9 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_tf_stderr.txt"
 py_file="${source_dir}/${example_name}_tf.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
     echo 'run test'
 fi

--- a/test/apphub_scripts/image_classification/cifar10_fast/run_torch.sh
+++ b/test/apphub_scripts/image_classification/cifar10_fast/run_torch.sh
@@ -20,8 +20,8 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_torch_stderr.txt"
 py_file="${source_dir}/${example_name}_torch.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
 fi

--- a/test/apphub_scripts/image_classification/mnist/run_nb.sh
+++ b/test/apphub_scripts/image_classification/mnist/run_nb.sh
@@ -20,4 +20,4 @@ stderr_file="${dir_path}/run_nb_stderr.txt"
 nb_out="${dir_path}/${example_name}_out.ipynb"
 nb_in="${source_dir}/${example_name}.ipynb"
 
-papermill $nb_in $nb_out $train_info -k nightly_build 2> $stderr_file
+papermill $nb_in $nb_out $train_info $@ -k nightly_build 2> $stderr_file

--- a/test/apphub_scripts/image_classification/mnist/run_tf.sh
+++ b/test/apphub_scripts/image_classification/mnist/run_tf.sh
@@ -21,9 +21,9 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_tf_stderr.txt"
 py_file="${source_dir}/${example_name}_tf.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
     echo 'run test'
 fi

--- a/test/apphub_scripts/image_classification/mnist/run_torch.sh
+++ b/test/apphub_scripts/image_classification/mnist/run_torch.sh
@@ -20,8 +20,8 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_torch_stderr.txt"
 py_file="${source_dir}/${example_name}_torch.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
 fi

--- a/test/apphub_scripts/image_generation/cvae/run_nb.sh
+++ b/test/apphub_scripts/image_generation/cvae/run_nb.sh
@@ -20,4 +20,4 @@ stderr_file="${dir_path}/run_nb_stderr.txt"
 nb_out="${dir_path}/${example_name}_out.ipynb"
 nb_in="${source_dir}/${example_name}.ipynb"
 
-papermill $nb_in $nb_out $train_info -k nightly_build 2> $stderr_file
+papermill $nb_in $nb_out $train_info $@ -k nightly_build 2> $stderr_file

--- a/test/apphub_scripts/image_generation/cvae/run_tf.sh
+++ b/test/apphub_scripts/image_generation/cvae/run_tf.sh
@@ -21,9 +21,9 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_tf_stderr.txt"
 py_file="${source_dir}/${example_name}_tf.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
     echo 'run test'
 fi

--- a/test/apphub_scripts/image_generation/cvae/run_torch.sh
+++ b/test/apphub_scripts/image_generation/cvae/run_torch.sh
@@ -20,8 +20,8 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_torch_stderr.txt"
 py_file="${source_dir}/${example_name}_torch.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
 fi

--- a/test/apphub_scripts/image_generation/cyclegan/run_nb.sh
+++ b/test/apphub_scripts/image_generation/cyclegan/run_nb.sh
@@ -20,4 +20,4 @@ stderr_file="${dir_path}/run_nb_stderr.txt"
 nb_out="${dir_path}/${example_name}_out.ipynb"
 nb_in="${source_dir}/${example_name}.ipynb"
 
-papermill $nb_in $nb_out $train_info -k nightly_build 2> $stderr_file
+papermill $nb_in $nb_out $train_info $@ -k nightly_build 2> $stderr_file

--- a/test/apphub_scripts/image_generation/cyclegan/run_tf.sh
+++ b/test/apphub_scripts/image_generation/cyclegan/run_tf.sh
@@ -21,9 +21,9 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_tf_stderr.txt"
 py_file="${source_dir}/${example_name}_tf.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
     echo 'run test'
 fi

--- a/test/apphub_scripts/image_generation/cyclegan/run_torch.sh
+++ b/test/apphub_scripts/image_generation/cyclegan/run_torch.sh
@@ -20,8 +20,8 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_torch_stderr.txt"
 py_file="${source_dir}/${example_name}_torch.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
 fi

--- a/test/apphub_scripts/image_generation/dcgan/run_nb.sh
+++ b/test/apphub_scripts/image_generation/dcgan/run_nb.sh
@@ -20,4 +20,4 @@ stderr_file="${dir_path}/run_nb_stderr.txt"
 nb_out="${dir_path}/${example_name}_out.ipynb"
 nb_in="${source_dir}/${example_name}.ipynb"
 
-papermill $nb_in $nb_out $train_info -k nightly_build 2> $stderr_file
+papermill $nb_in $nb_out $train_info $@ -k nightly_build 2> $stderr_file

--- a/test/apphub_scripts/image_generation/dcgan/run_tf.sh
+++ b/test/apphub_scripts/image_generation/dcgan/run_tf.sh
@@ -21,9 +21,9 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_tf_stderr.txt"
 py_file="${source_dir}/${example_name}_tf.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
     echo 'run test'
 fi

--- a/test/apphub_scripts/image_generation/dcgan/run_torch.sh
+++ b/test/apphub_scripts/image_generation/dcgan/run_torch.sh
@@ -20,8 +20,8 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_torch_stderr.txt"
 py_file="${source_dir}/${example_name}_torch.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
 fi

--- a/test/apphub_scripts/image_generation/pggan/run_nb.sh
+++ b/test/apphub_scripts/image_generation/pggan/run_nb.sh
@@ -20,4 +20,4 @@ stderr_file="${dir_path}/run_nb_stderr.txt"
 nb_out="${dir_path}/${example_name}_out.ipynb"
 nb_in="${source_dir}/${example_name}.ipynb"
 
-papermill $nb_in $nb_out $train_info -k nightly_build 2> $stderr_file
+papermill $nb_in $nb_out $train_info $@ -k nightly_build 2> $stderr_file

--- a/test/apphub_scripts/image_generation/pggan/run_tf.sh
+++ b/test/apphub_scripts/image_generation/pggan/run_tf.sh
@@ -21,9 +21,9 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_tf_stderr.txt"
 py_file="${source_dir}/${example_name}_tf.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
     echo 'run test'
 fi

--- a/test/apphub_scripts/image_generation/pggan/run_torch.sh
+++ b/test/apphub_scripts/image_generation/pggan/run_torch.sh
@@ -20,8 +20,8 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_torch_stderr.txt"
 py_file="${source_dir}/${example_name}_torch.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
 fi

--- a/test/apphub_scripts/instance_detection/retinanet/run_nb.sh
+++ b/test/apphub_scripts/instance_detection/retinanet/run_nb.sh
@@ -21,4 +21,4 @@ stderr_file="${dir_path}/run_nb_stderr.txt"
 nb_out="${dir_path}/${example_name}_out.ipynb"
 nb_in="${source_dir}/${example_name}.ipynb"
 
-papermill $nb_in $nb_out $train_info -k nightly_build 2> $stderr_file
+papermill $nb_in $nb_out $train_info $@ -k nightly_build 2> $stderr_file

--- a/test/apphub_scripts/instance_detection/retinanet/run_tf.sh
+++ b/test/apphub_scripts/instance_detection/retinanet/run_tf.sh
@@ -21,9 +21,9 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_tf_stderr.txt"
 py_file="${source_dir}/${example_name}_tf.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
     echo 'run test'
 fi

--- a/test/apphub_scripts/instance_detection/retinanet/run_torch.sh
+++ b/test/apphub_scripts/instance_detection/retinanet/run_torch.sh
@@ -20,8 +20,8 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_torch_stderr.txt"
 py_file="${source_dir}/${example_name}_torch.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
 fi

--- a/test/apphub_scripts/multi_task_learning/uncertainty_weighted_loss/run_nb.sh
+++ b/test/apphub_scripts/multi_task_learning/uncertainty_weighted_loss/run_nb.sh
@@ -20,4 +20,4 @@ stderr_file="${dir_path}/run_nb_stderr.txt"
 nb_out="${dir_path}/${example_name}_out.ipynb"
 nb_in="${source_dir}/${example_name}.ipynb"
 
-papermill $nb_in $nb_out $train_info -k nightly_build 2> $stderr_file
+papermill $nb_in $nb_out $train_info $@ -k nightly_build 2> $stderr_file

--- a/test/apphub_scripts/multi_task_learning/uncertainty_weighted_loss/run_tf.sh
+++ b/test/apphub_scripts/multi_task_learning/uncertainty_weighted_loss/run_tf.sh
@@ -21,9 +21,9 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_tf_stderr.txt"
 py_file="${source_dir}/${example_name}_tf.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
     echo 'run test'
 fi

--- a/test/apphub_scripts/multi_task_learning/uncertainty_weighted_loss/run_torch.sh
+++ b/test/apphub_scripts/multi_task_learning/uncertainty_weighted_loss/run_torch.sh
@@ -20,8 +20,8 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_torch_stderr.txt"
 py_file="${source_dir}/${example_name}_torch.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
 fi

--- a/test/apphub_scripts/one_shot_learning/siamese_network/run_nb.sh
+++ b/test/apphub_scripts/one_shot_learning/siamese_network/run_nb.sh
@@ -20,4 +20,4 @@ stderr_file="${dir_path}/run_nb_stderr.txt"
 nb_out="${dir_path}/${example_name}_out.ipynb"
 nb_in="${source_dir}/${example_name}.ipynb"
 
-papermill $nb_in $nb_out $train_info -k nightly_build 2> $stderr_file
+papermill $nb_in $nb_out $train_info $@ -k nightly_build 2> $stderr_file

--- a/test/apphub_scripts/one_shot_learning/siamese_network/run_tf.sh
+++ b/test/apphub_scripts/one_shot_learning/siamese_network/run_tf.sh
@@ -21,9 +21,9 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_tf_stderr.txt"
 py_file="${source_dir}/${example_name}_tf.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
     echo 'run test'
 fi

--- a/test/apphub_scripts/one_shot_learning/siamese_network/run_torch.sh
+++ b/test/apphub_scripts/one_shot_learning/siamese_network/run_torch.sh
@@ -20,8 +20,8 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_torch_stderr.txt"
 py_file="${source_dir}/${example_name}_torch.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
 fi

--- a/test/apphub_scripts/semantic_segmentation/unet/run_nb.sh
+++ b/test/apphub_scripts/semantic_segmentation/unet/run_nb.sh
@@ -20,4 +20,4 @@ stderr_file="${dir_path}/run_nb_stderr.txt"
 nb_out="${dir_path}/${example_name}_out.ipynb"
 nb_in="${source_dir}/${example_name}.ipynb"
 
-papermill $nb_in $nb_out $train_info -k nightly_build 2> $stderr_file
+papermill $nb_in $nb_out $train_info $@ -k nightly_build 2> $stderr_file

--- a/test/apphub_scripts/semantic_segmentation/unet/run_tf.sh
+++ b/test/apphub_scripts/semantic_segmentation/unet/run_tf.sh
@@ -21,9 +21,9 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_tf_stderr.txt"
 py_file="${source_dir}/${example_name}_tf.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
     echo 'run test'
 fi

--- a/test/apphub_scripts/semantic_segmentation/unet/run_torch.sh
+++ b/test/apphub_scripts/semantic_segmentation/unet/run_torch.sh
@@ -20,8 +20,8 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_torch_stderr.txt"
 py_file="${source_dir}/${example_name}_torch.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
 fi

--- a/test/apphub_scripts/style_transfer/fst_coco/run_nb.sh
+++ b/test/apphub_scripts/style_transfer/fst_coco/run_nb.sh
@@ -22,4 +22,4 @@ stderr_file="${dir_path}/run_nb_stderr.txt"
 nb_out="${dir_path}/${example_name}_out.ipynb"
 nb_in="${source_dir}/${example_name}.ipynb"
 
-papermill $nb_in $nb_out $train_info -k nightly_build 2> $stderr_file
+papermill $nb_in $nb_out $train_info $@ -k nightly_build 2> $stderr_file

--- a/test/apphub_scripts/style_transfer/fst_coco/run_tf.sh
+++ b/test/apphub_scripts/style_transfer/fst_coco/run_tf.sh
@@ -21,9 +21,9 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_tf_stderr.txt"
 py_file="${source_dir}/${example_name}_tf.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
     echo 'run test'
 fi

--- a/test/apphub_scripts/style_transfer/fst_coco/run_torch.sh
+++ b/test/apphub_scripts/style_transfer/fst_coco/run_torch.sh
@@ -20,8 +20,8 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_torch_stderr.txt"
 py_file="${source_dir}/${example_name}_torch.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
 fi

--- a/test/apphub_scripts/tabular/dnn/run_nb.sh
+++ b/test/apphub_scripts/tabular/dnn/run_nb.sh
@@ -20,4 +20,4 @@ stderr_file="${dir_path}/run_nb_stderr.txt"
 nb_out="${dir_path}/${example_name}_out.ipynb"
 nb_in="${source_dir}/${example_name}.ipynb"
 
-papermill $nb_in $nb_out $train_info -k nightly_build 2> $stderr_file
+papermill $nb_in $nb_out $train_info $@ -k nightly_build 2> $stderr_file

--- a/test/apphub_scripts/tabular/dnn/run_tf.sh
+++ b/test/apphub_scripts/tabular/dnn/run_tf.sh
@@ -21,9 +21,9 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_tf_stderr.txt"
 py_file="${source_dir}/${example_name}_tf.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
     echo 'run test'
 fi

--- a/test/apphub_scripts/tabular/dnn/run_torch.sh
+++ b/test/apphub_scripts/tabular/dnn/run_torch.sh
@@ -20,8 +20,8 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_torch_stderr.txt"
 py_file="${source_dir}/${example_name}_torch.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
 fi

--- a/test/apphub_scripts/template/run_nb.sh
+++ b/test/apphub_scripts/template/run_nb.sh
@@ -20,4 +20,4 @@ stderr_file="${dir_path}/run_nb_stderr.txt"
 nb_out="${dir_path}/${example_name}_out.ipynb"
 nb_in="${source_dir}/${example_name}.ipynb"
 
-papermill $nb_in $nb_out $train_info -k nightly_build 2> $stderr_file
+papermill $nb_in $nb_out $train_info $@ -k nightly_build 2> $stderr_file

--- a/test/apphub_scripts/template/run_tf.sh
+++ b/test/apphub_scripts/template/run_tf.sh
@@ -21,9 +21,9 @@ source_dir="${dir_path/'test/apphub_scripts'/'apphub'}"
 stderr_file="${dir_path}/run_tf_stderr.txt"
 py_file="${source_dir}/${example_name}_tf.py"
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
     echo 'run test'
 fi

--- a/test/apphub_scripts/template/run_torch.sh
+++ b/test/apphub_scripts/template/run_torch.sh
@@ -24,8 +24,8 @@ py_file="${source_dir}/${example_name}_torch.py"
 echo $py_file
 
 
-fastestimator train $py_file $train_info 2> $stderr_file
+fastestimator train $py_file $train_info $@ 2> $stderr_file
 
 if [ $need_test -eq 1 ]; then
-    fastestimator test $py_file $train_info 2>> $stderr_file
+    fastestimator test $py_file $train_info $@ 2>> $stderr_file
 fi


### PR DESCRIPTION
1. pass shell argument to its invoking subcommand. It allows users to feed new training argument or change argument without change bash script
2. the arguments are directly passed to its sub-comand so it still needs to follow the parameter syntax (run_nb.sh is different than run_tf.sh and run_torch.sh)

  ex1 :   update argument 
  bash test/apphub_scripts/image_classification/mnist/run_tf.sh --epochs 5    <---  use  --epochs 5
  bash test/apphub_scripts/image_classification/mnist/run_torch.sh -p epochs 5    <---  use  -p epochs 5
  ex2 :   add argument
  bash test/apphub_scripts/one_shot_learning/siamese_network/run_tf.sh --data_dir /data    <---  use  --data_dir /data
  bash test/apphub_scripts/one_shot_learning/siamese_network/run_torch.sh  -p data_dir /data  <---  use  -p data_dir /data 
 