### PR TITLE
first pass at defer functionality

### DIFF
--- a/fastestimator/backend/update_model.py
+++ b/fastestimator/backend/update_model.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Optional, Union
+from typing import Callable, Dict, List, Optional, Union
 
 import tensorflow as tf
 import torch
@@ -25,7 +25,9 @@ from fastestimator.backend.reduce_mean import reduce_mean
 def update_model(model: Union[tf.keras.Model, torch.nn.Module],
                  loss: Union[tf.Tensor, torch.Tensor],
                  tape: Optional[tf.GradientTape] = None,
-                 retain_graph: bool = True):
+                 retain_graph: bool = True,
+                 defer: bool = False,
+                 deferred: Optional[Dict[str, List[Callable[[], None]]]] = None) -> None:
     """Update `model` weights based on a given `loss`.
 
     This method can be used with TensorFlow models:
@@ -54,9 +56,14 @@ def update_model(model: Union[tf.keras.Model, torch.nn.Module],
         loss: A loss value to compute gradients from.
         tape: A TensorFlow GradientTape which was recording when the `loss` was computed (iff using TensorFlow).
         retain_graph: Whether to keep the model graph in memory (applicable only for PyTorch).
+        defer: If True, then the model update function will be stored into the `deferred` dictionary rather than
+            applied immediately.
+        deferred: A dictionary in which model update functions are stored.
 
     Raises:
         ValueError: If `model` is an unacceptable data type.
+        RuntimeError: If attempting to modify a PyTorch model which relied on gradients within a different PyTorch model
+            which has in turn already undergone a non-deferred update.
     """
     loss = reduce_mean(loss)
     if isinstance(model, tf.keras.Model):
