### PR TITLE
reduce the number of train/eval steps in nightly test down to 1

### DIFF
--- a/test/apphub_scripts/NLP/imdb/run_nb.sh
+++ b/test/apphub_scripts/NLP/imdb/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="imdb"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10 -p max_eval_steps_per_epoch 10"
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/NLP/imdb/run_nb.sh
+++ b/test/apphub_scripts/NLP/imdb/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="imdb"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2 -p max_eval_steps_per_epoch 2"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/NLP/imdb/run_tf.sh
+++ b/test/apphub_scripts/NLP/imdb/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="imdb"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/NLP/imdb/run_tf.sh
+++ b/test/apphub_scripts/NLP/imdb/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="imdb"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10 --max_eval_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/NLP/imdb/run_torch.sh
+++ b/test/apphub_scripts/NLP/imdb/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="imdb"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/NLP/imdb/run_torch.sh
+++ b/test/apphub_scripts/NLP/imdb/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="imdb"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10 --max_eval_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/NLP/language_modeling/run_nb.sh
+++ b/test/apphub_scripts/NLP/language_modeling/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="ptb"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/NLP/language_modeling/run_nb.sh
+++ b/test/apphub_scripts/NLP/language_modeling/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="ptb"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/NLP/language_modeling/run_tf.sh
+++ b/test/apphub_scripts/NLP/language_modeling/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="ptb"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/NLP/language_modeling/run_tf.sh
+++ b/test/apphub_scripts/NLP/language_modeling/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="ptb"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/NLP/language_modeling/run_torch.sh
+++ b/test/apphub_scripts/NLP/language_modeling/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="ptb"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/NLP/language_modeling/run_torch.sh
+++ b/test/apphub_scripts/NLP/language_modeling/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="ptb"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/NLP/named_entity_recognition/run_nb.sh
+++ b/test/apphub_scripts/NLP/named_entity_recognition/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="bert"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 4 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
+train_info="-p epochs 2 -p batch_size 4 -p max_train_steps_per_epoch 2 -p max_eval_steps_per_epoch 2"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/NLP/named_entity_recognition/run_nb.sh
+++ b/test/apphub_scripts/NLP/named_entity_recognition/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="bert"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 4 -p max_train_steps_per_epoch 10 -p max_eval_steps_per_epoch 10"
+train_info="-p epochs 2 -p batch_size 4 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/NLP/named_entity_recognition/run_tf.sh
+++ b/test/apphub_scripts/NLP/named_entity_recognition/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="bert"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/NLP/named_entity_recognition/run_tf.sh
+++ b/test/apphub_scripts/NLP/named_entity_recognition/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="bert"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 10 --max_eval_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/NLP/named_entity_recognition/run_torch.sh
+++ b/test/apphub_scripts/NLP/named_entity_recognition/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="bert"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 10 --max_eval_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/NLP/named_entity_recognition/run_torch.sh
+++ b/test/apphub_scripts/NLP/named_entity_recognition/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="bert"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/NLP/neural_machine_translation/run_nb.sh
+++ b/test/apphub_scripts/NLP/neural_machine_translation/run_nb.sh
@@ -20,11 +20,11 @@ full_path=$(realpath $0)
 dir_path=$(dirname $full_path)
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10 -p max_eval_steps_per_epoch 10"
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/NLP/neural_machine_translation/run_nb.sh
+++ b/test/apphub_scripts/NLP/neural_machine_translation/run_nb.sh
@@ -20,11 +20,11 @@ full_path=$(realpath $0)
 dir_path=$(dirname $full_path)
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2 -p max_eval_steps_per_epoch 2"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/NLP/neural_machine_translation/run_tf.sh
+++ b/test/apphub_scripts/NLP/neural_machine_translation/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="transformer"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/NLP/neural_machine_translation/run_tf.sh
+++ b/test/apphub_scripts/NLP/neural_machine_translation/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="transformer"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 10 --max_eval_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/NLP/neural_machine_translation/run_torch.sh
+++ b/test/apphub_scripts/NLP/neural_machine_translation/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="transformer"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 10 --max_eval_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/NLP/neural_machine_translation/run_torch.sh
+++ b/test/apphub_scripts/NLP/neural_machine_translation/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="transformer"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/adversarial_training/ecc/run_nb.sh
+++ b/test/apphub_scripts/adversarial_training/ecc/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="ecc"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10 -p max_eval_steps_per_epoch 10"
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/adversarial_training/ecc/run_nb.sh
+++ b/test/apphub_scripts/adversarial_training/ecc/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="ecc"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2 -p max_eval_steps_per_epoch 2"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/adversarial_training/ecc/run_tf.sh
+++ b/test/apphub_scripts/adversarial_training/ecc/run_tf.sh
@@ -19,13 +19,13 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="ecc"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10 --max_eval_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
-need_test=1
+need_test=0
 # ==============================================================================================
 
 full_path=$(realpath $0)

--- a/test/apphub_scripts/adversarial_training/ecc/run_tf.sh
+++ b/test/apphub_scripts/adversarial_training/ecc/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="ecc"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/adversarial_training/ecc/run_torch.sh
+++ b/test/apphub_scripts/adversarial_training/ecc/run_torch.sh
@@ -18,13 +18,13 @@ set -e
 example_name="ecc"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10 --max_eval_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
-need_test=1
+need_test=0
 # ==============================================================================================
 
 full_path=$(realpath $0)

