### PR TITLE
upgraded backend to tf 2.3.0 and torch 1.6.0, updated tests

### DIFF
--- a/CICD/PR_test/Jenkinsfile
+++ b/CICD/PR_test/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
         stage('PR-test') {
             steps {
                 script {
-                    def customImage = docker.build("$IMAGE_TAG", "--no-cache --build-arg InstallFE=False -f docker/nightly/Dockerfile.cpu .")
+                    def customImage = docker.build("$IMAGE_TAG", "--no-cache --build-arg InstallFE=False - < docker/nightly/Dockerfile.cpu")
                     try {
                         customImage.inside('-u root') {
                             sh 'pip install --no-cache-dir .'

--- a/CICD/PR_test/Jenkinsfile
+++ b/CICD/PR_test/Jenkinsfile
@@ -12,7 +12,7 @@ pipeline {
         stage('PR-test') {
             steps {
                 script {
-                    def customImage = docker.build("$IMAGE_TAG", "--no-cache - < docker/nightly/Dockerfile.cpu")
+                    def customImage = docker.build("$IMAGE_TAG", "--no-cache --build-arg InstallFE=False -f docker/nightly/Dockerfile.cpu .")
                     try {
                         customImage.inside('-u root') {
                             sh 'pip install --no-cache-dir .'

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ FastEstimator is a high-level deep learning library built on TensorFlow2 and PyT
 ### 1. Install Dependencies:
 
 * Install TensorFlow [here](https://www.tensorflow.org/install)
-* Install PyTorch [here](https://pytorch.org/get-started/locally/) (for GPU users, choose CUDA 10.1)
+* Install PyTorch [here](https://pytorch.org/get-started/locally/) (for GPU users, **choose CUDA 10.1**)
 
 * Extra Dependencies:
 

--- a/README.md
+++ b/README.md
@@ -11,23 +11,27 @@ FastEstimator is a high-level deep learning library built on TensorFlow2 and PyT
 
 ## Installation:
 ### 1. Install Dependencies:
-* Windows (CPU):
-    ``` bash
-    $ pip install torch==1.4.0+cpu torchvision==0.5.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
-    ```
-    * Install Visual C++ 2015 build tools [here](https://go.microsoft.com/fwlink/?LinkId=691126) and install default option.
 
-    * Install latest Visual C++ redistributable [here](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads) and choose x86 for 32 bit OS, x64 for 64 bit OS.
+* Install TensorFlow 2.3.0 from intruction [here](https://www.tensorflow.org/install)
+* Install PyTorch 1.6.0 from intruction [here](https://pytorch.org/get-started/locally/) (for GPU users, choose CUDA 10.1)
 
-* Linux (CPU/GPU):
-    ``` bash
-    $ apt-get install libglib2.0-0 libsm6 libxrender1 libxext6
-    ```
+* Extra Dependencies:
 
-* Mac (CPU):
-    ``` bash
-    $ echo No dependency needed ":)"
-    ```
+    * Windows:
+
+        * Install Visual C++ 2015 build tools [here](https://go.microsoft.com/fwlink/?LinkId=691126) and install default option.
+
+        * Install latest Visual C++ redistributable [here](https://support.microsoft.com/en-us/help/2977003/the-latest-supported-visual-c-downloads) and choose x86 for 32 bit OS, x64 for 64 bit OS.
+
+    * Linux:
+        ``` bash
+        $ apt-get install libglib2.0-0 libsm6 libxrender1 libxext6
+        ```
+
+    * Mac:
+        ``` bash
+        $ echo No extra dependency needed ":)"
+        ```
 
 ### 2. Install FastEstimator:
 * Stable (Linux/Mac):

--- a/README.md
+++ b/README.md
@@ -8,12 +8,14 @@ FastEstimator is a high-level deep learning library built on TensorFlow2 and PyT
 
 ## Prerequisites:
 * Python >= 3.6
+* TensorFlow >= 2.3.0
+* PyTorch >= 1.6.0
 
 ## Installation:
 ### 1. Install Dependencies:
 
-* Install TensorFlow 2.3.0 [here](https://www.tensorflow.org/install)
-* Install PyTorch 1.6.0 [here](https://pytorch.org/get-started/locally/) (for GPU users, choose CUDA 10.1)
+* Install TensorFlow [here](https://www.tensorflow.org/install)
+* Install PyTorch [here](https://pytorch.org/get-started/locally/) (for GPU users, choose CUDA 10.1)
 
 * Extra Dependencies:
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ FastEstimator is a high-level deep learning library built on TensorFlow2 and PyT
 ## Installation:
 ### 1. Install Dependencies:
 
-* Install TensorFlow 2.3.0 from intruction [here](https://www.tensorflow.org/install)
-* Install PyTorch 1.6.0 from intruction [here](https://pytorch.org/get-started/locally/) (for GPU users, choose CUDA 10.1)
+* Install TensorFlow 2.3.0 [here](https://www.tensorflow.org/install)
+* Install PyTorch 1.6.0 [here](https://pytorch.org/get-started/locally/) (for GPU users, choose CUDA 10.1)
 
 * Extra Dependencies:
 

--- a/docker/nightly/Dockerfile.cpu
+++ b/docker/nightly/Dockerfile.cpu
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:2.1.0-py3
+FROM tensorflow/tensorflow:2.3.0
 
 RUN apt-get update
 
@@ -17,18 +17,21 @@ RUN apt-get install -y \
     texlive-latex-base \
     texlive-latex-extra
 
-# GPU cleaning requirement
-RUN apt-get install -y \
-    lsof
-
 # upgrade essential packages
 RUN pip install --upgrade pip setuptools
 
+# nightly test related packages
 RUN pip install --no-cache-dir \
     ipython \
     ipykernel \
     ipywidgets \
     papermill
+RUN ipython kernel install --user --name nightly_build
+
+# GPU cleaning requirement
+RUN apt-get install -y lsof
+
+# backend dependencies
+RUN pip install torch==1.6.0+cpu torchvision==0.7.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
 
 RUN pip install git+https://github.com/fastestimator/fastestimator.git
-RUN ipython kernel install --user --name nightly_build

--- a/docker/nightly/Dockerfile.cpu
+++ b/docker/nightly/Dockerfile.cpu
@@ -34,4 +34,6 @@ RUN apt-get install -y lsof
 # backend dependencies
 RUN pip install torch==1.6.0+cpu torchvision==0.7.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
 
-RUN pip install git+https://github.com/fastestimator/fastestimator.git
+# install FastEstimator
+ARG InstallFE=True
+RUN if [ $InstallFE = "True" ]; then pip install git+https://github.com/fastestimator/fastestimator.git; fi

--- a/docker/nightly/Dockerfile.gpu
+++ b/docker/nightly/Dockerfile.gpu
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:2.1.0-gpu-py3
+FROM tensorflow/tensorflow:2.3.0-gpu
 
 RUN apt-get update
 
@@ -17,18 +17,21 @@ RUN apt-get install -y \
     texlive-latex-base \
     texlive-latex-extra
 
-# GPU cleaning requirement
-RUN apt-get install -y \
-    lsof
-    
 # upgrade essential packages
 RUN pip install --upgrade pip setuptools
 
+# nightly test related packages
 RUN pip install --no-cache-dir \
     ipython \
     ipykernel \
     ipywidgets \
     papermill
+RUN ipython kernel install --user --name nightly_build
+
+# GPU cleaning requirement
+RUN apt-get install -y lsof
+
+# backend dependencies
+RUN pip install torch==1.6.0+cu101 torchvision==0.7.0+cu101 -f https://download.pytorch.org/whl/torch_stable.html
 
 RUN pip install git+https://github.com/fastestimator/fastestimator.git
-RUN ipython kernel install --user --name nightly_build

--- a/docker/nightly/Dockerfile.gpu
+++ b/docker/nightly/Dockerfile.gpu
@@ -34,4 +34,6 @@ RUN apt-get install -y lsof
 # backend dependencies
 RUN pip install torch==1.6.0+cu101 torchvision==0.7.0+cu101 -f https://download.pytorch.org/whl/torch_stable.html
 
-RUN pip install git+https://github.com/fastestimator/fastestimator.git
+# install FastEstimator
+ARG InstallFE=True
+RUN if [ $InstallFE = "True" ]; then pip install git+https://github.com/fastestimator/fastestimator.git; fi

--- a/docker/stable/Dockerfile.cpu
+++ b/docker/stable/Dockerfile.cpu
@@ -34,5 +34,6 @@ RUN apt-get install -y lsof
 # backend dependencies
 RUN pip install torch==1.6.0+cpu torchvision==0.7.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
 
-# install fastestimator
-RUN pip install fastestimator
+# install FastEstimator
+ARG InstallFE=True
+RUN if [ $InstallFE = "True" ]; then pip install fastestimator; fi

--- a/docker/stable/Dockerfile.cpu
+++ b/docker/stable/Dockerfile.cpu
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:2.1.0-py3
+FROM tensorflow/tensorflow:2.3.0
 
 RUN apt-get update
 
@@ -20,10 +20,19 @@ RUN apt-get install -y \
 # upgrade essential packages
 RUN pip install --upgrade pip setuptools
 
+# nightly test related packages
 RUN pip install --no-cache-dir \
     ipython \
     ipykernel \
     ipywidgets \
     papermill
+RUN ipython kernel install --user --name nightly_build
 
+# GPU cleaning requirement
+RUN apt-get install -y lsof
+
+# backend dependencies
+RUN pip install torch==1.6.0+cpu torchvision==0.7.0+cpu -f https://download.pytorch.org/whl/torch_stable.html
+
+# install fastestimator
 RUN pip install fastestimator

--- a/docker/stable/Dockerfile.gpu
+++ b/docker/stable/Dockerfile.gpu
@@ -34,5 +34,6 @@ RUN apt-get install -y lsof
 # backend dependencies
 RUN pip install torch==1.6.0+cu101 torchvision==0.7.0+cu101 -f https://download.pytorch.org/whl/torch_stable.html
 
-# install fastestimator
-RUN pip install fastestimator
+# install FastEstimator
+ARG InstallFE=True
+RUN if [ $InstallFE = "True" ]; then pip install fastestimator; fi

--- a/docker/stable/Dockerfile.gpu
+++ b/docker/stable/Dockerfile.gpu
@@ -1,4 +1,4 @@
-FROM tensorflow/tensorflow:2.1.0-gpu-py3
+FROM tensorflow/tensorflow:2.3.0-gpu
 
 RUN apt-get update
 
@@ -20,10 +20,19 @@ RUN apt-get install -y \
 # upgrade essential packages
 RUN pip install --upgrade pip setuptools
 
+# nightly test related packages
 RUN pip install --no-cache-dir \
     ipython \
     ipykernel \
     ipywidgets \
     papermill
+RUN ipython kernel install --user --name nightly_build
 
+# GPU cleaning requirement
+RUN apt-get install -y lsof
+
+# backend dependencies
+RUN pip install torch==1.6.0+cu101 torchvision==0.7.0+cu101 -f https://download.pytorch.org/whl/torch_stable.html
+
+# install fastestimator
 RUN pip install fastestimator

--- a/setup.py
+++ b/setup.py
@@ -51,9 +51,8 @@ def get_dependency():
         'scipy==1.4.1',
         'PyLaTeX==1.3.2',
         'natsort==7.0.1',
-        'tensorflow_probability==0.8.0',
-        'transformers==2.4.1',
-        'tensorflow==2.1.0',
+        'tensorflow_probability==0.11.0',
+        'transformers==3.1.0',
         'pytorch-model-summary==0.1.2',
         'graphviz==0.14.1',
         'hiddenlayer==0.3',
@@ -67,8 +66,6 @@ def get_dependency():
             "pycocotools @ git+https://github.com/philferriere/cocoapi.git#egg=pycocotools&subdirectory=PythonAPI")
     else:
         dependencies.append('pycocotools-fix')
-        dependencies.append('torch==1.4.0')
-        dependencies.append('torchvision==0.5.0')
     return dependencies
 
 

--- a/test/PR_test/integration_test/op/tensorop/test_un_hadamard.py
+++ b/test/PR_test/integration_test/op/tensorop/test_un_hadamard.py
@@ -42,9 +42,11 @@ class TestUnHadamard(unittest.TestCase):
         output = fromhadamard.forward(
             data=[
                 torch.tensor([[1., -1., -1., 1.], [-1., 1., -1., -1.], [-1., 1., -1., -1.], [-1., 1., -1., -1.],
-                              [-1., 1., 1., 1.]])
+                              [-1., 1., 1., 1.]]).to("cuda:0" if torch.cuda.is_available() else "cpu")
             ],
             state={})[0]
+        if torch.cuda.is_available():
+            output = output.to("cpu")
         output = np.argmax(output, axis=-1)
         self.assertTrue(is_equal(output, torch.tensor([3, 2, 2, 2, 0])))
 
@@ -57,8 +59,11 @@ class TestUnHadamard(unittest.TestCase):
                                1.], [1., -1., 1., -1., 1., -1., 1., -1., 1., -1., 1., -1., 1., -1., 1.,
                                      -1.], [1., -1., 1., -1., 1., -1., 1., -1., -1., 1., -1., 1., -1., 1., -1.,
                                             1.], [-1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
-                              [-1., 1., 1., 1., -1., -1., -1., -1., 1., 1., 1., 1., -1., -1., -1., -1.]])
+                              [-1., 1., 1., 1., -1., -1., -1., -1., 1., 1., 1., 1., -1., -1., -1.,
+                               -1.]]).to("cuda:0" if torch.cuda.is_available() else "cpu")
             ],
             state={})[0]
+        if torch.cuda.is_available():
+            output = output.to("cpu")
         output = np.argmax(output, axis=-1)
         self.assertTrue(is_equal(output, torch.tensor([0, 1, 9, 0, 4])))

--- a/test/PR_test/unit_test/backend/test_iwd.py
+++ b/test/PR_test/unit_test/backend/test_iwd.py
@@ -111,9 +111,11 @@ class TestIWD(unittest.TestCase):
         self.assertTrue(np.allclose(b, target))
 
     def test_torch_input(self):
-        n = torch.tensor([[0.5] * 5, [0] + [1] * 4])
+        n = torch.tensor([[0.5] * 5, [0] + [1] * 4]).to("cuda:0" if torch.cuda.is_available() else "cpu")
         target = torch.tensor([[0.2, 0.2, 0.2, 0.2, 0.2], [0.95, 0.0125, 0.0125, 0.0125, 0.0125]])
         b = fe.backend.iwd(n)
+        if torch.cuda.is_available():
+            b = b.to("cpu")
         self.assertTrue(np.allclose(b, target))
 
     def test_torch_input_eps(self):


### PR DESCRIPTION
From now on, we will ask users to install tensorflow and pytorch as dependency before installing fastestimator.
