### PR TITLE
allowing use of dict as batchsize, fix potential benchmark bug

### DIFF
--- a/fastestimator/pipeline.py
+++ b/fastestimator/pipeline.py
@@ -119,6 +119,11 @@ class Pipeline:
             # batch_size check
             for batch_size in get_current_items(to_list(self.batch_size)):
                 assert isinstance(batch_size, (int, dict)), "unsupported batch_size format: {}".format(type(batch_size))
+                if isinstance(batch_size, dict):
+                    assert all([key in {"train", "eval", "test", "infer"} for key in batch_size.keys()]), \
+                        "batch size dictionaries must be keyed on mode"
+                    assert all([isinstance(val, int) for val in batch_size.values()]), \
+                        "batch size dictionary values must be integers"
             # ops check
             for op in get_current_items(self.ops):
                 assert isinstance(op, NumpyOp), "unsupported op format, must provide NumpyOp in Pipeline"

--- a/fastestimator/trace/io/traceability.py
+++ b/fastestimator/trace/io/traceability.py
@@ -533,6 +533,8 @@ class Traceability(Trace):
             batch_size = self.system.pipeline.batch_size
             if isinstance(batch_size, Scheduler):
                 batch_size = batch_size.get_current_value(epoch)
+            if isinstance(batch_size, dict):
+                batch_size = batch_size[mode]
             if batch_size is not None:
                 batch_size = f" (Batch Size: {batch_size})"
         self._draw_subgraph(diagram, diagram, label_last_seen, f'Pipeline{batch_size}', pipe_ops)

--- a/test/PR_test/integration_test/test_pipeline.py
+++ b/test/PR_test/integration_test/test_pipeline.py
@@ -390,6 +390,22 @@ class TestPipelineGetResults(unittest.TestCase):
         ans = {"x": np.array([[0]], dtype=np.float32), "y": np.array([[1]], dtype=np.float32)}
         self.assertTrue(is_equal(data, ans))
 
+    def test_pipeline_get_result_dict_batch_size_train_eval(self):
+        pipeline = fe.Pipeline(train_data=self.sample_torch_dataset,
+                               eval_data=self.sample_torch_dataset,
+                               ops=NumpyOpAdd1(inputs="x", outputs="y"),
+                               batch_size={"train": 2, "eval": 1})
+        data_train = pipeline.get_results(mode="train", epoch=1)
+        data_eval = pipeline.get_results(mode="eval", epoch=1)
+        data_train["x"] = data_train["x"].numpy()
+        data_train["y"] = data_train["y"].numpy()
+        data_eval["x"] = data_eval["x"].numpy()
+        data_eval["y"] = data_eval["y"].numpy()
+        ans_train = {"x": np.array([[0], [1]], dtype=np.float32), "y": np.array([[1], [2]], dtype=np.float32)}
+        ans_eval = {"x": np.array([[0]], dtype=np.float32), "y": np.array([[1]], dtype=np.float32)}
+        self.assertTrue(is_equal(data_train, ans_train))
+        self.assertTrue(is_equal(data_eval, ans_eval))
+
 
 class TestPipelineGetLoader(unittest.TestCase):
     """ This test cover:

--- a/test/PR_test/integration_test/test_pipeline.py
+++ b/test/PR_test/integration_test/test_pipeline.py
@@ -368,6 +368,28 @@ class TestPipelineGetResults(unittest.TestCase):
         }
         self.assertTrue(is_equal(data, ans))
 
+    def test_pipeline_get_result_dict_batch_size(self):
+        pipeline = fe.Pipeline(train_data=self.sample_torch_dataset,
+                               ops=NumpyOpAdd1(inputs="x", outputs="y"),
+                               batch_size={"train": 1})
+        data = pipeline.get_results(mode="train", epoch=1)
+        data["x"] = data["x"].numpy()
+        data["y"] = data["y"].numpy()
+        ans = {"x": np.array([[0]], dtype=np.float32), "y": np.array([[1]], dtype=np.float32)}
+        self.assertTrue(is_equal(data, ans))
+
+    def test_pipeline_get_result_dict_batch_size_scheduler(self):
+        pipeline = fe.Pipeline(train_data=self.sample_torch_dataset,
+                               ops=NumpyOpAdd1(inputs="x", outputs="y"),
+                               batch_size=EpochScheduler({1: {
+                                   "train": 1
+                               }}))
+        data = pipeline.get_results(mode="train", epoch=1)
+        data["x"] = data["x"].numpy()
+        data["y"] = data["y"].numpy()
+        ans = {"x": np.array([[0]], dtype=np.float32), "y": np.array([[1]], dtype=np.float32)}
+        self.assertTrue(is_equal(data, ans))
+
 
 class TestPipelineGetLoader(unittest.TestCase):
     """ This test cover:


### PR DESCRIPTION
the original benchmark function was not considering use case of having scheduler as batch_size, this PR can fix it too. 