--- a/test/apphub_scripts/adversarial_training/ecc/run_torch.sh
+++ b/test/apphub_scripts/adversarial_training/ecc/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="ecc"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/adversarial_training/ecc_hinge/run_nb.sh
+++ b/test/apphub_scripts/adversarial_training/ecc_hinge/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="ecc_hinge"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2 -p max_eval_steps_per_epoch 2"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/adversarial_training/ecc_hinge/run_nb.sh
+++ b/test/apphub_scripts/adversarial_training/ecc_hinge/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="ecc_hinge"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10 -p max_eval_steps_per_epoch 10"
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/adversarial_training/ecc_hinge/run_tf.sh
+++ b/test/apphub_scripts/adversarial_training/ecc_hinge/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="ecc_hinge"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/adversarial_training/ecc_hinge/run_tf.sh
+++ b/test/apphub_scripts/adversarial_training/ecc_hinge/run_tf.sh
@@ -19,13 +19,13 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="ecc_hinge"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10 --max_eval_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
-need_test=1
+need_test=0
 # ==============================================================================================
 
 full_path=$(realpath $0)

--- a/test/apphub_scripts/adversarial_training/ecc_hinge/run_torch.sh
+++ b/test/apphub_scripts/adversarial_training/ecc_hinge/run_torch.sh
@@ -18,13 +18,13 @@ set -e
 example_name="ecc_hinge"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10 --max_eval_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
-need_test=1
+need_test=0
 # ==============================================================================================
 
 full_path=$(realpath $0)

--- a/test/apphub_scripts/adversarial_training/ecc_hinge/run_torch.sh
+++ b/test/apphub_scripts/adversarial_training/ecc_hinge/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="ecc_hinge"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/adversarial_training/fgsm/run_nb.sh
+++ b/test/apphub_scripts/adversarial_training/fgsm/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="fgsm"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10 -p max_eval_steps_per_epoch 10"
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/adversarial_training/fgsm/run_nb.sh
+++ b/test/apphub_scripts/adversarial_training/fgsm/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="fgsm"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2 -p max_eval_steps_per_epoch 2"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/adversarial_training/fgsm/run_tf.sh
+++ b/test/apphub_scripts/adversarial_training/fgsm/run_tf.sh
@@ -19,13 +19,13 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="fgsm"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10 --max_eval_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
-need_test=1
+need_test=0
 # ==============================================================================================
 
 full_path=$(realpath $0)

--- a/test/apphub_scripts/adversarial_training/fgsm/run_tf.sh
+++ b/test/apphub_scripts/adversarial_training/fgsm/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="fgsm"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/adversarial_training/fgsm/run_torch.sh
+++ b/test/apphub_scripts/adversarial_training/fgsm/run_torch.sh
@@ -18,13 +18,13 @@ set -e
 example_name="fgsm"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10 --max_eval_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
-need_test=1
+need_test=0
 # ==============================================================================================
 
 full_path=$(realpath $0)

--- a/test/apphub_scripts/adversarial_training/fgsm/run_torch.sh
+++ b/test/apphub_scripts/adversarial_training/fgsm/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="fgsm"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/anomaly_detection/alocc/run_nb.sh
+++ b/test/apphub_scripts/anomaly_detection/alocc/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="alocc"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/anomaly_detection/alocc/run_nb.sh
+++ b/test/apphub_scripts/anomaly_detection/alocc/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="alocc"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/anomaly_detection/alocc/run_tf.sh
+++ b/test/apphub_scripts/anomaly_detection/alocc/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="alocc"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/anomaly_detection/alocc/run_tf.sh
+++ b/test/apphub_scripts/anomaly_detection/alocc/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="alocc"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/anomaly_detection/alocc/run_torch.sh
+++ b/test/apphub_scripts/anomaly_detection/alocc/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="alocc"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/anomaly_detection/alocc/run_torch.sh
+++ b/test/apphub_scripts/anomaly_detection/alocc/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="alocc"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/automl/rand_augment/run_nb.sh
+++ b/test/apphub_scripts/automl/rand_augment/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="rand_augment"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10 -p max_eval_steps_per_epoch 10 -p max_level 1 -p max_num_augment 1 -p final_step 20"
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1 -p max_level 1 -p max_num_augment 1 -p final_step 20"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/automl/rand_augment/run_nb.sh
+++ b/test/apphub_scripts/automl/rand_augment/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="rand_augment"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1 -p max_level 1 -p max_num_augment 1 -p final_step 20"
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2 -p max_eval_steps_per_epoch 2 -p max_level 1 -p max_num_augment 1 -p final_step 20"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/automl/rand_augment/run_tf.sh
+++ b/test/apphub_scripts/automl/rand_augment/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="rand_augment"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1 --level 1 --num_augment 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2 --level 1 --num_augment 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/automl/rand_augment/run_tf.sh
+++ b/test/apphub_scripts/automl/rand_augment/run_tf.sh
@@ -19,13 +19,13 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="rand_augment"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10 --max_eval_steps_per_epoch 10 --level 1 --num_augment 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1 --level 1 --num_augment 1"
 
 # Do you want to run "fastestimator test"? (bool)
-need_test=1
+need_test=0
 # ==============================================================================================
 
 full_path=$(realpath $0)

