### PR TITLE
fix apphub fails in nightly test, p2

### DIFF
--- a/apphub/image_generation/cyclegan/cyclegan.ipynb
+++ b/apphub/image_generation/cyclegan/cyclegan.ipynb
@@ -463,7 +463,7 @@
    "source": [
     "from fastestimator.op.tensorop.model import ModelOp, UpdateOp\n",
     "\n",
-    "device = \"cuda\" if torch.cuda.is_available() else \"cpu\"\n",
+    "device = \"cuda:0\" if torch.cuda.is_available() else \"cpu\"\n",
     "\n",
     "network = fe.Network(ops=[\n",
     "    ModelOp(inputs=\"real_A\", model=g_AtoB, outputs=\"fake_B\"),\n",

--- a/apphub/image_generation/cyclegan/cyclegan_torch.py
+++ b/apphub/image_generation/cyclegan/cyclegan_torch.py
@@ -213,7 +213,7 @@ def get_estimator(weight=10.0,
                   data_dir=None):
     train_data, _ = load_data(batch_size=batch_size, root_dir=data_dir)
 
-    device = "cuda" if torch.cuda.is_available() else "cpu"
+    device = "cuda:0" if torch.cuda.is_available() else "cpu"
     pipeline = fe.Pipeline(
         train_data=train_data,
         ops=[

--- a/apphub/instance_detection/retinanet/retinanet.ipynb
+++ b/apphub/instance_detection/retinanet/retinanet.ipynb
@@ -671,7 +671,7 @@
     "        self.all_anchors, self.num_anchors_per_level = _get_fpn_anchor_box(width=input_shape[1], height=input_shape[0])\n",
     "        self.all_anchors = torch.Tensor(self.all_anchors)\n",
     "        if torch.cuda.is_available():\n",
-    "            self.all_anchors = self.all_anchors.to(\"cuda\")\n",
+    "            self.all_anchors = self.all_anchors.to(\"cuda:0\")\n",
     "\n",
     "    def forward(self, data, state):\n",
     "        cls_pred, loc_pred = data  # [Batch, #anchor, #num_classes], [Batch, #anchor, 4]\n",

--- a/apphub/instance_detection/retinanet/retinanet_torch.py
+++ b/apphub/instance_detection/retinanet/retinanet_torch.py
@@ -309,7 +309,7 @@ class PredictBox(TensorOp):
         self.all_anchors, self.num_anchors_per_level = _get_fpn_anchor_box(width=input_shape[1], height=input_shape[0])
         self.all_anchors = torch.Tensor(self.all_anchors)
         if torch.cuda.is_available():
-            self.all_anchors = self.all_anchors.to("cuda")
+            self.all_anchors = self.all_anchors.to("cuda:0")
 
     def forward(self, data, state):
         cls_pred, loc_pred = data  # [Batch, #anchor, #num_classes], [Batch, #anchor, 4]

--- a/apphub/style_transfer/fst_coco/fst_torch.py
+++ b/apphub/style_transfer/fst_coco/fst_torch.py
@@ -231,7 +231,7 @@ def get_estimator(batch_size=4,
                   data_dir=None):
     train_data, _ = mscoco.load_data(root_dir=data_dir, load_bboxes=False, load_masks=False, load_captions=False)
 
-    device = "cuda" if torch.cuda.is_available() else "cpu"
+    device = "cuda:0" if torch.cuda.is_available() else "cpu"
     style_img = cv2.imread(style_img_path)
     assert style_img is not None, "cannot load the style image, please go to the folder with style image"
     style_img = cv2.resize(style_img, (256, 256))

--- a/fastestimator/op/tensorop/model/model.py
+++ b/fastestimator/op/tensorop/model/model.py
@@ -53,9 +53,12 @@ class ModelOp(TensorOp):
         self.multi_inputs = False
 
     def build(self, framework: str, device: Optional[torch.device] = None) -> None:
-        if framework == "torch":
-            self.multi_inputs = len(inspect.signature(self.model.forward).parameters.keys()) > 1 and len(
-                self.inputs) > 1
+        if framework == "torch" and len(self.inputs) > 1:
+            if hasattr(self.model, "module"):
+                # multi-gpu models have module attribute
+                self.multi_inputs = len(inspect.signature(self.model.module.forward).parameters.keys()) > 1
+            else:
+                self.multi_inputs = len(inspect.signature(self.model.forward).parameters.keys()) > 1
 
     def get_fe_models(self) -> Set[Model]:
         return {self.model}

--- a/test/apphub_scripts/automl/rand_augment/run_nb.sh
+++ b/test/apphub_scripts/automl/rand_augment/run_nb.sh
@@ -22,7 +22,7 @@ example_name="rand_augment"
 # 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2 -p max_eval_steps_per_epoch 2 -p max_level 1 -p max_num_augment 1 -p final_step 20"
+train_info="-p epochs 2 -p batch_size 8 -p max_train_steps_per_epoch 2 -p max_eval_steps_per_epoch 2 -p max_level 1 -p max_num_augment 1 -p final_step 4"
 
 # ==============================================================================================
 


### PR DESCRIPTION
several issues found:

1. torch multi-gpu training will create a new instance on top of existing model instance, and its forward function signature is different. Therefore, for pytorch multi-gpu model, we need to check the model.module.forward instead.

2. it seems like recent change of using *args in `feed_forward` isn't working entirely well with pytorch multi-gpu. For example, in tensorOp, "cuda:0" is now required instead of simply "cuda".   In the future, all pytorch tensorOp should use nn.Module instead, it will improve the parallel training performance.

3. found one small mistake in randaugment notebook argument, now fixed