### PR TITLE
fix restore wizard issue

### DIFF
--- a/fastestimator/summary/system.py
+++ b/fastestimator/summary/system.py
@@ -256,8 +256,7 @@ class System:
             json.dump(state, fp, indent=4)
         # Save all of the models / optimizer states
         for model in self.network.models:
-            if hasattr(model, "optimizer") and model.optimizer is not None:
-                save_model(model, save_dir=save_dir, save_optimizer=True)
+            save_model(model, save_dir=save_dir, save_optimizer=hasattr(model, "optimizer") and model.optimizer)
         # Save everything else
         objects = {
             'summary': self.summary,
@@ -336,10 +335,7 @@ class System:
         if not os.path.exists(weights_path):
             raise FileNotFoundError(f"Cannot find model weights file at {weights_path}")
         optimizer_path = os.path.join(base_path, f"{model.model_name}_opt.{optimizer_ext}")
-        if os.path.exists(optimizer_path):
-            load_model(model, weights_path=weights_path, load_optimizer=True)
-        else:
-            load_model(model, weights_path=weights_path)
+        load_model(model, weights_path=weights_path, load_optimizer=os.path.exists(optimizer_path))
 
     @staticmethod
     def _load_list(states: Dict[str, Any], state_key: str, in_memory_objects: List[Any]) -> None:


### PR DESCRIPTION
during `fe.build`, when model's `optimizer_fn=None`(like when calling a non-trainable model),  `Restorewizard` will try to save its optimizer, which will lead to error.

This PR will fix this behavior by checking whether the optimizer exists while saving the state, during loading, it would check for presence of optimizer file and load accordingly. 