--- a/test/apphub_scripts/automl/rand_augment/run_torch.sh
+++ b/test/apphub_scripts/automl/rand_augment/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="rand_augment"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1 --level 1 --num_augment 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2 --level 1 --num_augment 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/automl/rand_augment/run_torch.sh
+++ b/test/apphub_scripts/automl/rand_augment/run_torch.sh
@@ -18,13 +18,13 @@ set -e
 example_name="rand_augment"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10 --max_eval_steps_per_epoch 10 --level 1 --num_augment 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1 --level 1 --num_augment 1"
 
 # Do you want to run "fastestimator test"? (bool)
-need_test=1
+need_test=0
 # ==============================================================================================
 
 full_path=$(realpath $0)

--- a/test/apphub_scripts/contrastive_learning/simclr/run_nb.sh
+++ b/test/apphub_scripts/contrastive_learning/simclr/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="simclr"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs_pretrain 1 -p epochs_finetune 1 -p batch_size 8 -p max_train_steps_per_epoch 1"
+train_info="-p epochs_pretrain 1 -p epochs_finetune 1 -p batch_size 8 -p max_train_steps_per_epoch 2"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/contrastive_learning/simclr/run_nb.sh
+++ b/test/apphub_scripts/contrastive_learning/simclr/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="simclr"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs_pretrain 1 -p epochs_finetune 1 -p batch_size 8 -p max_train_steps_per_epoch 10"
+train_info="-p epochs_pretrain 1 -p epochs_finetune 1 -p batch_size 8 -p max_train_steps_per_epoch 1"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/contrastive_learning/simclr/run_tf.sh
+++ b/test/apphub_scripts/contrastive_learning/simclr/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="simclr"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs_pretrain 1 --epochs_finetune 1 --batch_size 8 --max_train_steps_per_epoch 10"
+train_info="--epochs_pretrain 1 --epochs_finetune 1 --batch_size 8 --max_train_steps_per_epoch 1"
 # ==============================================================================================
 
 full_path=$(realpath $0)

--- a/test/apphub_scripts/contrastive_learning/simclr/run_tf.sh
+++ b/test/apphub_scripts/contrastive_learning/simclr/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="simclr"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs_pretrain 1 --epochs_finetune 1 --batch_size 8 --max_train_steps_per_epoch 1"
+train_info="--epochs_pretrain 1 --epochs_finetune 1 --batch_size 8 --max_train_steps_per_epoch 2"
 # ==============================================================================================
 
 full_path=$(realpath $0)

--- a/test/apphub_scripts/contrastive_learning/simclr/run_torch.sh
+++ b/test/apphub_scripts/contrastive_learning/simclr/run_torch.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="simclr"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs_pretrain 1 --epochs_finetune 1 --batch_size 8 --max_train_steps_per_epoch 10"
+train_info="--epochs_pretrain 1 --epochs_finetune 1 --batch_size 8 --max_train_steps_per_epoch 1"
 # ==============================================================================================
 
 full_path=$(realpath $0)

--- a/test/apphub_scripts/contrastive_learning/simclr/run_torch.sh
+++ b/test/apphub_scripts/contrastive_learning/simclr/run_torch.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="simclr"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs_pretrain 1 --epochs_finetune 1 --batch_size 8 --max_train_steps_per_epoch 1"
+train_info="--epochs_pretrain 1 --epochs_finetune 1 --batch_size 8 --max_train_steps_per_epoch 2"
 # ==============================================================================================
 
 full_path=$(realpath $0)

--- a/test/apphub_scripts/curriculum_learning/superloss/run_nb.sh
+++ b/test/apphub_scripts/curriculum_learning/superloss/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="superloss"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2 -p max_eval_steps_per_epoch 2"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/curriculum_learning/superloss/run_nb.sh
+++ b/test/apphub_scripts/curriculum_learning/superloss/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="superloss"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10 -p max_eval_steps_per_epoch 10"
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/curriculum_learning/superloss/run_tf.sh
+++ b/test/apphub_scripts/curriculum_learning/superloss/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="superloss"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/curriculum_learning/superloss/run_tf.sh
+++ b/test/apphub_scripts/curriculum_learning/superloss/run_tf.sh
@@ -19,13 +19,13 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="superloss"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
-need_test=1
+need_test=0
 # ==============================================================================================
 
 full_path=$(realpath $0)

--- a/test/apphub_scripts/curriculum_learning/superloss/run_torch.sh
+++ b/test/apphub_scripts/curriculum_learning/superloss/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="superloss"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/curriculum_learning/superloss/run_torch.sh
+++ b/test/apphub_scripts/curriculum_learning/superloss/run_torch.sh
@@ -18,13 +18,13 @@ set -e
 example_name="superloss"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
-need_test=1
+need_test=0
 # ==============================================================================================
 
 full_path=$(realpath $0)

--- a/test/apphub_scripts/image_classification/cifar10_fast/run_nb.sh
+++ b/test/apphub_scripts/image_classification/cifar10_fast/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="cifar10_fast"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2 -p max_eval_steps_per_epoch 2"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/image_classification/cifar10_fast/run_nb.sh
+++ b/test/apphub_scripts/image_classification/cifar10_fast/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="cifar10_fast"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10 -p max_eval_steps_per_epoch 10"
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/image_classification/cifar10_fast/run_tf.sh
+++ b/test/apphub_scripts/image_classification/cifar10_fast/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="cifar10_fast"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/image_classification/cifar10_fast/run_tf.sh
+++ b/test/apphub_scripts/image_classification/cifar10_fast/run_tf.sh
@@ -19,13 +19,13 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="cifar10_fast"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
-need_test=1
+need_test=0
 # ==============================================================================================
 
 full_path=$(realpath $0)

