### PR TITLE
fix nightly test of key error

### DIFF
--- a/test/PR_test/integration_test/test_estimator.py
+++ b/test/PR_test/integration_test/test_estimator.py
@@ -284,13 +284,9 @@ class TestEstimatorWarmup(unittest.TestCase):
         est = fe.Estimator(pipeline=pipeline, network=network, epochs=2)
         est._prepare_traces(run_modes={"train", "eval"})
 
-        strategy = tf.distribute.get_strategy()
-        if isinstance(strategy, tf.distribute.MirroredStrategy):
-            with self.assertRaises(StagingError):
-                est._warmup()
-        else:
-            with self.assertRaises(KeyError):
-                est._warmup()
+        # in multi-gpu environment it may raise Staging Error instead of KeyError
+        with self.assertRaises((StagingError, KeyError)):
+            est._warmup()
 
     def test_estimator_warmup_trace_missing_key(self):
         loader = get_sample_tf_dataset()


### PR DESCRIPTION
It seems that even in multi-gpu environment, it sometimes raises KeyError instead of StagingError. 
The new code will pass if either type of the errors raises