### PR TITLE
Reduce excessive key pruning warning printing

### DIFF
--- a/apphub/image_classification/pyramidnet/pyramidnet_tf.py
+++ b/apphub/image_classification/pyramidnet/pyramidnet_tf.py
@@ -150,3 +150,8 @@ def get_estimator(epochs=150,
                              train_steps_per_epoch=train_steps_per_epoch,
                              eval_steps_per_epoch=eval_steps_per_epoch)
     return estimator
+
+
+if __name__ == "__main__":
+    est = get_estimator()
+    est.fit()

--- a/apphub/image_classification/pyramidnet/pyramidnet_torch.py
+++ b/apphub/image_classification/pyramidnet/pyramidnet_torch.py
@@ -246,3 +246,8 @@ def get_estimator(epochs=150,
                              train_steps_per_epoch=train_steps_per_epoch,
                              eval_steps_per_epoch=eval_steps_per_epoch)
     return estimator
+
+
+if __name__ == "__main__":
+    est = get_estimator()
+    est.fit()

--- a/fastestimator/dataset/dataloader.py
+++ b/fastestimator/dataset/dataloader.py
@@ -27,6 +27,7 @@ from torch.utils.data.dataloader import _BaseDataLoaderIter, _MultiProcessingDat
 
 from fastestimator.dataset.extend_dataset import ExtendDataset
 from fastestimator.dataset.op_dataset import OpDataset
+from fastestimator.util.base_util import Suppressor
 from fastestimator.util.data import FilteredData
 
 
@@ -150,10 +151,11 @@ class FEDataLoader(DataLoader):
                 return _SPPostBatchIter(self)
             return _SPPreBatchIter(self)
         else:
-            if self.batch_size is None:
-                # We use 'fake' batch size here to identify datasets which perform their own batching
-                return _MPPostBatchIter(self)
-            return _MPPreBatchIter(self)
+            with Suppressor(allow_pyprint=True):  # Prevent unnecessary warnings about resetting numbers of threads
+                if self.batch_size is None:
+                    # We use 'fake' batch size here to identify datasets which perform their own batching
+                    return _MPPostBatchIter(self)
+                return _MPPreBatchIter(self)
 
     def __len__(self):
         return self.fe_samples_to_yield

--- a/fastestimator/util/base_util.py
+++ b/fastestimator/util/base_util.py
@@ -138,6 +138,10 @@ class Suppressor(object):
 
     This class is intentionally not @traceable.
 
+    Args:
+        allow_pyprint: Whether to allow python printing to occur still within this scope (and therefore only silence
+            printing from non-python sources like c).
+
     ```python
     x = lambda: print("hello")
     x()  # "hello"
@@ -146,6 +150,8 @@ class Suppressor(object):
     x()  # "hello"
     ```
     """
+    def __init__(self, allow_pyprint: bool = False):
+        self.allow_pyprint = allow_pyprint
 
     def __enter__(self) -> None:
         # This is not necessary to block printing, but lets the system know what's happening
@@ -171,6 +177,8 @@ class Suppressor(object):
         Args:
             dummy: The string which wanted to be printed.
         """
+        if self.allow_pyprint:
+            os.write(self.reals[0], dummy.encode('utf-8'))
 
     def flush(self) -> None:
         """A function to empty the current print buffer. No-op in this case.


### PR DESCRIPTION
add helper text (+2 squashed commits)
Squashed commits:
[00347ace] type hinting
[7fb93cf6] pyramidnet lacks test data (+6 squashed commits)
Squashed commits:
[8021d5a4] add python stubs to pyramidnet apphub
[9027ff34] remember what warnings you've already given
[570eb713] fix multi-processing issue with tests
[ef97b12e] finally block the errant c multiprocessing warnings
[8d90db85] improved control over warnings
[df4ad8eb] make warning printing only happen once regardless of number of threads being used in pipeline