--- a/test/apphub_scripts/image_classification/cifar10_fast/run_torch.sh
+++ b/test/apphub_scripts/image_classification/cifar10_fast/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="cifar10_fast"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/image_classification/cifar10_fast/run_torch.sh
+++ b/test/apphub_scripts/image_classification/cifar10_fast/run_torch.sh
@@ -18,13 +18,13 @@ set -e
 example_name="cifar10_fast"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
-need_test=1
+need_test=0
 # ==============================================================================================
 
 full_path=$(realpath $0)

--- a/test/apphub_scripts/image_classification/mnist/run_nb.sh
+++ b/test/apphub_scripts/image_classification/mnist/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="mnist"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10 -p max_eval_steps_per_epoch 10"
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/image_classification/mnist/run_nb.sh
+++ b/test/apphub_scripts/image_classification/mnist/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="mnist"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2 -p max_eval_steps_per_epoch 2"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/image_classification/mnist/run_tf.sh
+++ b/test/apphub_scripts/image_classification/mnist/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="mnist"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/image_classification/mnist/run_tf.sh
+++ b/test/apphub_scripts/image_classification/mnist/run_tf.sh
@@ -19,13 +19,13 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="mnist"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10 --max_eval_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
-need_test=1
+need_test=0
 # ==============================================================================================
 
 full_path=$(realpath $0)

--- a/test/apphub_scripts/image_classification/mnist/run_torch.sh
+++ b/test/apphub_scripts/image_classification/mnist/run_torch.sh
@@ -18,13 +18,13 @@ set -e
 example_name="mnist"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10 --max_eval_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
-need_test=1
+need_test=0
 # ==============================================================================================
 
 full_path=$(realpath $0)

--- a/test/apphub_scripts/image_classification/mnist/run_torch.sh
+++ b/test/apphub_scripts/image_classification/mnist/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="mnist"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/image_classification/pyramidnet/run_nb.sh
+++ b/test/apphub_scripts/image_classification/pyramidnet/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="pyramidnet"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 2 -p max_train_steps_per_epoch 2 -p max_eval_steps_per_epoch 2"
+train_info="-p epochs 2 -p batch_size 2 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/image_classification/pyramidnet/run_nb.sh
+++ b/test/apphub_scripts/image_classification/pyramidnet/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="pyramidnet"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 2 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
+train_info="-p epochs 2 -p batch_size 2 -p max_train_steps_per_epoch 2 -p max_eval_steps_per_epoch 2"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/image_classification/pyramidnet/run_tf.sh
+++ b/test/apphub_scripts/image_classification/pyramidnet/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="pyramidnet"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/image_classification/pyramidnet/run_tf.sh
+++ b/test/apphub_scripts/image_classification/pyramidnet/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="pyramidnet"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
+train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/image_classification/pyramidnet/run_torch.sh
+++ b/test/apphub_scripts/image_classification/pyramidnet/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="pyramidnet"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
+train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/image_classification/pyramidnet/run_torch.sh
+++ b/test/apphub_scripts/image_classification/pyramidnet/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="pyramidnet"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/image_generation/cvae/run_nb.sh
+++ b/test/apphub_scripts/image_generation/cvae/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="cvae"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/image_generation/cvae/run_nb.sh
+++ b/test/apphub_scripts/image_generation/cvae/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="cvae"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/image_generation/cvae/run_tf.sh
+++ b/test/apphub_scripts/image_generation/cvae/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="cvae"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/image_generation/cvae/run_tf.sh
+++ b/test/apphub_scripts/image_generation/cvae/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="cvae"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/image_generation/cvae/run_torch.sh
+++ b/test/apphub_scripts/image_generation/cvae/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="cvae"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/image_generation/cvae/run_torch.sh
+++ b/test/apphub_scripts/image_generation/cvae/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="cvae"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/image_generation/cyclegan/run_nb.sh
+++ b/test/apphub_scripts/image_generation/cyclegan/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="cyclegan"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 2 -p max_train_steps_per_epoch 10"
+train_info="-p epochs 2 -p batch_size 2 -p max_train_steps_per_epoch 1"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/image_generation/cyclegan/run_nb.sh
+++ b/test/apphub_scripts/image_generation/cyclegan/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="cyclegan"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 2 -p max_train_steps_per_epoch 1"
+train_info="-p epochs 2 -p batch_size 2 -p max_train_steps_per_epoch 2"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/image_generation/cyclegan/run_tf.sh
+++ b/test/apphub_scripts/image_generation/cyclegan/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="cyclegan"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 2 --max_train_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 2 --max_train_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/image_generation/cyclegan/run_tf.sh
+++ b/test/apphub_scripts/image_generation/cyclegan/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="cyclegan"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 2 --max_train_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 2 --max_train_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/image_generation/cyclegan/run_torch.sh
+++ b/test/apphub_scripts/image_generation/cyclegan/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="cyclegan"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 2 --max_train_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 2 --max_train_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/image_generation/cyclegan/run_torch.sh
+++ b/test/apphub_scripts/image_generation/cyclegan/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="cyclegan"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 2 --max_train_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 2 --max_train_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/image_generation/dcgan/run_nb.sh
+++ b/test/apphub_scripts/image_generation/dcgan/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="dcgan"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 5 -p batch_size 8 -p max_train_steps_per_epoch 1 -p model_name model_epoch_5.h5"
+train_info="-p epochs 5 -p batch_size 8 -p max_train_steps_per_epoch 2 -p model_name model_epoch_5.h5"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/image_generation/dcgan/run_nb.sh
+++ b/test/apphub_scripts/image_generation/dcgan/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="dcgan"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 5 -p batch_size 8 -p max_train_steps_per_epoch 10 -p model_name model_epoch_5.h5"
+train_info="-p epochs 5 -p batch_size 8 -p max_train_steps_per_epoch 1 -p model_name model_epoch_5.h5"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/image_generation/dcgan/run_tf.sh
+++ b/test/apphub_scripts/image_generation/dcgan/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="dcgan"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/image_generation/dcgan/run_tf.sh
+++ b/test/apphub_scripts/image_generation/dcgan/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="dcgan"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/image_generation/dcgan/run_torch.sh
+++ b/test/apphub_scripts/image_generation/dcgan/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="dcgan"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/image_generation/dcgan/run_torch.sh
+++ b/test/apphub_scripts/image_generation/dcgan/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="dcgan"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/image_generation/pggan/run_nb.sh
+++ b/test/apphub_scripts/image_generation/pggan/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="pggan"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 3 -p target_size 8 -p max_train_steps_per_epoch 1"
+train_info="-p epochs 3 -p target_size 8 -p max_train_steps_per_epoch 2"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/image_generation/pggan/run_nb.sh
+++ b/test/apphub_scripts/image_generation/pggan/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="pggan"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 3 -p target_size 8 -p max_train_steps_per_epoch 20"
+train_info="-p epochs 3 -p target_size 8 -p max_train_steps_per_epoch 1"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/image_generation/pggan/run_tf.sh
+++ b/test/apphub_scripts/image_generation/pggan/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="pggan"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 3 --target_size 8 --max_train_steps_per_epoch 1"
+train_info="--epochs 3 --target_size 8 --max_train_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/image_generation/pggan/run_tf.sh
+++ b/test/apphub_scripts/image_generation/pggan/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="pggan"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 3 --target_size 8 --max_train_steps_per_epoch 20"
+train_info="--epochs 3 --target_size 8 --max_train_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/image_generation/pggan/run_torch.sh
+++ b/test/apphub_scripts/image_generation/pggan/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="pggan"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 3 --target_size 8 --max_train_steps_per_epoch 1"
+train_info="--epochs 3 --target_size 8 --max_train_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/image_generation/pggan/run_torch.sh
+++ b/test/apphub_scripts/image_generation/pggan/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="pggan"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 3 --target_size 8 --max_train_steps_per_epoch 20"
+train_info="--epochs 3 --target_size 8 --max_train_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/instance_detection/retinanet/run_nb.sh
+++ b/test/apphub_scripts/instance_detection/retinanet/run_nb.sh
@@ -20,12 +20,12 @@ full_path=$(realpath $0)
 dir_path=$(dirname $full_path)
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
 class_json_path="${dir_path}/class.json"
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1 \
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2 -p max_eval_steps_per_epoch 2 \
             -p class_json_path ${class_json_path}"
 
 # ==============================================================================================

