### PR TITLE
adds warning message when pruning key in dataset

### DIFF
--- a/fastestimator/dataset/op_dataset.py
+++ b/fastestimator/dataset/op_dataset.py
@@ -69,6 +69,9 @@ class _DelayedDeepDict(dict):
         """
         for key in self.base:
             if retain and key not in retain:
+                self.warned.add(key)
+                print("FastEstimator-Warn: the key '{}' is being pruned since it is unused outside of the Pipeline."
+                      " To prevent this, you can declare the key as an input of a Trace or TensorOp.".format(key))
                 continue
             if key not in self:
                 if deep_remainder:


### PR DESCRIPTION
The previous PR only print warning when there's intermediate variable pruned produced by Op, this PR will make sure unused variable in dataset also gets the warning. 