### PR TITLE
change the default autosharding policy to remove warning message

### DIFF
--- a/fastestimator/estimator.py
+++ b/fastestimator/estimator.py
@@ -340,6 +340,10 @@ class Estimator:
                 new_loader = new_loader.take(self.system.max_eval_steps_per_epoch)
             if isinstance(tf.distribute.get_strategy(), tf.distribute.MirroredStrategy) and isinstance(
                     self.network, TFNetwork) and not isinstance(new_loader, DistributedDataset):
+                # The default autoshard policy is file, changing it to data to avoid warning
+                options = tf.data.Options()
+                options.experimental_distribute.auto_shard_policy = tf.data.experimental.AutoShardPolicy.DATA
+                new_loader = new_loader.with_options(options)
                 new_loader = tf.distribute.get_strategy().experimental_distribute_dataset(new_loader)
         return new_loader
 


### PR DESCRIPTION
Pretty sure you don't want to see the following message printed very epoch right?  well lucky for you, this PR fixed it. 

```
W tensorflow/core/grappler/optimizers/data/auto_shard.cc:656] In AUTO-mode, and switching to DATA-based sharding, instead of FILE-based sharding as we cannot find appropriate reader dataset op(s) to shard. Error: Did not find a shardable source, walked to a node which is not a dataset: name: “FlatMapDataset/_2”
op: “FlatMapDataset”
input: “TensorDataset/_1”
attr {
  key: “Targuments”
  value {
    list {
    }
  }
}
attr {
  key: “f”
  value {
    func {
      name: “__inference_Dataset_flat_map_flat_map_fn_614"
    }
  }
}
attr {
  key: “output_shapes”
  value {
    list {
      shape {
        dim {
          size: -1
        }
        dim {
          size: -1
        }
        dim {
          size: -1
        }
        dim {
          size: -1
        }
      }
      shape {
        dim {
          size: -1
        }
      }
    }
  }
}
attr {
  key: “output_types”
  value {
    list {
      type: DT_FLOAT
      type: DT_UINT8
    }
  }
}
. Consider either turning off auto-sharding or switching the auto_shard_policy to DATA to shard this dataset. You can do this by creating a new `tf.data.Options()` object then setting `options.experimental_distribute.auto_shard_policy = AutoShardPolicy.DATA` before applying the options object to the dataset via `dataset.with_options(options)`.
```