--- a/test/apphub_scripts/instance_detection/retinanet/run_nb.sh
+++ b/test/apphub_scripts/instance_detection/retinanet/run_nb.sh
@@ -20,12 +20,12 @@ full_path=$(realpath $0)
 dir_path=$(dirname $full_path)
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
 class_json_path="${dir_path}/class.json"
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10 -p max_eval_steps_per_epoch 10 \
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1 \
             -p class_json_path ${class_json_path}"
 
 # ==============================================================================================

--- a/test/apphub_scripts/instance_detection/retinanet/run_tf.sh
+++ b/test/apphub_scripts/instance_detection/retinanet/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="retinanet"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/instance_detection/retinanet/run_tf.sh
+++ b/test/apphub_scripts/instance_detection/retinanet/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="retinanet"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 10 --max_eval_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/instance_detection/retinanet/run_torch.sh
+++ b/test/apphub_scripts/instance_detection/retinanet/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="retinanet"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 10 --max_eval_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/instance_detection/retinanet/run_torch.sh
+++ b/test/apphub_scripts/instance_detection/retinanet/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="retinanet"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/instance_detection/yolov5/run_nb.sh
+++ b/test/apphub_scripts/instance_detection/yolov5/run_nb.sh
@@ -20,11 +20,11 @@ full_path=$(realpath $0)
 dir_path=$(dirname $full_path)
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size_per_gpu 4 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
+train_info="-p epochs 2 -p batch_size_per_gpu 4 -p max_train_steps_per_epoch 2 -p max_eval_steps_per_epoch 2"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/instance_detection/yolov5/run_nb.sh
+++ b/test/apphub_scripts/instance_detection/yolov5/run_nb.sh
@@ -20,11 +20,11 @@ full_path=$(realpath $0)
 dir_path=$(dirname $full_path)
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size_per_gpu 4 -p max_train_steps_per_epoch 10 -p max_eval_steps_per_epoch 10"
+train_info="-p epochs 2 -p batch_size_per_gpu 4 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/instance_detection/yolov5/run_tf.sh
+++ b/test/apphub_scripts/instance_detection/yolov5/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="yolov5"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size_per_gpu 4 --max_train_steps_per_epoch 10 --max_eval_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size_per_gpu 4 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/instance_detection/yolov5/run_tf.sh
+++ b/test/apphub_scripts/instance_detection/yolov5/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="yolov5"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size_per_gpu 4 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size_per_gpu 4 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/instance_detection/yolov5/run_torch.sh
+++ b/test/apphub_scripts/instance_detection/yolov5/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="yolov5"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size_per_gpu 4 --max_train_steps_per_epoch 10 --max_eval_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size_per_gpu 4 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/instance_detection/yolov5/run_torch.sh
+++ b/test/apphub_scripts/instance_detection/yolov5/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="yolov5"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size_per_gpu 4 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size_per_gpu 4 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/lr_controller/super_convergence/run_nb.sh
+++ b/test/apphub_scripts/lr_controller/super_convergence/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="super_convergence"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p lr_epochs 2 -p max_train_steps_per_epoch 10"
+train_info="-p epochs 2 -p batch_size 8 -p lr_epochs 2 -p max_train_steps_per_epoch 1"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/lr_controller/super_convergence/run_nb.sh
+++ b/test/apphub_scripts/lr_controller/super_convergence/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="super_convergence"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p lr_epochs 2 -p max_train_steps_per_epoch 1"
+train_info="-p epochs 2 -p batch_size 8 -p lr_epochs 2 -p max_train_steps_per_epoch 2"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/lr_controller/super_convergence/run_tf.sh
+++ b/test/apphub_scripts/lr_controller/super_convergence/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="super_convergence"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --lr_epochs 2 --max_train_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 8 --lr_epochs 2 --max_train_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/lr_controller/super_convergence/run_tf.sh
+++ b/test/apphub_scripts/lr_controller/super_convergence/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="super_convergence"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --lr_epochs 2 --max_train_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 8 --lr_epochs 2 --max_train_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/lr_controller/super_convergence/run_torch.sh
+++ b/test/apphub_scripts/lr_controller/super_convergence/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="super_convergence"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --lr_epochs 2 --max_train_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 8 --lr_epochs 2 --max_train_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/lr_controller/super_convergence/run_torch.sh
+++ b/test/apphub_scripts/lr_controller/super_convergence/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="super_convergence"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --lr_epochs 2 --max_train_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 8 --lr_epochs 2 --max_train_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/multi_task_learning/uncertainty_weighted_loss/run_nb.sh
+++ b/test/apphub_scripts/multi_task_learning/uncertainty_weighted_loss/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="uncertainty_loss"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10 -p max_eval_steps_per_epoch 10"
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/multi_task_learning/uncertainty_weighted_loss/run_nb.sh
+++ b/test/apphub_scripts/multi_task_learning/uncertainty_weighted_loss/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="uncertainty_loss"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2 -p max_eval_steps_per_epoch 2"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/multi_task_learning/uncertainty_weighted_loss/run_tf.sh
+++ b/test/apphub_scripts/multi_task_learning/uncertainty_weighted_loss/run_tf.sh
@@ -19,13 +19,13 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="uncertainty_loss"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10 --max_eval_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
-need_test=1
+need_test=0
 # ==============================================================================================
 
 full_path=$(realpath $0)

