### PR TITLE
fix the cifar/cifairlabel format issues that failed nightly test

### DIFF
--- a/fastestimator/dataset/data/cifair10.py
+++ b/fastestimator/dataset/data/cifair10.py
@@ -71,8 +71,7 @@ def load_data(root_dir: str = None, image_key: str = "x", label_key: str = "y") 
     fpath = os.path.join(image_extracted_path, 'test_batch')
     x_test, y_test = _load_batch(fpath)
 
-    y_train = np.reshape(y_train, (len(y_train), 1))
-    y_test = np.reshape(y_test, (len(y_test), 1))
+    y_test = np.array(y_test)
 
     x_train = x_train.transpose((0, 2, 3, 1))
     x_test = x_test.transpose((0, 2, 3, 1))

--- a/fastestimator/dataset/data/cifair100.py
+++ b/fastestimator/dataset/data/cifair100.py
@@ -66,8 +66,7 @@ def load_data(root_dir: str = None, image_key: str = "x", label_key: str = "y",
     fpath = os.path.join(image_extracted_path, 'test')
     x_test, y_test = _load_batch(fpath, label_key=label_mode + '_labels')
 
-    y_train = np.reshape(y_train, (len(y_train), 1))
-    y_test = np.reshape(y_test, (len(y_test), 1))
+    y_test = np.array(y_test)
 
     x_train = x_train.transpose((0, 2, 3, 1))
     x_test = x_test.transpose((0, 2, 3, 1))

--- a/fastestimator/dataset/data/cifar10.py
+++ b/fastestimator/dataset/data/cifar10.py
@@ -76,8 +76,7 @@ def load_data(root_dir: str = None, image_key: str = "x", label_key: str = "y",
     fpath = os.path.join(image_extracted_path, "test_batch")
     x_eval, y_eval = load_batch(fpath)
 
-    y_train = np.expand_dims(y_train, -1)
-    y_eval = np.expand_dims(y_eval, -1)
+    y_eval = np.array(y_eval)
 
     if channels_last:
         x_train = x_train.transpose(0, 2, 3, 1)

--- a/fastestimator/dataset/data/cifar100.py
+++ b/fastestimator/dataset/data/cifar100.py
@@ -76,8 +76,7 @@ def load_data(root_dir: str = None,
     eval_data_path = os.path.join(image_extracted_path, "test")
     x_eval, y_eval = load_batch(eval_data_path, label_key=label_mode + "_labels")
 
-    y_train = np.expand_dims(y_train, -1)
-    y_eval = np.expand_dims(y_eval, -1)
+    y_eval = np.array(y_eval)
 
     if channels_last:
         x_train = x_train.transpose(0, 2, 3, 1)


### PR DESCRIPTION
To support multi-dimensional cross entropy, the label shape can no longer be ambiguous like before.

For example, in torch's sparse cross entropy, we require the shape of `y_pred` to be in (B, ..., C) and `y_true`'s shape needs to be (B, ...) 

However, in case of Cifar/Cifair, y_true's shape is (B, ..., 1), which now violates the shape requirement. This violation used to be allowed under the 1-dimensional label assumption. But since the assumption no longer holds after the multi-dimensional cross entropy support, we need to start enforcing label's shape. 

Hence this PR.