### PR TITLE
update uncertainty calibration 1.5.2 release

### DIFF
--- a/docker/stable/Dockerfile.cpu
+++ b/docker/stable/Dockerfile.cpu
@@ -48,4 +48,4 @@ RUN pip install torch==1.10.2+cpu torchvision==0.11.3+cpu torchaudio==0.10.2+cpu
 
 # install FastEstimator
 ARG InstallFE=True
-RUN if [ $InstallFE = "True" ]; then pip install fastestimator==1.5.1; fi
+RUN if [ $InstallFE = "True" ]; then pip install fastestimator==1.5.2; fi

--- a/docker/stable/Dockerfile.gpu
+++ b/docker/stable/Dockerfile.gpu
@@ -52,4 +52,4 @@ RUN pip install torch==1.10.2+cu113 torchvision==0.11.3+cu113 torchaudio==0.10.2
 
 # install FastEstimator
 ARG InstallFE=True
-RUN if [ $InstallFE = "True" ]; then pip install fastestimator==1.5.1; fi
+RUN if [ $InstallFE = "True" ]; then pip install fastestimator==1.5.2; fi

--- a/fastestimator/__init__.py
+++ b/fastestimator/__init__.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
     from fastestimator.network import Network, build
     from fastestimator.pipeline import Pipeline
 
-__version__ = '1.5.1'
+__version__ = '1.5.2'
 fe_deterministic_seed = None
 fe_history_path = None  # Where to save training histories. None for ~/fastestimator_data/history.db, False to disable
 fe_build_count = 0

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ def get_dependency():
         'dot2tex==2.11.3',
         'gdown==3.12.0',
         'PySocks==1.7.1',
-        'uncertainty-calibration==0.0.9',
+        'uncertainty-calibration==0.1.4',
         'dill==0.3.4',
         'scikit-image==0.19.1',
         'prettytable==3.1.0',


### PR DESCRIPTION
So the uncertainty calibration is installing `sklearn`, it causes problem during FE installation, therefore voided our 1.5.1 release.

Now upgrading to 1.5.2 with the new uncertainty calibration version.