@@ -72,12 +79,39 @@ def update_model(model: Union[tf.keras.Model, torch.nn.Module],
             # scale down gradient to balance scale-up loss
             if isinstance(model.current_optimizer, mixed_precision.LossScaleOptimizer):
                 gradients = model.current_optimizer.get_unscaled_gradients(gradients)
-            model.current_optimizer.apply_gradients(zip(gradients, model.trainable_variables))
+            if defer:
+                deferred.setdefault(model.model_name, []).append(
+                    lambda: model.current_optimizer.apply_gradients(zip(gradients, model.trainable_variables)))
+            else:
+                model.current_optimizer.apply_gradients(zip(gradients, model.trainable_variables))
     elif isinstance(model, torch.nn.Module):
         trainable_params = [p for p in model.parameters() if p.requires_grad]
-        gradients = get_gradient(loss, trainable_params, retain_graph=retain_graph)
+        try:
+            gradients = get_gradient(loss, trainable_params, retain_graph=retain_graph)
+        except RuntimeError as err:
+            if err.args and isinstance(err.args[0], str) and err.args[0].startswith(
+                    'one of the variables needed for gradient computation has been modified by an inplace operation'):
+                raise RuntimeError(
+                    "When computing gradients for '{}', some variables it relied on during the forward pass had already"
+                    " been updated. Consider setting defer=True in earlier UpdateOps related to models which interact "
+                    "with this one.".format(model.model_name))
+            raise err
         for gradient, parameter in zip(gradients, trainable_params):
-            parameter.grad = gradient
-        model.current_optimizer.step()
+            if parameter.grad is not None:
+                parameter.grad += gradient
+            else:
+                parameter.grad = gradient.clone()
+        if defer:
+            # Only need to call once per model since gradients are getting accumulated
+            deferred[model.model_name] = [lambda: _torch_step(model.current_optimizer)]
+        else:
+            model.current_optimizer.step()
+            model.current_optimizer.zero_grad()
+            deferred.pop(model.model_name, None)  # Don't need those deferred steps anymore
     else:
         raise ValueError("Unrecognized model instance {}".format(type(model)))
+
+
+def _torch_step(optimizer: torch.optim.Optimizer) -> None:
+    optimizer.step()
+    optimizer.zero_grad()

--- a/test/PR_test/integration_test/op/tensorop/model/test_updateop.py
+++ b/test/PR_test/integration_test/op/tensorop/model/test_updateop.py
@@ -1,7 +1,6 @@
 import unittest
 from copy import deepcopy
 
-import numpy as np
 import tensorflow as tf
 import torch
 
@@ -13,7 +12,7 @@ from fastestimator.test.unittest_util import MultiLayerTorchModel, is_equal, one
 class TestUpdateOp(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.state = {'mode': 'train', 'epoch': 1, 'warmup': False}
+        cls.state = {'mode': 'train', 'epoch': 1, 'warmup': False, "deferred": {}}
         cls.tf_input_data = tf.Variable([[2.0, 1.5, 1.0], [1.0, -1.0, -0.5]])
         cls.torch_input_data = torch.tensor([[1.0, 1.0, 1.0, -0.5], [0.5, 1.0, -1.0, -0.5]],
                                             dtype=torch.float32,
@@ -29,7 +28,7 @@ class TestUpdateOp(unittest.TestCase):
             self.state['tape'] = tape
             pred = fe.backend.feed_forward(model, self.tf_input_data)
             loss = fe.backend.mean_squared_error(y_pred=pred, y_true=self.tf_y)
-            output = op.forward(data=loss, state=self.state)
+            op.forward(data=loss, state=self.state)
         weights_after = model.layers[1].get_weights()
         self.assertFalse(is_equal(weights_before, weights_after))
 
@@ -39,6 +38,6 @@ class TestUpdateOp(unittest.TestCase):
         op = UpdateOp(model=model, loss_name='loss')
         pred = fe.backend.feed_forward(model, self.torch_input_data)
         loss = fe.backend.mean_squared_error(y_pred=pred, y_true=self.torch_y)
-        output = op.forward(data=loss, state=self.state)
+        op.forward(data=loss, state=self.state)
         weights_after = model.fc1.weight.data.numpy()
         self.assertFalse(is_equal(weights_before, weights_after))

--- a/test/PR_test/integration_test/test_network.py
+++ b/test/PR_test/integration_test/test_network.py
@@ -21,6 +21,7 @@ class UnknownCompiledModel:
     def __init__(self, model):
         self.model = model
         self.fe_compiled = True
+        self.model_name = 'unk'
 
 
 class SampleNumpyOp(NumpyOp):

--- a/test/PR_test/integration_test/trace/io/test_best_model_saver.py
+++ b/test/PR_test/integration_test/trace/io/test_best_model_saver.py
@@ -38,7 +38,7 @@ class TestBestModelSaver(unittest.TestCase):
         cls.tf_model = fe.build(model_fn=one_layer_tf_model, optimizer_fn='adam', model_name='tf')
         cls.torch_model = fe.build(model_fn=MultiLayerTorchModel, optimizer_fn='adam', model_name='torch')
         cls.data = Data({'loss': 0.5})
-        cls.state = {'mode': 'train', 'epoch': 1, 'warmup': False}
+        cls.state = {'mode': 'train', 'epoch': 1, 'warmup': False, 'deferred': {}}
         cls.tf_input_data = tf.Variable([[2.0, 1.5, 1.0], [1.0, -1.0, -0.5]])
         cls.tf_y = tf.constant([[-6], [1]])
         cls.torch_input_data = torch.tensor([[1.0, 1.0, 1.0, -0.5], [0.5, 1.0, -1.0, -0.5]], dtype=torch.float32)
@@ -50,7 +50,7 @@ class TestBestModelSaver(unittest.TestCase):
             self.state['tape'] = tape
             pred = fe.backend.feed_forward(self.tf_model, self.tf_input_data)
             loss = fe.backend.mean_squared_error(y_pred=pred, y_true=self.tf_y)
-            output = op.forward(data=loss, state=self.state)
+            op.forward(data=loss, state=self.state)
         bms = BestModelSaver(model=self.tf_model, save_dir=self.save_dir)
         bms.on_epoch_end(data=self.data)
         m2 = fe.build(model_fn=one_layer_model_without_weights, optimizer_fn='adam')
@@ -61,9 +61,9 @@ class TestBestModelSaver(unittest.TestCase):
         op = UpdateOp(model=self.torch_model, loss_name='loss')
         pred = fe.backend.feed_forward(self.torch_model, self.torch_input_data)
         loss = fe.backend.mean_squared_error(y_pred=pred, y_true=self.torch_y)
-        output = op.forward(data=loss, state=self.state)
+        op.forward(data=loss, state=self.state)
         bms = BestModelSaver(model=self.torch_model, save_dir=self.save_dir)
         bms.on_epoch_end(data=self.data)
         m2 = fe.build(model_fn=MultiLayerTorchModelWithoutWeights, optimizer_fn='adam')
-        fe.backend.load_model(m2, os.path.join(self.save_dir,'torch_best_loss.pt'))
+        fe.backend.load_model(m2, os.path.join(self.save_dir, 'torch_best_loss.pt'))
         self.assertTrue(is_equal(list(m2.parameters()), list(self.torch_model.parameters())))

--- a/test/PR_test/unit_test/op/tensorop/meta/test_fuse.py
+++ b/test/PR_test/unit_test/op/tensorop/meta/test_fuse.py
@@ -22,7 +22,7 @@ class TestFuse(unittest.TestCase):
             self.assertListEqual(fuse.outputs, ['y', 'w'])
         with self.subTest('Check op mode'):
             self.assertSetEqual(fuse.mode, {'test'})
-        output = fuse.forward(data=self.multi_input_tf, state={"mode": "test"})
+        output = fuse.forward(data=self.multi_input_tf, state={"mode": "test", "deferred": {}})
         with self.subTest('Check output type'):
             self.assertEqual(type(output), list)
         with self.subTest('Check output image shape'):
@@ -39,7 +39,7 @@ class TestFuse(unittest.TestCase):
             self.assertListEqual(fuse.outputs, ['y', 'w'])
         with self.subTest('Check op mode'):
             self.assertSetEqual(fuse.mode, {'test'})
-        output = fuse.forward(data=self.multi_input_tf, state={"mode": "test"})
+        output = fuse.forward(data=self.multi_input_tf, state={"mode": "test", "deferred": {}})
         with self.subTest('Check output type'):
             self.assertEqual(type(output), list)
         with self.subTest('Check output image shape'):

--- a/test/PR_test/unit_test/op/tensorop/meta/test_repeat.py
+++ b/test/PR_test/unit_test/op/tensorop/meta/test_repeat.py
@@ -2,8 +2,8 @@ import unittest
 
 import tensorflow as tf
 
-from fastestimator.op.tensorop.meta import Repeat
 from fastestimator.op.tensorop import LambdaOp
+from fastestimator.op.tensorop.meta import Repeat
 
 
 class TestRepeat(unittest.TestCase):
@@ -17,7 +17,7 @@ class TestRepeat(unittest.TestCase):
             self.assertListEqual(repeat_op.outputs, ['x', 'y'])
         with self.subTest('Check op mode'):
             self.assertSetEqual(repeat_op.mode, {'eval'})
-        output = repeat_op.forward(data=[tf.ones([1])], state={"mode": "eval"})
+        output = repeat_op.forward(data=[tf.ones([1])], state={"deferred": {}, "mode": "eval"})
         with self.subTest('Check output type'):
             self.assertEqual(type(output), list)
         with self.subTest('Check output value (x)'):
@@ -35,7 +35,7 @@ class TestRepeat(unittest.TestCase):
             self.assertListEqual(repeat_op.outputs, ['x', 'y'])
         with self.subTest('Check op mode'):
             self.assertSetEqual(repeat_op.mode, {'eval'})
-        output = repeat_op.forward(data=[tf.ones([1])], state={"mode": "eval"})
+        output = repeat_op.forward(data=[tf.ones([1])], state={"deferred": {}, "mode": "eval"})
         with self.subTest('Check output type'):
             self.assertEqual(type(output), list)
         with self.subTest('Check output value (x)'):
@@ -53,7 +53,7 @@ class TestRepeat(unittest.TestCase):
             self.assertListEqual(repeat_op.outputs, ['x', 'y'])
         with self.subTest('Check op mode'):
             self.assertSetEqual(repeat_op.mode, {'eval'})
-        output = repeat_op.forward(data=[tf.ones([1])], state={"mode": "eval"})
+        output = repeat_op.forward(data=[tf.ones([1])], state={"deferred": {}, "mode": "eval"})
         with self.subTest('Check output type'):
             self.assertEqual(type(output), list)
         with self.subTest('Check output value (x)'):
@@ -71,7 +71,7 @@ class TestRepeat(unittest.TestCase):
             self.assertListEqual(repeat_op.outputs, ['x', 'y'])
         with self.subTest('Check op mode'):
             self.assertSetEqual(repeat_op.mode, {'eval'})
-        output = repeat_op.forward(data=[tf.ones([1])], state={"mode": "eval"})
+        output = repeat_op.forward(data=[tf.ones([1])], state={"deferred": {}, "mode": "eval"})
         with self.subTest('Check output type'):
             self.assertEqual(type(output), list)
         with self.subTest('Check output value (x)'):
@@ -89,7 +89,7 @@ class TestRepeat(unittest.TestCase):
             self.assertListEqual(repeat_op.outputs, ['x', 'y'])
         with self.subTest('Check op mode'):
             self.assertSetEqual(repeat_op.mode, {'eval'})
-        output = repeat_op.forward(data=[tf.ones([1]), 10 + tf.ones([1])], state={"mode": "eval"})
+        output = repeat_op.forward(data=[tf.ones([1]), 10 + tf.ones([1])], state={"deferred": {}, "mode": "eval"})
         with self.subTest('Check output type'):
             self.assertEqual(type(output), list)
         with self.subTest('Check output value (x)'):
@@ -108,7 +108,7 @@ class TestRepeat(unittest.TestCase):
         with self.subTest('Check op mode'):
             self.assertSetEqual(repeat_op.mode, {'eval'})
         x = [tf.ones([1])]
-        output = tf.function(lambda y: repeat_op.forward(data=y, state={"mode": "eval"}))
+        output = tf.function(lambda y: repeat_op.forward(data=y, state={"deferred": {}, "mode": "eval"}))
         output(x)  # build the graph
         output = output(x)
         with self.subTest('Check output type'):
@@ -129,7 +129,7 @@ class TestRepeat(unittest.TestCase):
         with self.subTest('Check op mode'):
             self.assertSetEqual(repeat_op.mode, {'eval'})
         x = [tf.ones([1])]
-        output = tf.function(lambda y: repeat_op.forward(data=y, state={"mode": "eval"}))
+        output = tf.function(lambda y: repeat_op.forward(data=y, state={"deferred": {}, "mode": "eval"}))
         output(x)  # build the graph
         output = output(x)
         with self.subTest('Check output type'):
@@ -150,7 +150,7 @@ class TestRepeat(unittest.TestCase):
         with self.subTest('Check op mode'):
             self.assertSetEqual(repeat_op.mode, {'eval'})
         x = [tf.ones([1])]
-        output = tf.function(lambda y: repeat_op.forward(data=y, state={"mode": "eval"}))
+        output = tf.function(lambda y: repeat_op.forward(data=y, state={"deferred": {}, "mode": "eval"}))
         output(x)  # build the graph
         output = output(x)
         with self.subTest('Check output type'):
@@ -171,7 +171,7 @@ class TestRepeat(unittest.TestCase):
         with self.subTest('Check op mode'):
             self.assertSetEqual(repeat_op.mode, {'eval'})
         x = [tf.ones([1])]
-        output = tf.function(lambda y: repeat_op.forward(data=y, state={"mode": "eval"}))
+        output = tf.function(lambda y: repeat_op.forward(data=y, state={"deferred": {}, "mode": "eval"}))
         output(x)
         output = output(x)
         with self.subTest('Check output type'):
@@ -192,7 +192,7 @@ class TestRepeat(unittest.TestCase):
         with self.subTest('Check op mode'):
             self.assertSetEqual(repeat_op.mode, {'eval'})
         x = [tf.ones([1]), 10 + tf.ones([1])]
-        output = tf.function(lambda y: repeat_op.forward(data=y, state={"mode": "eval"}))
+        output = tf.function(lambda y: repeat_op.forward(data=y, state={"deferred": {}, "mode": "eval"}))
         output(x)
         output = output(x)
         with self.subTest('Check output type'):
@@ -212,7 +212,7 @@ class TestRepeat(unittest.TestCase):
             self.assertListEqual(repeat_op.outputs, ['x', 'y'])
         with self.subTest('Check op mode'):
             self.assertSetEqual(repeat_op.mode, {'eval'})
-        output = repeat_op.forward(data=[tf.ones([1])], state={"mode": "eval"})
+        output = repeat_op.forward(data=[tf.ones([1])], state={"deferred": {}, "mode": "eval"})
         with self.subTest('Check output type'):
             self.assertEqual(type(output), list)
         with self.subTest('Check output value (x)'):
@@ -230,7 +230,7 @@ class TestRepeat(unittest.TestCase):
             self.assertListEqual(repeat_op.outputs, ['x', 'y'])
         with self.subTest('Check op mode'):
             self.assertSetEqual(repeat_op.mode, {'eval'})
-        output = repeat_op.forward(data=[tf.ones([1])], state={"mode": "eval"})
+        output = repeat_op.forward(data=[tf.ones([1])], state={"deferred": {}, "mode": "eval"})
         with self.subTest('Check output type'):
             self.assertEqual(type(output), list)
         with self.subTest('Check output value (x)'):
@@ -248,7 +248,7 @@ class TestRepeat(unittest.TestCase):
             self.assertListEqual(repeat_op.outputs, ['x', 'y'])
         with self.subTest('Check op mode'):
             self.assertSetEqual(repeat_op.mode, {'eval'})
-        output = repeat_op.forward(data=[tf.ones([1])], state={"mode": "eval"})
+        output = repeat_op.forward(data=[tf.ones([1])], state={"deferred": {}, "mode": "eval"})
         with self.subTest('Check output type'):
             self.assertEqual(type(output), list)
         with self.subTest('Check output value (x)'):
@@ -266,7 +266,7 @@ class TestRepeat(unittest.TestCase):
             self.assertListEqual(repeat_op.outputs, ['x', 'y'])
         with self.subTest('Check op mode'):
             self.assertSetEqual(repeat_op.mode, {'eval'})
-        output = repeat_op.forward(data=[tf.ones([1])], state={"mode": "eval"})
+        output = repeat_op.forward(data=[tf.ones([1])], state={"deferred": {}, "mode": "eval"})
         with self.subTest('Check output type'):
             self.assertEqual(type(output), list)
         with self.subTest('Check output value (x)'):
@@ -284,7 +284,7 @@ class TestRepeat(unittest.TestCase):
             self.assertListEqual(repeat_op.outputs, ['x', 'y'])
         with self.subTest('Check op mode'):
             self.assertSetEqual(repeat_op.mode, {'eval'})
-        output = repeat_op.forward(data=[tf.ones([1]), 10 + tf.ones([1])], state={"mode": "eval"})
+        output = repeat_op.forward(data=[tf.ones([1]), 10 + tf.ones([1])], state={"deferred": {}, "mode": "eval"})
         with self.subTest('Check output type'):
             self.assertEqual(type(output), list)
         with self.subTest('Check output value (x)'):


### PR DESCRIPTION
PyTorch 1.5+ requires that gradient steps be applied in a deferred manner when training GANs and other multi-model interactions. 