### PR TITLE
rplace  sklearn dependency with scikit-learn

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ def get_dependency():
         'dot2tex==2.11.3',
         'gdown==3.12.0',
         'PySocks==1.7.1',
-        'uncertainty-calibration==0.0.9',
+        'uncertainty-calibration==0.1.4',
         'dill==0.3.4',
         'scikit-image==0.19.1',
         'prettytable==3.1.0',
@@ -67,7 +67,7 @@ def get_dependency():
         'plotly==5.7.0',
         'kaleido>=0.2.1',
         'orjson>=3.6.7',
-        'sklearn',
+        'scikit-learn',
         'lazy_loader',
     ]
     if os.name == "nt":


### PR DESCRIPTION
`uncertainty-calibration` is using sklearn as dependency, but its latest release corrected the dependency, therefore we will use their latest release.