--- a/test/apphub_scripts/multi_task_learning/uncertainty_weighted_loss/run_tf.sh
+++ b/test/apphub_scripts/multi_task_learning/uncertainty_weighted_loss/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="uncertainty_loss"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/multi_task_learning/uncertainty_weighted_loss/run_torch.sh
+++ b/test/apphub_scripts/multi_task_learning/uncertainty_weighted_loss/run_torch.sh
@@ -18,13 +18,13 @@ set -e
 example_name="uncertainty_loss"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10 --max_eval_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
-need_test=1
+need_test=0
 # ==============================================================================================
 
 full_path=$(realpath $0)

--- a/test/apphub_scripts/multi_task_learning/uncertainty_weighted_loss/run_torch.sh
+++ b/test/apphub_scripts/multi_task_learning/uncertainty_weighted_loss/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="uncertainty_loss"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/neural_architecture_search/naswot/run_nb.sh
+++ b/test/apphub_scripts/neural_architecture_search/naswot/run_nb.sh
@@ -18,8 +18,8 @@ set -e
 example_name="naswot"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
 train_info="-p batch_size 128 -p num_archs 10"

--- a/test/apphub_scripts/neural_architecture_search/naswot/run_nb.sh
+++ b/test/apphub_scripts/neural_architecture_search/naswot/run_nb.sh
@@ -18,8 +18,8 @@ set -e
 example_name="naswot"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
 train_info="-p batch_size 128 -p num_archs 10"

--- a/test/apphub_scripts/neural_architecture_search/naswot/run_tf.sh
+++ b/test/apphub_scripts/neural_architecture_search/naswot/run_tf.sh
@@ -19,8 +19,8 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="naswot"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
 train_info="--batch_size 128 --num_archs 10"
 # ==============================================================================================

--- a/test/apphub_scripts/neural_architecture_search/naswot/run_tf.sh
+++ b/test/apphub_scripts/neural_architecture_search/naswot/run_tf.sh
@@ -19,8 +19,8 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="naswot"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
 train_info="--batch_size 128 --num_archs 10"
 # ==============================================================================================

--- a/test/apphub_scripts/neural_architecture_search/naswot/run_torch.sh
+++ b/test/apphub_scripts/neural_architecture_search/naswot/run_torch.sh
@@ -19,8 +19,8 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="naswot"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
 train_info="--batch_size 128 --num_archs 10"
 # ==============================================================================================

