### PR TITLE
Dice improvements

### DIFF
--- a/fastestimator/trace/metric/dice.py
+++ b/fastestimator/trace/metric/dice.py
@@ -19,6 +19,8 @@ from typing import Dict, Iterable, Optional, Union
 import numpy as np
 
 from fastestimator.backend._dice_score import dice_score
+from fastestimator.backend._reduce_max import reduce_max
+from fastestimator.backend._reduce_min import reduce_min
 from fastestimator.summary.summary import ValWithError
 from fastestimator.trace.meta._per_ds import per_ds
 from fastestimator.trace.trace import Trace
@@ -41,7 +43,8 @@ class Dice(Trace):
         mask_overlap: Whether an individual pixel can belong to only 1 class (False) or more than 1 class
             (True). If False, a threshold of 0.0 can be used to binarize by whatever the maximum predicted class is.
         exclude_channels: A collection of channel indices to be ignored.
-        channel_mapping: Optional names to give to each channel.
+        channel_mapping: Optional names to give to each channel. If provided then dice will be reported per-channel
+            in addition to reporting the aggregate value.
         include_std: Whether to also report standard deviations when computing dice scores.
         mode: What mode(s) to execute this Trace in. For example, "train", "eval", "test", or "infer". To execute
             regardless of mode, pass None. To execute in all modes except for a particular one, you can pass an argument
@@ -91,6 +94,20 @@ class Dice(Trace):
     def on_batch_end(self, data: Data) -> None:
         y_true, y_pred = data[self.true_key], data[self.pred_key]
 
+        # Do some quick input sanity checking to help prevent end user error (sparse or non-normalized masks)
+        test = reduce_min(y_pred)
+        assert 0 <= test, "Predicted mask values passed to the Dice trace should range from 0 to 1, but found a " \
+                          f"value of {test}"
+        test = reduce_max(y_pred)
+        assert test <= 1, "Predicted mask values passed to the Dice trace should range from 0 to 1, but found a " \
+                          f"value of {test}"
+        test = reduce_min(y_true)
+        assert 0 <= test, "Ground truth mask values passed to the Dice trace should range from 0 to 1, but found a " \
+                          f"value of {test}"
+        test = reduce_max(y_true)
+        assert test <= 1, "Ground truth mask values passed to the Dice trace should range from 0 to 1, but found a " \
+                          f"value of {test}"
+
         dice = to_number(dice_score(y_pred=y_pred,
                                     y_true=y_true,
                                     sample_average=False,
@@ -138,8 +155,8 @@ class Dice(Trace):
             if self.include_std:
                 std = np.std(ch_vals)
                 stds.append(std)
-            # If there are multiple channels then report each of them
-            if len(self.per_ch_dice.items()) > 1:
+            # If there are multiple channels and the user has provided channel names, then report each channel
+            if len(self.per_ch_dice.items()) > 1 and self.channel_mapping:
                 if self.include_std:
                     data.write_with_log(f"{self.outputs[0]}_{ch_name}", ValWithError(mean - std, mean, mean + std))
                 else:


### PR DESCRIPTION
have dice trace only report per-channel output if channel mappings are provided. Also include a sanity test on inputs to prevent user accidentally tricking themselves