### PR TITLE
improve stability of batchdataset probability sampling

### DIFF
--- a/fastestimator/dataset/batch_dataset.py
+++ b/fastestimator/dataset/batch_dataset.py
@@ -106,7 +106,7 @@ class BatchDataset(FEDataset):
             assert len(self.datasets) == len(self.probability), "the length of dataset must match probability"
             assert len(self.num_samples) == 1, "num_sample must be scalar for probability mode"
             assert len(self.datasets) > 1, "number of datasets must be more than one to use probability mode"
-            assert sum(self.probability) == 1, "sum of probability must be 1"
+            assert abs(sum(self.probability) - 1) < 1e-6, "sum of probability must be 1"
             for p in self.probability:
                 assert isinstance(p, float) and p > 0, "must provide positive float for probability distribution"
         else:

--- a/fastestimator/dataset/batch_dataset.py
+++ b/fastestimator/dataset/batch_dataset.py
@@ -106,7 +106,7 @@ class BatchDataset(FEDataset):
             assert len(self.datasets) == len(self.probability), "the length of dataset must match probability"
             assert len(self.num_samples) == 1, "num_sample must be scalar for probability mode"
             assert len(self.datasets) > 1, "number of datasets must be more than one to use probability mode"
-            assert abs(sum(self.probability) - 1) < 1e-6, "sum of probability must be 1"
+            assert abs(sum(self.probability) - 1) < 1e-8, "Probabilities must sum to 1"
             for p in self.probability:
                 assert isinstance(p, float) and p > 0, "must provide positive float for probability distribution"
         else:


### PR DESCRIPTION
sometimes when probability is provided as [0.5, 0.05, 0.05, 0.05, 0.05, 0.05 ..] , the summation is not exactly 1 due to truncation error. 

for example, 

```python
>>> sum([0.5, 0.05, 0.05])
0.6000000000000001
```
This PR should make it more robust. 