### PR TITLE
making replacement optional in mscoco dataset, adding output channel arg in unet

### DIFF
--- a/fastestimator/architecture/pytorch/unet.py
+++ b/fastestimator/architecture/pytorch/unet.py
@@ -82,12 +82,13 @@ class UNet(nn.Module):
 
     Args:
         input_size: The size of the input tensor (channels, height, width).
+        output_channel: The number of output channels.
 
     Raises:
         ValueError: Length of `input_size` is not 3.
         ValueError: `input_size`[1] or `input_size`[2] is not a multiple of 16.
     """
-    def __init__(self, input_size: Tuple[int, int, int] = (1, 128, 128)) -> None:
+    def __init__(self, input_size: Tuple[int, int, int] = (1, 128, 128), output_channel: int = 1) -> None:
         UNet._check_input_size(input_size)
         super().__init__()
         self.input_size = input_size
@@ -103,7 +104,7 @@ class UNet(nn.Module):
                                   nn.ReLU(inplace=True),
                                   nn.Conv2d(64, 64, 3, padding=1),
                                   nn.ReLU(inplace=True),
-                                  nn.Conv2d(64, 1, 1),
+                                  nn.Conv2d(64, output_channel, 1),
                                   nn.Sigmoid())
 
         for layer in self.dec1:

--- a/fastestimator/architecture/tensorflow/unet.py
+++ b/fastestimator/architecture/tensorflow/unet.py
@@ -20,11 +20,12 @@ from tensorflow.keras.models import Model
 
 
 # noinspection PyPep8Naming
-def UNet(input_size: Tuple[int, int, int] = (128, 128, 1)) -> tf.keras.Model:
+def UNet(input_size: Tuple[int, int, int] = (128, 128, 1), output_channel: int = 1) -> tf.keras.Model:
     """A standard UNet implementation in TensorFlow
 
     Args:
         input_size: The size of the input tensor (height, width, channels).
+        output_channel: The number of output channels.
 
     Raises:
         ValueError: Length of `input_size` is not 3.
@@ -77,7 +78,7 @@ def UNet(input_size: Tuple[int, int, int] = (128, 128, 1)) -> tf.keras.Model:
     merge9 = concatenate([conv1, up9], axis=-1)
     conv9 = Conv2D(64, 3, **conv_config)(merge9)
     conv9 = Conv2D(64, 3, **conv_config)(conv9)
-    conv10 = Conv2D(1, 1, activation='sigmoid')(conv9)
+    conv10 = Conv2D(output_channel, 1, activation='sigmoid')(conv9)
     model = Model(inputs=inputs, outputs=conv10)
     return model
 


### PR DESCRIPTION
To be consistent with other literatures that use MSCOCO, sometimes we need to filter out certain samples without replacement. This replacement feature enables this behavior.

The unet architecture has output channel to be hardcoded at 1, making it configurable will improve flexibility.