--- a/test/apphub_scripts/neural_architecture_search/naswot/run_torch.sh
+++ b/test/apphub_scripts/neural_architecture_search/naswot/run_torch.sh
@@ -19,8 +19,8 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="naswot"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
 train_info="--batch_size 128 --num_archs 10"
 # ==============================================================================================

--- a/test/apphub_scripts/one_shot_learning/siamese_network/run_nb.sh
+++ b/test/apphub_scripts/one_shot_learning/siamese_network/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="siamese"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 4 -p max_train_steps_per_epoch 10 -p max_eval_steps_per_epoch 10"
+train_info="-p epochs 2 -p batch_size 4 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/one_shot_learning/siamese_network/run_nb.sh
+++ b/test/apphub_scripts/one_shot_learning/siamese_network/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="siamese"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 4 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
+train_info="-p epochs 2 -p batch_size 4 -p max_train_steps_per_epoch 2 -p max_eval_steps_per_epoch 2"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/one_shot_learning/siamese_network/run_tf.sh
+++ b/test/apphub_scripts/one_shot_learning/siamese_network/run_tf.sh
@@ -19,13 +19,13 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="siamese"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 10 --max_eval_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
-need_test=1
+need_test=0
 # ==============================================================================================
 
 full_path=$(realpath $0)

--- a/test/apphub_scripts/one_shot_learning/siamese_network/run_tf.sh
+++ b/test/apphub_scripts/one_shot_learning/siamese_network/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="siamese"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/one_shot_learning/siamese_network/run_torch.sh
+++ b/test/apphub_scripts/one_shot_learning/siamese_network/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="siamese"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/one_shot_learning/siamese_network/run_torch.sh
+++ b/test/apphub_scripts/one_shot_learning/siamese_network/run_torch.sh
@@ -18,13 +18,13 @@ set -e
 example_name="siamese"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 10 --max_eval_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
-need_test=1
+need_test=0
 # ==============================================================================================
 
 full_path=$(realpath $0)

--- a/test/apphub_scripts/semantic_segmentation/unet/run_nb.sh
+++ b/test/apphub_scripts/semantic_segmentation/unet/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="unet"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 4 -p max_train_steps_per_epoch 10 -p max_eval_steps_per_epoch 10"
+train_info="-p epochs 2 -p batch_size 4 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/semantic_segmentation/unet/run_nb.sh
+++ b/test/apphub_scripts/semantic_segmentation/unet/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="unet"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 4 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
+train_info="-p epochs 2 -p batch_size 4 -p max_train_steps_per_epoch 2 -p max_eval_steps_per_epoch 2"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/semantic_segmentation/unet/run_tf.sh
+++ b/test/apphub_scripts/semantic_segmentation/unet/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="unet"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/semantic_segmentation/unet/run_tf.sh
+++ b/test/apphub_scripts/semantic_segmentation/unet/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="unet"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 10 --max_eval_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/semantic_segmentation/unet/run_torch.sh
+++ b/test/apphub_scripts/semantic_segmentation/unet/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="unet"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 10 --max_eval_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/semantic_segmentation/unet/run_torch.sh
+++ b/test/apphub_scripts/semantic_segmentation/unet/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="unet"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/style_transfer/fst_coco/run_nb.sh
+++ b/test/apphub_scripts/style_transfer/fst_coco/run_nb.sh
@@ -20,13 +20,13 @@ dir_path=$(dirname $full_path)
 example_name="fst"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
 style_img_path="${dir_path}/Vassily_Kandinsky,_1913_-_Composition_7.jpg"
 test_img_path="${dir_path}/panda.jpeg"
-train_info="-p epochs 2 -p batch_size 4 -p max_train_steps_per_epoch 1 -p style_img_path ${style_img_path} \
+train_info="-p epochs 2 -p batch_size 4 -p max_train_steps_per_epoch 2 -p style_img_path ${style_img_path} \
             -p test_img_path ${test_img_path}"
 
 # ==============================================================================================

--- a/test/apphub_scripts/style_transfer/fst_coco/run_nb.sh
+++ b/test/apphub_scripts/style_transfer/fst_coco/run_nb.sh
@@ -20,13 +20,13 @@ dir_path=$(dirname $full_path)
 example_name="fst"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
 style_img_path="${dir_path}/Vassily_Kandinsky,_1913_-_Composition_7.jpg"
 test_img_path="${dir_path}/panda.jpeg"
-train_info="-p epochs 2 -p batch_size 4 -p max_train_steps_per_epoch 10 -p style_img_path ${style_img_path} \
+train_info="-p epochs 2 -p batch_size 4 -p max_train_steps_per_epoch 1 -p style_img_path ${style_img_path} \
             -p test_img_path ${test_img_path}"
 
 # ==============================================================================================

--- a/test/apphub_scripts/style_transfer/fst_coco/run_tf.sh
+++ b/test/apphub_scripts/style_transfer/fst_coco/run_tf.sh
@@ -21,11 +21,11 @@ dir_path=$(dirname $full_path)
 example_name="fst"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
 style_img_path="${dir_path}/Vassily_Kandinsky,_1913_-_Composition_7.jpg"
