### PR TITLE
Monitor Names

### DIFF
--- a/fastestimator/trace/adapt/early_stopping.py
+++ b/fastestimator/trace/adapt/early_stopping.py
@@ -56,6 +56,7 @@ class EarlyStopping(Trace):
             raise ValueError("compare_mode can only be `min` or `max`")
 
         self.monitored_key = monitor
+        self.fe_monitor_names.add(monitor)
         self.min_delta = abs(min_delta)
         self.wait = 0
         self.best = 0

--- a/fastestimator/trace/adapt/reduce_lr_on_plateau.py
+++ b/fastestimator/trace/adapt/reduce_lr_on_plateau.py
@@ -55,6 +55,7 @@ class ReduceLROnPlateau(Trace):
             assert len(model.loss_name) == 1, "the model has more than one losses, please provide the metric explicitly"
             metric = next(iter(model.loss_name))
         super().__init__(mode="eval", inputs=metric, outputs=model.model_name + "_lr")
+        self.fe_monitor_names.add(metric)
         self.model = model
         self.patience = patience
         self.factor = factor

--- a/fastestimator/trace/io/best_model_saver.py
+++ b/fastestimator/trace/io/best_model_saver.py
@@ -53,6 +53,7 @@ class BestModelSaver(Trace):
         super().__init__(mode="eval",
                          inputs=metric,
                          outputs=["since_best_{}".format(metric), "{}_{}".format(save_best_mode, metric)])
+        self.fe_monitor_names.add(metric)
         self.model = model
         self.model_name = "{}_best_{}".format(self.model.model_name, self.metric)
         self.save_dir = save_dir

--- a/fastestimator/trace/trace.py
+++ b/fastestimator/trace/trace.py
@@ -68,6 +68,9 @@ class Trace:
     inputs: List[str]
     outputs: List[str]
     mode: Set[str]
+    # You can put keys in here to have them automatically added to EvalEssential without the user having to manually add
+    # them to the Estimator monitor_names. See BestModelSaver for an example.
+    fe_monitor_names: Set[str]
 
     def __init__(self,
                  inputs: Union[None, str, Iterable[str]] = None,
@@ -76,6 +79,7 @@ class Trace:
         self.inputs = to_list(inputs)
         self.outputs = to_list(outputs)
         self.mode = parse_modes(to_set(mode))
+        self.fe_monitor_names = set()  # The use-case here is rare enough that we don't want to add this to the init sig
 
     def on_begin(self, data: Data) -> None:
         """Runs once at the beginning of training or testing.
@@ -221,8 +225,8 @@ class Logger(Trace):
             self._print_message("FastEstimator-Start: step: {}; ".format(start_step), data)
 
     def on_batch_end(self, data: Data) -> None:
-        if self.system.mode == "train" and self.system.log_steps and (
-                self.system.global_step % self.system.log_steps == 0 or self.system.global_step == 1):
+        if self.system.mode == "train" and self.system.log_steps and (self.system.global_step % self.system.log_steps
+                                                                      == 0 or self.system.global_step == 1):
             self._print_message("FastEstimator-Train: step: {}; ".format(self.system.global_step), data)
 
     def on_epoch_end(self, data: Data) -> None:


### PR DESCRIPTION
let traces automatically declare monitor variables so that people don't have to manually add them to the estimator