-train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 1 --style_img_path ${style_img_path}"
+train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 2 --style_img_path ${style_img_path}"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/style_transfer/fst_coco/run_tf.sh
+++ b/test/apphub_scripts/style_transfer/fst_coco/run_tf.sh
@@ -21,11 +21,11 @@ dir_path=$(dirname $full_path)
 example_name="fst"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
 style_img_path="${dir_path}/Vassily_Kandinsky,_1913_-_Composition_7.jpg"
-train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 10 --style_img_path ${style_img_path}"
+train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 1 --style_img_path ${style_img_path}"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/style_transfer/fst_coco/run_torch.sh
+++ b/test/apphub_scripts/style_transfer/fst_coco/run_torch.sh
@@ -20,11 +20,11 @@ dir_path=$(dirname $full_path)
 example_name="fst"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
 style_img_path="${dir_path}/Vassily_Kandinsky,_1913_-_Composition_7.jpg"
-train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 10 --style_img_path ${style_img_path}"
+train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 1 --style_img_path ${style_img_path}"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/style_transfer/fst_coco/run_torch.sh
+++ b/test/apphub_scripts/style_transfer/fst_coco/run_torch.sh
@@ -20,11 +20,11 @@ dir_path=$(dirname $full_path)
 example_name="fst"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
 style_img_path="${dir_path}/Vassily_Kandinsky,_1913_-_Composition_7.jpg"
-train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 1 --style_img_path ${style_img_path}"
+train_info="--epochs 2 --batch_size 4 --max_train_steps_per_epoch 2 --style_img_path ${style_img_path}"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/tabular/dnn/run_nb.sh
+++ b/test/apphub_scripts/tabular/dnn/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="dnn"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10 -p max_eval_steps_per_epoch 10"
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/tabular/dnn/run_nb.sh
+++ b/test/apphub_scripts/tabular/dnn/run_nb.sh
@@ -18,11 +18,11 @@ set -e
 example_name="dnn"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1 -p max_eval_steps_per_epoch 1"
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2 -p max_eval_steps_per_epoch 2"
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/tabular/dnn/run_tf.sh
+++ b/test/apphub_scripts/tabular/dnn/run_tf.sh
@@ -19,13 +19,13 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="dnn"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10 --max_eval_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
-need_test=1
+need_test=0
 # ==============================================================================================
 
 full_path=$(realpath $0)

--- a/test/apphub_scripts/tabular/dnn/run_tf.sh
+++ b/test/apphub_scripts/tabular/dnn/run_tf.sh
@@ -19,10 +19,10 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name="dnn"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/tabular/dnn/run_torch.sh
+++ b/test/apphub_scripts/tabular/dnn/run_torch.sh
@@ -18,10 +18,10 @@ set -e
 example_name="dnn"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2 --max_eval_steps_per_epoch 2"
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0

--- a/test/apphub_scripts/tabular/dnn/run_torch.sh
+++ b/test/apphub_scripts/tabular/dnn/run_torch.sh
@@ -18,13 +18,13 @@ set -e
 example_name="dnn"
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10 --max_eval_steps_per_epoch 10"
+train_info="--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1 --max_eval_steps_per_epoch 1"
 
 # Do you want to run "fastestimator test"? (bool)
-need_test=1
+need_test=0
 # ==============================================================================================
 
 full_path=$(realpath $0)

--- a/test/apphub_scripts/template/run_nb.sh
+++ b/test/apphub_scripts/template/run_nb.sh
@@ -18,8 +18,8 @@ set -e
 example_name=
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
 train_info=

--- a/test/apphub_scripts/template/run_nb.sh
+++ b/test/apphub_scripts/template/run_nb.sh
@@ -18,8 +18,8 @@ set -e
 example_name=
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 1"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
 train_info=

--- a/test/apphub_scripts/template/run_tf.sh
+++ b/test/apphub_scripts/template/run_tf.sh
@@ -19,13 +19,13 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name=
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
 train_info=
 
 # Do you want to run "fastestimator test"? (bool)
-need_test=1
+need_test=0
 # ==============================================================================================
 
 full_path=$(realpath $0)

--- a/test/apphub_scripts/template/run_tf.sh
+++ b/test/apphub_scripts/template/run_tf.sh
@@ -19,8 +19,8 @@ export TF_CPP_MIN_LOG_LEVEL=2
 example_name=
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
 train_info=
 

--- a/test/apphub_scripts/template/run_torch.sh
+++ b/test/apphub_scripts/template/run_torch.sh
@@ -18,13 +18,13 @@ set -e
 example_name=
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:10
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 10"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
 # 3. The syntax of this expression is different from run_notebook.py
 train_info=
 
 # Do you want to run "fastestimator test"? (bool)
-need_test=1
+need_test=0
 # ==============================================================================================
 
 full_path=$(realpath $0)

--- a/test/apphub_scripts/template/run_torch.sh
+++ b/test/apphub_scripts/template/run_torch.sh
@@ -18,8 +18,8 @@ set -e
 example_name=
 
 # The training arguments
-# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:1
-# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 1"
+# 1. Usually we set the epochs:2, batch_size:2, max_train_steps_per_epoch:2
+# 2. The expression for the following setup is "--epochs 2 --batch_size 8 --max_train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
 train_info=
 


### PR DESCRIPTION
I noticed there are several apphubs that take ~1min/step to execute on CPU. This ends up taking a long time unnecessarily. Now reducing the train/eval steps per epoch to 1.

Also disabling the estimator.test in nightly test because its operation is the same as eval.