### PR TITLE
Slicers

### DIFF
--- a/fastestimator/architecture/tensorflow/lenet.py
+++ b/fastestimator/architecture/tensorflow/lenet.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Tuple
+from typing import TYPE_CHECKING, Tuple
 
 import tensorflow as tf
 from tensorflow.keras import Sequential, layers
+
+if TYPE_CHECKING:
+    from tensorflow.python.keras import Sequential, layers
 
 
 # noinspection PyPep8Naming

--- a/fastestimator/architecture/tensorflow/lenet.py
+++ b/fastestimator/architecture/tensorflow/lenet.py
@@ -15,10 +15,11 @@
 from typing import TYPE_CHECKING, Tuple
 
 import tensorflow as tf
-from tensorflow.keras import Sequential, layers
 
 if TYPE_CHECKING:
     from tensorflow.python.keras import Sequential, layers
+else:
+    from tensorflow.keras import Sequential, layers
 
 
 # noinspection PyPep8Naming

--- a/fastestimator/backend/_abs.py
+++ b/fastestimator/backend/_abs.py
@@ -12,16 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import TypeVar
-
 import numpy as np
 import tensorflow as tf
 import torch
 
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor, np.ndarray)
+from fastestimator.types import ArrayT
 
 
-def abs(tensor: Tensor) -> Tensor:
+def abs(tensor: ArrayT) -> ArrayT:
     """Compute the absolute value of a tensor.
 
     This method can be used with Numpy data:

--- a/fastestimator/backend/_get_shape.py
+++ b/fastestimator/backend/_get_shape.py
@@ -12,16 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import TypeVar
+from typing import Tuple
 
 import numpy as np
 import tensorflow as tf
 import torch
 
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor, np.ndarray)
+from fastestimator.types import Array
 
 
-def get_shape(tensor: Tensor) -> Tensor:
+def get_shape(tensor: Array) -> Tuple[int, ...]:
     """Find shape of a given `tensor`.
 
     This method can be used with Numpy data:

--- a/fastestimator/backend/_to_tensor.py
+++ b/fastestimator/backend/_to_tensor.py
@@ -12,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Collection, TypeVar, Union, overload
+from typing import Collection, Literal, Union, overload
 
 import numpy as np
 import tensorflow as tf
 import torch
 
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor, np.ndarray)
-CollectionT = TypeVar('CollectionT', bound=Collection)
+from fastestimator.types import Array, ArrayT, CollectionT
 
 
 @overload
@@ -28,7 +27,23 @@ def to_tensor(data: CollectionT, target_type: str, shared_memory: bool = False) 
 
 
 @overload
-def to_tensor(data: Union[Tensor, float, int], target_type: str, shared_memory: bool = False) -> Tensor:
+def to_tensor(data: Union[Array, float, int], target_type: Literal['tf'], shared_memory: bool = False) -> tf.Tensor:
+    ...
+
+
+@overload
+def to_tensor(data: Union[Array, float, int], target_type: Literal['torch'],
+              shared_memory: bool = False) -> torch.Tensor:
+    ...
+
+
+@overload
+def to_tensor(data: Union[Array, float, int], target_type: Literal['np'], shared_memory: bool = False) -> np.ndarray:
+    ...
+
+
+@overload
+def to_tensor(data: Union[Array, float, int], target_type: str, shared_memory: bool = False) -> Array:
     ...
 
 
@@ -37,8 +52,8 @@ def to_tensor(data: None, target_type: str, shared_memory: bool = False) -> None
     ...
 
 
-def to_tensor(data: Union[Collection, Tensor, float, int, None], target_type: str,
-              shared_memory: bool = False) -> Union[Collection, Tensor, None]:
+def to_tensor(data: Union[Collection, Array, float, int, None], target_type: str,
+              shared_memory: bool = False) -> Union[Collection, ArrayT, Array, None]:
     """Convert tensors within a collection of `data` to a given `target_type` recursively.
 
     This method can be used with Numpy data:

--- a/fastestimator/dataset/csv_dataset.py
+++ b/fastestimator/dataset/csv_dataset.py
@@ -47,7 +47,6 @@ class CSVDataset(InMemoryDataset):
         kwargs: Other arguments to be passed through to pandas csv reader function. See the pandas docs for details:
             https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html.
     """
-
     def __init__(self,
                  file_path: str,
                  delimiter: str = ",",
@@ -76,4 +75,7 @@ class CSVDataset(InMemoryDataset):
             else:
                 raise ValueError(f"Received an unexpected datatype for include_if: {type(include_if)}")
         self.parent_path = os.path.dirname(file_path)
+        # Remove banned characters from column names since users won't be able to access them later. This can happen,
+        # for example, when a csv file is missing one or more headers (which would normally then render as "Unnamed: 1")
+        df.rename(lambda x: x.replace(":", "").replace("|", "").replace(";", ""), axis='columns', inplace=True)
         super().__init__(df.to_dict(orient='index'))

--- a/fastestimator/dataset/data/em_3d.py
+++ b/fastestimator/dataset/data/em_3d.py
@@ -72,16 +72,16 @@ def get_encode_label(label_data):
     return encoded_label
 
 
-def load_data(root_dir: Optional[str] = None, image_key: str = "image",
-              label_key: str = "label") -> Tuple[NumpyDataset, NumpyDataset]:
+def load_data(root_dir: Optional[str] = None, image_key: str = "image", label_key: str = "label",
+              tile: bool = True) -> Tuple[NumpyDataset, NumpyDataset]:
     """Load and return the 3d electron microscope platelet dataset.
 
 
     Sourced from https://bio3d-vision.github.io/platelet-description.
     Electronic Microscopy 3D cell dataset, consists of 2 3D images, one 800x800x50 and the other 800x800x24.
-    The 800x800x50 is used as training dataset and 800x800x24 is used for validation. Instead of using the entire
-    800x800 images, the 800x800x50 is tiled into 256x256x24 tiles with an overlap of 128 producing around 75 training
-    images and similarly the 800x800x24 image is tiled to produce 25 validation images.
+    The 800x800x50 is used as training dataset and 800x800x24 is used for validation. If `tile` is True, then instead
+    of using the entire 800x800 images, the 800x800x50 is tiled into 256x256x24 tiles with an overlap of 128 producing
+    around 75 training images and similarly the 800x800x24 image is tiled to produce 25 validation images.
 
     The method downloads the dataset from google drive and provides train and validation NumpyDataset.
     While the dataset contains encoded value 0 as background, its omitted in the one hot encoded class label provided
@@ -99,6 +99,7 @@ def load_data(root_dir: Optional[str] = None, image_key: str = "image",
             the data will be saved into `fastestimator_data` under the user's home directory.
         image_key: The key for image.
         label_key: The key for label.
+        tile: Whether to tile the image into multiple smaller images, or to return the individual volumes directly.
 
     Returns:
         (train_data, eval_data)
@@ -126,6 +127,19 @@ def load_data(root_dir: Optional[str] = None, image_key: str = "image",
     encoded_train_label = get_encode_label(train_label_data)
     encoded_val_label = get_encode_label(val_label_data)
 
+    if not tile:
+        train_data = np.expand_dims(np.moveaxis(train_data, 0, -1), 0)
+        train_labels = np.expand_dims(np.moveaxis(encoded_train_label, 0, -1), 0)
+        train_labels = np.eye(7, dtype=np.float32)[train_labels].take(indices=range(1, 7), axis=-1)
+
+        val_data = np.expand_dims(np.moveaxis(val_data, 0, -1), 0)
+        val_labels = np.expand_dims(np.moveaxis(encoded_val_label, 0, -1), 0)
+        val_labels = np.eye(7, dtype=np.float32)[val_labels].take(indices=range(1, 7), axis=-1)
+
+        train_data = NumpyDataset({image_key: train_data, label_key: train_labels})
+        eval_data = NumpyDataset({image_key: val_data, label_key: val_labels})
+        return train_data, eval_data
+
     train_data_slices = [train_data[0:24], train_data[13:37], train_data[26:50]]
     train_label_slices = [encoded_train_label[0:24], encoded_train_label[13:37], encoded_train_label[26:50]]
 
@@ -137,8 +151,8 @@ def load_data(root_dir: Optional[str] = None, image_key: str = "image",
     val_data_tiles = np.moveaxis(generate_tiles(val_data), 1, -1)
     val_label_tiles = np.moveaxis(generate_tiles(encoded_val_label), 1, -1)
 
-    val_label_tiles = np.eye(7)[val_label_tiles].take(indices=range(1, 7), axis=-1)
-    training_label_tiles = np.eye(7)[training_label_tiles].take(indices=range(1, 7), axis=-1)
+    val_label_tiles = np.eye(7, dtype=np.float32)[val_label_tiles].take(indices=range(1, 7), axis=-1)
+    training_label_tiles = np.eye(7, dtype=np.float32)[training_label_tiles].take(indices=range(1, 7), axis=-1)
 
     train_data = NumpyDataset({image_key: training_data_tiles, label_key: training_label_tiles})
     eval_data = NumpyDataset({image_key: val_data_tiles, label_key: val_label_tiles})

--- a/fastestimator/dataset/op_dataset.py
+++ b/fastestimator/dataset/op_dataset.py
@@ -196,6 +196,8 @@ class OpDataset(Dataset):
         Args:
             candidates: Unused keys which you might need to print a warning message about.
         """
+        if not candidates:
+            return
         # Keys can't contain the ":" or ";" character due to check_io_names base_util function
         warned = set((str(cls.warned.value, 'utf8') or "").split(":"))
         if ";" not in warned:

--- a/fastestimator/network.py
+++ b/fastestimator/network.py
@@ -41,7 +41,7 @@ from fastestimator.op.tensorop.tensorop import TensorOp
 from fastestimator.pipeline import Pipeline
 from fastestimator.schedule.schedule import EpochScheduler, RepeatScheduler, Scheduler, get_current_items
 from fastestimator.slicer.slicer import Slicer, forward_slicers, reverse_slicers, sanity_assert_slicers
-from fastestimator.types import Array, Model, Tensor
+from fastestimator.types import Array, Model
 from fastestimator.util.base_util import NonContext, filter_nones, to_list, warn
 from fastestimator.util.traceability_util import trace_model, traceable
 from fastestimator.util.util import Suppressor, detach_tensors, get_batch_size, get_device, get_num_gpus, \

--- a/fastestimator/op/numpyop/numpyop.py
+++ b/fastestimator/op/numpyop/numpyop.py
@@ -271,7 +271,8 @@ class RemoveIf(NumpyOp):
 def forward_numpyop(ops: List[NumpyOp],
                     data: MutableMapping[str, Any],
                     state: Dict[str, Any],
-                    batched: Optional[str] = None) -> Optional[FilteredData]:
+                    batched: Optional[str] = None,
+                    shared: bool = True) -> Optional[FilteredData]:
     """Call the forward function for list of NumpyOps, and modify the data dictionary in place.
 
     Args:
@@ -280,6 +281,8 @@ def forward_numpyop(ops: List[NumpyOp],
         state: Information about the current execution context, ex. {"mode": "train"}. Must contain at least the mode.
         batched: Whether the `data` is batched or not. If it is batched, provide the string ('tf', 'torch', or 'np')
             indicating which type of tensors the batch contains.
+        shared: Whether you want to place the resulting data into multi-processing shared memory. Only applicable when
+            `batched` is 'torch'.
     """
     if not ops:
         # Shortcut to prevent wasting time in to_tensor calls if there aren't any ops
@@ -310,5 +313,5 @@ def forward_numpyop(ops: List[NumpyOp],
     if batched:
         # Cast data back to original tensor type after performing batch forward
         for key, val in data.items():
-            data[key] = to_tensor(val, target_type=batched, shared_memory=True)
+            data[key] = to_tensor(val, target_type=batched, shared_memory=shared)
     return None

--- a/fastestimator/op/tensorop/model/model.py
+++ b/fastestimator/op/tensorop/model/model.py
@@ -14,19 +14,17 @@
 # ==============================================================================
 import inspect
 from functools import partial
-from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, TypeVar, Union
+from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union
 
 import tensorflow as tf
 import torch
 
 from fastestimator.backend._feed_forward import feed_forward
 from fastestimator.op.tensorop.tensorop import TensorOp
+from fastestimator.types import Model, Tensor
 from fastestimator.util.base_util import to_list, warn
 from fastestimator.util.traceability_util import FeInputSpec, traceable
 from fastestimator.util.util import get_num_devices
-
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor)
-Model = TypeVar('Model', tf.keras.Model, torch.nn.Module)
 
 
 @traceable()
@@ -55,7 +53,7 @@ class ModelOp(TensorOp):
             different between single-gpu and multi-gpu environments, though we attempt to prevent this.
     """
     def __init__(self,
-                 model: Union[tf.keras.Model, torch.nn.Module],
+                 model: Model,
                  inputs: Union[None, str, Iterable[str]] = None,
                  outputs: Union[None, str, Iterable[str]] = None,
                  mode: Union[None, str, Iterable[str]] = None,

--- a/fastestimator/schedule/schedule.py
+++ b/fastestimator/schedule/schedule.py
@@ -187,18 +187,18 @@ def get_signature_epochs(items: List[Any], total_epochs: int, mode: Optional[str
 
 
 @overload
-def get_current_items(items: Iterable[Union[T, Scheduler[T]]],
+def get_current_items(items: Iterable[Union[T, Scheduler[T], T2, Scheduler[T2]]],
                       run_modes: Optional[Union[str, Iterable[str]]] = None,
                       epoch: Optional[int] = None,
-                      ds_id: Optional[str] = None) -> List[T]:
+                      ds_id: Optional[str] = None) -> List[Union[T, T2]]:
     ...
 
 
 @overload
-def get_current_items(items: Iterable[Union[T, T2, Scheduler[T], Scheduler[T2]]],
+def get_current_items(items: Iterable[Union[T, Scheduler[T]]],
                       run_modes: Optional[Union[str, Iterable[str]]] = None,
                       epoch: Optional[int] = None,
-                      ds_id: Optional[str] = None) -> List[Union[T, T2]]:
+                      ds_id: Optional[str] = None) -> List[T]:
     ...
 
 

--- a/fastestimator/slicer/__init__.py
+++ b/fastestimator/slicer/__init__.py
@@ -1,0 +1,28 @@
+# Copyright 2023 The FastEstimator Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from typing import TYPE_CHECKING
+
+import lazy_loader as lazy
+
+__getattr__, __dir__, __all__ = lazy.attach(__name__, submod_attrs={'slicer': ['Slicer'],
+                                                                    'axis_slicer': ['AxisSlicer'],
+                                                                    'mean_unslicer': ['MeanUnslicer'],
+                                                                    'sliding_slicer': ['SlidingSlicer']})
+
+if TYPE_CHECKING:
+    from fastestimator.slicer.axis_slicer import AxisSlicer
+    from fastestimator.slicer.mean_unslicer import MeanUnslicer
+    from fastestimator.slicer.slicer import Slicer
+    from fastestimator.slicer.sliding_slicer import SlidingSlicer

--- a/fastestimator/slicer/axis_slicer.py
+++ b/fastestimator/slicer/axis_slicer.py
@@ -1,0 +1,67 @@
+# Copyright 2023 The FastEstimator Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from typing import Iterable, List, Sequence, Tuple, Union
+
+from fastestimator.backend._concat import concat
+from fastestimator.backend._expand_dims import expand_dims
+from fastestimator.backend._get_shape import get_shape
+from fastestimator.slicer.slicer import Slicer
+from fastestimator.types import Tensor
+from fastestimator.util.traceability_util import traceable
+
+
+@traceable()
+class AxisSlicer(Slicer):
+    """A slicer which cuts along a given axis.
+
+    This slicer cuts volumes along the specified axis, reducing the total dimension of the input by 1. For example, if
+    you want to feed a batched channel-first 3D volume [B, C, W, H, D] into a 2D model [B, C, W, H] then you could set
+    `axis=-1` or `axis=4`.
+
+    Args:
+        slice: The input key(s) which this Slicer slices. Data which this slicer does not cut will be replicated across
+            the resulting minibatches so that the network ops always have access to all of the batch keys.
+        unslice: The input key(s) which this Slicer un-slices. By default (empty tuple) the Slicer will un-slice
+            whatever keys were specified in `slice`. If you do not want to un-slice those keys, then pass None or
+            manually specify the specific key(s) which you would like this slicer to un-slice.
+        axis: The axis along which to cut the data
+        mode: What mode(s) to invoke this Slicer in. For example, "train", "eval", "test", or "infer". To invoke
+            regardless of mode, pass None. To invoke in all modes except for a particular one, you can pass an argument
+            like "!infer" or "!train".
+        ds_id: What dataset id(s) to invoke this Slicer in. To invoke regardless of ds_id, pass None. To invoke in all
+            ds_ids except for a particular one, you can pass an argument like "!ds1".
+    """
+    def __init__(self,
+                 axis: int,
+                 slice: Union[None, str, Sequence[str]] = None,
+                 unslice: Union[None, str, Sequence[str]] = (),
+                 mode: Union[None, str, Iterable[str]] = None,
+                 ds_id: Union[None, str, Iterable[str]] = None) -> None:
+        super().__init__(slice=slice, unslice=unslice, mode=mode, ds_id=ds_id)
+        assert isinstance(axis, int), f"Axis must be an integer, got {type(axis)}"
+        self.axis = axis
+
+    def _slice_batch(self, batch: Tensor) -> List[Tensor]:
+        shape = get_shape(batch)
+        cut_index: List[Union[slice, int]] = [slice(None) for _ in range(len(shape))]
+        slices = []
+        for i in range(0, shape[self.axis]):
+            cut_index[self.axis] = i
+            slices.append(batch[cut_index])
+        return slices
+
+    def _unslice_batch(self, slices: Tuple[Tensor, ...], key: str) -> Tensor:
+        expanded = [expand_dims(elem, self.axis) for elem in slices]
+        return concat(expanded, axis=self.axis)

--- a/fastestimator/slicer/mean_unslicer.py
+++ b/fastestimator/slicer/mean_unslicer.py
@@ -1,0 +1,47 @@
+# Copyright 2023 The FastEstimator Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from typing import Iterable, Sequence, Tuple, Union
+
+from fastestimator.backend._zeros_like import zeros_like
+from fastestimator.slicer.slicer import Slicer
+from fastestimator.types import Tensor
+from fastestimator.util.traceability_util import traceable
+
+
+@traceable()
+class MeanUnslicer(Slicer):
+    """A slicer which re-combines mini-batches via averaging.
+
+    Args:
+        unslice: The input key(s) which this Slicer un-slices.
+        axis: The axis along which to cut the data
+        mode: What mode(s) to invoke this Slicer in. For example, "train", "eval", "test", or "infer". To invoke
+            regardless of mode, pass None. To invoke in all modes except for a particular one, you can pass an argument
+            like "!infer" or "!train".
+        ds_id: What dataset id(s) to invoke this Slicer in. To invoke regardless of ds_id, pass None. To invoke in all
+            ds_ids except for a particular one, you can pass an argument like "!ds1".
+    """
+    def __init__(self,
+                 unslice: Union[str, Sequence[str]],
+                 mode: Union[None, str, Iterable[str]] = None,
+                 ds_id: Union[None, str, Iterable[str]] = None) -> None:
+        super().__init__(slice=None, unslice=unslice, mode=mode, ds_id=ds_id)
+
+    def _unslice_batch(self, slices: Tuple[Tensor, ...], key: str) -> Tensor:
+        mean = zeros_like(slices[0])
+        for minibatch in slices:
+            mean += minibatch
+        mean /= len(slices)
+        return mean

--- a/fastestimator/slicer/slicer.py
+++ b/fastestimator/slicer/slicer.py
@@ -1,0 +1,212 @@
+# Copyright 2023 The FastEstimator Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from typing import Dict, Iterable, List, MutableMapping, Sequence, Set, Tuple, Union
+
+from fastestimator.types import Tensor
+from fastestimator.util.base_util import check_ds_id, check_io_names, parse_modes, to_list, to_set
+from fastestimator.util.traceability_util import traceable
+
+
+@traceable()
+class Slicer():
+    """A base class for FastEstimator Slicers.
+
+    Slicers cut batches into mini-batches in order to pass them through the network, then re-assemble them after
+    bringing all of the pieces back together on the CPU before handing them off to network post-processing and traces.
+
+    Args:
+        slice: The input key(s) which this Slicer slices. Data which this slicer does not cut will be replicated across
+            the resulting minibatches so that the network ops always have access to all of the batch keys.
+        unslice: The input key(s) which this Slicer un-slices. By default (empty tuple) the Slicer will un-slice
+            whatever keys were specified in `slice`. If you do not want to un-slice those keys, then pass None or
+            manually specify the specific keys which you would like this slicer to un-slice.
+        mode: What mode(s) to invoke this Slicer in. For example, "train", "eval", "test", or "infer". To invoke
+            regardless of mode, pass None. To invoke in all modes except for a particular one, you can pass an argument
+            like "!infer" or "!train".
+        ds_id: What dataset id(s) to invoke this Slicer in. To invoke regardless of ds_id, pass None. To invoke in all
+            ds_ids except for a particular one, you can pass an argument like "!ds1".
+    """
+    slice_inputs: List[str]
+    unslice_inputs: List[str]
+    mode: Set[str]
+    ds_id: Set[str]
+    minibatch_size: int = 0  # Used for traceability
+
+    def __init__(self,
+                 slice: Union[None, str, Sequence[str]] = None,
+                 unslice: Union[None, str, Sequence[str]] = (),
+                 mode: Union[None, str, Iterable[str]] = None,
+                 ds_id: Union[None, str, Iterable[str]] = None) -> None:
+        if isinstance(unslice, tuple) and len(unslice) == 0:
+            # If unslice keys are not specified, then use the slice keys by default for convenience
+            unslice = slice
+        self.slice_inputs = check_io_names(to_list(slice))
+        self.unslice_inputs = check_io_names(to_list(unslice))
+        self.mode = parse_modes(to_set(mode))
+        self.ds_id = check_ds_id(to_set(ds_id))
+        self.minibatch_size = 0
+        if not self.slice_inputs and not self.unslice_inputs:
+            raise ValueError("At least one of slice_inputs or unslice_inputs should be provided")
+        if self.slice_inputs and type(self)._slice_batch == Slicer._slice_batch:
+            raise NotImplementedError(
+                f"Slice inputs were provided, but {type(self).__name__} does not implement _slice_batch")
+        if self.unslice_inputs and type(self)._unslice_batch == Slicer._unslice_batch:
+            raise NotImplementedError(
+                f"Unslice inputs were provided, but {type(self).__name__} does not implement _unslice_batch")
+
+    def slice_batches(self, batches: Tuple[Tensor, ...]) -> List[Tuple[Tensor, ...]]:
+        """A method to convert one or more data tensors into slices.
+
+        Args:
+            batches: One or more data tensors, in a 1-1 relationship with self.slice_inputs
+
+        Returns:
+            The slices corresponding to each of the input batch(es)
+        """
+        slices = [self._slice_batch(batch) for batch in batches]
+        self.minibatch_size = len(slices[0])
+        for sl in slices[1:]:
+            assert len(sl) == self.minibatch_size, \
+                f"Slicer produced inconsistent number of slices over inputs: {self.slice_inputs}"
+        return [minibatch for minibatch in zip(*slices)]
+
+    def _slice_batch(self, batch: Tensor) -> List[Tensor]:
+        """A method to convert a single tensor into a list of smaller slices.
+
+        Child classes which support slice_inputs must implement this method.
+
+        Args:
+            batch: A tensor of data to be cut apart.
+
+        Returns:
+            The input tensor, but cut into slices
+        """
+        raise NotImplementedError
+
+    def _unslice_batch(self, slices: Tuple[Tensor, ...], key: str) -> Tensor:
+        """A method to convert a list of smaller slices back into a single tensor.
+
+        Child classes which support unslice_inputs must implement this method.
+
+        Args:
+            slices: Small slices of data to be re-combined
+            key: The data dictionary key corresponding to these slices (in case you need to use it for something). Note
+                that slicers are not guaranteed to be provided with all of their declared unslice_inputs during each
+                step. If the key is not used later on during training, then we do not bother un-slicing it.
+
+        Returns:
+            A single tensor produced by combining all of the available slices.
+        """
+        raise NotImplementedError
+
+
+def sanity_assert_slicers(slicers: List[Slicer]) -> None:
+    """A sanity test to ensure that slicers in a given list don't interfere with each-other.
+
+    Args:
+        slicers: The slicers to be run during a given batch.
+
+    Raises:
+        ValueError: If multiple slicers attempt to slice/unslice the same keys simultaneously.
+    """
+    if len(slicers) == 0:
+        return
+    slice_inputs = set(slicers[0].slice_inputs)
+    unslice_inputs = set(slicers[0].unslice_inputs)
+    for slicer in slicers[1:]:
+        more_s_inputs = set(slicer.slice_inputs)
+        more_u_inputs = set(slicer.unslice_inputs)
+        if slice_inputs & more_s_inputs:
+            raise ValueError(
+                f"Multiple Slicers tried to slice the same keys simultaneously: {slice_inputs & more_s_inputs}")
+        if unslice_inputs & more_u_inputs:
+            raise ValueError(
+                f"Multiple Slicers tried to un-slice the same keys simultaneously: {unslice_inputs & more_u_inputs}")
+        slice_inputs |= more_s_inputs
+        unslice_inputs |= more_u_inputs
+    if unslice_inputs and not slice_inputs:
+        raise ValueError("Cannot unslice keys if no slicing is performed.")
+
+
+def forward_slicers(slicers: List[Slicer], data: MutableMapping[str, Tensor]) -> List[Dict[str, Tensor]]:
+    """Perform a forward pass over a list of slicers, cutting a batch of data apart into multiple mini-batches.
+
+    Any data (keys) which are not explicitly handled by a Slicer in the input list will simply be replicated across
+    all of the mini-batches produced by this function.
+
+    Args:
+        slicers: The slicers with which to cut apart the batch.
+        data: The batch to be cut apart.
+
+    Raises:
+        ValueError: If the slicers produce an inconsistent number of mini-batches.
+
+    Returns:
+        A list of mini-batches created by slicing the input batch.
+    """
+    slices = []
+    sliced_inputs = set()
+    for slicer in slicers:
+        if not slicer.slice_inputs:
+            continue
+        input_data = tuple([data[key] for key in slicer.slice_inputs])
+        sliced_data = slicer.slice_batches(input_data)
+        if not slices:
+            slices = [{key: value for key, value in zip(slicer.slice_inputs, element)} for element in sliced_data]
+        else:
+            if len(sliced_data) != len(slices):
+                raise ValueError(
+                    f"Multiple Slicers produced an inconsistent number of slices: {len(slices)} vs {len(sliced_data)}")
+            for minibatch, new_entry in zip(slices, [{key: value for key, value in zip(slicer.slice_inputs, element)}
+                                                     for element in sliced_data]):
+                minibatch.update(new_entry)
+        sliced_inputs |= set(slicer.slice_inputs)
+    leftover_data = {key: data[key] for key in data.keys() - sliced_inputs}
+    for minibatch in slices:
+        minibatch.update(leftover_data)
+    return slices
+
+
+def reverse_slicers(slicers: List[Slicer], data: List[MutableMapping[str, Tensor]],
+                    original_data: Dict[str, Tensor]) -> Dict[str, Tensor]:
+    """Compile a list of mini-batches back into a single batch of data, according to a given list of slicers.
+
+    Note that the `data` provided need not contain all of the keys requested by the slicer.unslice_inputs. Missing keys
+    will simply be skipped, with the assumption that the user does not care about that data down-stream. Any data not
+    explicitly handled by a slicer here will be passed back based on its value in `original_data` or else the first
+    occurrence in the `data` list, with any differing values in subsequent mini-batches being ignored.
+
+    Args:
+        slicers: The slicers to use when re-combining the mini-batches
+        data: A list of mini-batches.
+        original_data: The pre-sliced data. Used as a fallback when slicers don't handle un-slicing things.
+
+    Returns:
+        A single combined batch of data.
+    """
+    if not data:
+        return {}
+    batch = {}
+    processed_keys = set()
+    for slicer in slicers:
+        for key in slicer.unslice_inputs:
+            if key not in data[0]:
+                continue
+            slices = tuple([minibatch[key] for minibatch in data])
+            batch[key] = slicer._unslice_batch(slices, key=key)
+            processed_keys.add(key)
+    leftover_data = {key: original_data.get(key, data[0][key]) for key in data[0].keys() - processed_keys}
+    batch.update(leftover_data)
+    return batch

--- a/fastestimator/slicer/sliding_slicer.py
+++ b/fastestimator/slicer/sliding_slicer.py
@@ -1,0 +1,215 @@
+# Copyright 2023 The FastEstimator Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+from typing import Iterable, List, Optional, Sequence, Tuple, Union
+
+import tensorflow as tf
+import torch
+
+from fastestimator.backend._expand_dims import expand_dims
+from fastestimator.backend._get_shape import get_shape
+from fastestimator.backend._squeeze import squeeze
+from fastestimator.backend._to_tensor import to_tensor
+from fastestimator.slicer.slicer import Slicer
+from fastestimator.types import Tensor, TensorT
+from fastestimator.util.base_util import to_list
+from fastestimator.util.traceability_util import traceable
+
+
+@traceable()
+class SlidingSlicer(Slicer):
+    """A slicer which cuts inputs using a sliding window.
+
+    This slicer cuts inputs using a sliding window, which should have the same rank as the input array. For example, if
+    you want to feed a giant batched channel-first 2D image [B, C, W, H] into a model which can only handle smaller
+    images of size [B, C, W2, H2] then you could set window_size=[-1, -1, W2, H2].
+
+    Args:
+        window_size: The size of your sliding window. Use -1 for any axis when you want to copy the size from the input.
+        strides: How far to step in each direction each time you move a sliding window. Use 0 for each axis which you
+            set as -1 in `window_size`. If you set `strides` < `window_size` you will get overlapping windows. If you
+            set `strides` > `window_size` you will drop data from your input. If a single integer is provided if will be
+            used for every axis where sliding occurs. If an empty sequence (default) is provided, then `strides` will be
+            set equal to `window_size` such that there is no overlap between windows.
+        pad_mode: One of 'drop', 'partial', or 'constant'. If 'drop' then the final slice along various axes will be
+            dropped if the `window_size` does not tile perfectly with the input shape. If 'partial' then the final slice
+            along various axes may be of a different (smaller) shape than other slices (if `window_size` does not
+            perfectly tile the input shape). If 'constant' then the final slice along various axis will be filled out by
+            `pad_val`.
+        pad_val: The value to fill out the input with when `pad_mode` is 'constant'.
+        slice: The input key(s) which this Slicer slices. Data which this slicer does not cut will be replicated across
+            the resulting minibatches so that the network ops always have access to all of the batch keys. If multiple
+            keys are provided here it is expected that they all have the same shape.
+        unslice: The input key(s) which this Slicer un-slices. By default (empty tuple) the Slicer will un-slice
+            whatever keys were specified in `slice`. If you do not want to un-slice those keys, then pass None or
+            manually specify the specific key(s) which you would like this slicer to un-slice.
+        unslice_mode: When re-combining your slices, how to you want to handle overlapping regions? Options are 'sum'
+            or 'avg'. Regardless of option, any gaps between slices will be filled in by the `pad_val`.
+        unslice_shape: The shape of your final tensor(s) after you unslice it. This argument is only required if you did
+            not provide `slice` keys. If `slice` keys were provided, then the unslice_shape is inferred at every step
+            based on the shape of the inputs before slicing.
+        squeeze_window: If enabled, then all axes which are set to 1 in `window_size` will be squeezed out during the
+            network forward pass, and re-introduced later during un-slicing. This makes it more convenient if you want
+            to, for example, use SlidingSlicer to feed 3D image data into a 2D network (though you may want to instead
+            consider AxisSlicer as a simpler way to achieve that purpose).
+        mode: What mode(s) to invoke this Slicer in. For example, "train", "eval", "test", or "infer". To invoke
+            regardless of mode, pass None. To invoke in all modes except for a particular one, you can pass an argument
+            like "!infer" or "!train".
+        ds_id: What dataset id(s) to invoke this Slicer in. To invoke regardless of ds_id, pass None. To invoke in all
+            ds_ids except for a particular one, you can pass an argument like "!ds1".
+    """
+    def __init__(self,
+                 window_size: Sequence[int],
+                 strides: Union[int, Sequence[int]] = (),
+                 pad_mode: str = 'drop',
+                 pad_val: Union[int, float] = 0.0,
+                 slice: Union[None, str, Sequence[str]] = None,
+                 unslice: Union[None, str, Sequence[str]] = (),
+                 unslice_mode: str = "avg",
+                 unslice_shape: Optional[Tuple[int, ...]] = None,
+                 squeeze_window: bool = False,
+                 mode: Union[None, str, Iterable[str]] = None,
+                 ds_id: Union[None, str, Iterable[str]] = None) -> None:
+        super().__init__(slice=slice, unslice=unslice, mode=mode, ds_id=ds_id)
+        self.window_size = to_list(window_size)
+        assert len(self.window_size) > 0, "A window_size must be specified"
+        for dim in self.window_size:
+            assert isinstance(dim, int), \
+                f"All window_size dimensions must be integers, but found {dim} of type {type(dim)}"
+            assert dim > 0 or dim == -1, f"All window_size dimensions must be positive or -1, but found {dim}"
+            # TODO - allow window_size=0 to delete an axis? or some other way to reduce dimensionality?
+        if isinstance(strides, int):
+            self.strides = [strides if size > 0 else 0 for size in self.window_size]
+        else:
+            self.strides = to_list(strides)
+            if not strides:
+                self.strides = [size if size > 0 else 0 for size in self.window_size]
+        assert len(self.strides) == len(self.window_size), "strides and window_size should have the same number of " + \
+            f"dimensions, but got {self.strides} vs {self.window_size}"
+        for dim in self.strides:
+            assert isinstance(dim, int), f"All stride dimensions must be integers, but found {dim} of type {type(dim)}"
+            assert dim >= 0, f"All stride dimensions must be non-negative, but found {dim}."
+        options = ('drop', 'partial', 'constant')
+        assert pad_mode in options, f"pad_mode must be one of {options}, but got {pad_mode}"
+        self.pad_mode = pad_mode
+        self.pad_val = pad_val
+        options = ("sum", "avg")
+        assert unslice_mode in options, f"unslice_mode must be one of: {options}, but got {unslice_mode}"
+        self.unslice_mode = unslice_mode
+        self.static_unslice_shape = True if unslice_shape is not None else False
+        self.unslice_shape = unslice_shape
+        if self.unslice_inputs and not self.slice_inputs:
+            assert self.static_unslice_shape, "If you want to use SlidingSlicer to unslice data you must either " + \
+                "use it to perform the initial slicing, or else provide the unslice_shape that you want your data " + \
+                "to take after it is reconstructed."
+        self.auto_squeeze: List[int] = []
+        if squeeze_window:
+            for idx, size in enumerate(self.window_size):
+                if size == 1:
+                    self.auto_squeeze.append(idx)
+
+    def _slice_batch(self, batch: Tensor) -> List[Tensor]:
+        shape = get_shape(batch)
+        if len(self.window_size) != len(shape):
+            raise ValueError(f"Sliding window size: {self.window_size} is incompatible with data shape: {shape}. " + \
+                               "They must have the same rank.")
+        if self.unslice_inputs and not self.static_unslice_shape:
+            # If we have to unslice things later, then need to remember the desired shape if the user didn't give us one
+            self.unslice_shape = tuple([int(x) for x in tuple(shape)])
+        stride_template = [
+            slice(None) if stride == 0 or stride >= dim else None for stride, dim in zip(self.strides, shape)
+        ]
+        cuts = self._get_cuts(shape, stride_template)
+        batch = self._solve_padding(batch=batch, batch_shape=shape)
+        minibatches = [batch[cut] for cut in cuts]
+        for ax in reversed(self.auto_squeeze):
+            minibatches = [squeeze(minibatch, axis=ax) for minibatch in minibatches]
+        return minibatches
+
+    def _get_cuts(self, data_shape: Tuple[int, ...], stride_template: List[Optional[slice]]) -> List[List[slice]]:
+        results = []
+        for axis, cut_template in enumerate(stride_template):
+            if cut_template is None:
+                target_shape = data_shape[axis]
+                for start in range(0, target_shape, self.strides[axis]):
+                    stop = start + self.window_size[axis]
+                    if stop > target_shape:
+                        if self.pad_mode == 'drop':
+                            continue
+                        elif self.pad_mode == 'partial':
+                            stop = target_shape
+                        else:
+                            # Padding the input
+                            pass
+                    new_cut = slice(start, stop)
+                    new_template = list(stride_template)
+                    new_template[axis] = new_cut
+                    results.extend(self._get_cuts(data_shape, new_template))
+                # Each level of recursion should only solve one axis, so break here
+                break
+        if not results:
+            # No slices were generated, so all of the slices are already defined within the stride_template
+            return [stride_template]
+        return results
+
+    def _solve_padding(self, batch: TensorT, batch_shape: Tuple[int, ...]) -> TensorT:
+        if self.pad_mode == 'constant':
+            paddings = [[0, int(win - ((tru % (stride or tru)) or win))] for tru,
+                        win,
+                        stride in zip(batch_shape, self.window_size, self.strides)]
+            if isinstance(batch, torch.Tensor):
+                paddings.reverse()  # Torch padding reads from right-most dim to left-most dim
+                paddings = [elem for x in paddings for elem in x]
+                batch = torch.nn.functional.pad(batch, pad=paddings, mode='constant', value=self.pad_val)
+            else:
+                batch = tf.pad(batch,
+                               paddings=tf.constant(paddings),
+                               mode="CONSTANT",
+                               constant_values=tf.cast(self.pad_val, dtype=batch.dtype))
+        return batch
+
+    def _unslice_batch(self, slices: Tuple[Tensor, ...], key: str) -> Tensor:
+        target_shape = self.unslice_shape
+        assert target_shape is not None, "Unit tests should run forward_slicers before running reverse_slicers"
+
+        stride_template = [
+            slice(None) if stride == 0 or stride >= dim else None for stride, dim in zip(self.strides, target_shape)
+        ]
+        cuts = self._get_cuts(target_shape, stride_template)
+        assert len(cuts) == len(slices), f"SlidingSlicer could not unslice key: {key}. It received {len(slices)} " + \
+            f"slices, but a target_shape of {target_shape} with strides of {self.strides} could not have produced this."
+
+        # TF doesn't support slice assignment, and np doesn't support indexing using list of slice, so we'll use torch
+        # for everything and then cast back to tf later if needed
+        merged_dtype = torch.float32 if self.unslice_mode == 'avg' else to_tensor(slices[0], target_type='torch').dtype
+        merged = torch.zeros(size=target_shape, dtype=merged_dtype)
+        merged = self._solve_padding(batch=merged, batch_shape=target_shape)
+        counts = torch.zeros(size=target_shape, dtype=torch.int32)
+        counts = self._solve_padding(batch=counts, batch_shape=target_shape)
+
+        for cut, data in zip(cuts, slices):
+            for ax in self.auto_squeeze:
+                data = expand_dims(data, axis=ax)
+            merged[cut] += to_tensor(data=data, target_type='torch')
+            counts[cut] += 1
+
+        if self.unslice_mode == 'avg':
+            merged /= torch.maximum(counts, torch.tensor(1.0))
+
+        merged[counts == 0] = torch.tensor(self.pad_val, dtype=merged_dtype)
+
+        # Remove any border padding which may have been added
+        merged = merged[[slice(target) for target in target_shape]]
+
+        return merged if isinstance(slices[0], torch.Tensor) else to_tensor(data=merged, target_type='tf')

--- a/fastestimator/summary/system.py
+++ b/fastestimator/summary/system.py
@@ -264,11 +264,14 @@ class System:
             'custom_graphs': self.custom_graphs,
             'traces': [trace.__getstate__() if hasattr(trace, '__getstate__') else {} for trace in self.traces],
             'tops': [op.__getstate__() if hasattr(op, '__getstate__') else {} for op in self.network.ops],
+            'slops': [sl.__getstate__() if hasattr(sl, '__getstate__') else {} for sl in self.network.slicers],
             'pops': [op.__getstate__() if hasattr(op, '__getstate__') else {} for op in self.network.postprocessing],
             'nops': [op.__getstate__() if hasattr(op, '__getstate__') else {} for op in self.pipeline.ops],
             'ds': {
-                mode: {key: value.__getstate__()
-                       for key, value in ds.items() if hasattr(value, '__getstate__')}
+                mode: {
+                    key: value.__getstate__()
+                    for key, value in ds.items() if hasattr(value, '__getstate__')
+                }
                 for mode,
                 ds in self.pipeline.data.items()
             }
@@ -310,6 +313,7 @@ class System:
         self.custom_graphs = objects['custom_graphs']
         self._load_list(objects, 'traces', self.traces)
         self._load_list(objects, 'tops', self.network.ops)
+        self._load_list(objects, 'slops', self.network.slicers)
         self._load_list(objects, 'pops', self.network.postprocessing)
         self._load_list(objects, 'nops', self.pipeline.ops)
         self._load_dict(objects, 'ds', self.pipeline.data)

--- a/fastestimator/trace/metric/mcc.py
+++ b/fastestimator/trace/metric/mcc.py
@@ -12,14 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Union, Iterable
+from typing import Any, Dict, Union, Iterable
 
 import numpy as np
 from sklearn.metrics import matthews_corrcoef
 
 from fastestimator.trace.meta._per_ds import per_ds
 from fastestimator.trace.trace import Trace
-from fastestimator.util.data import Any, Data, Dict
+from fastestimator.util.data import Data
 from fastestimator.util.traceability_util import traceable
 from fastestimator.util.util import to_number
 

--- a/fastestimator/util/base_util.py
+++ b/fastestimator/util/base_util.py
@@ -496,7 +496,8 @@ def check_ds_id(ds_ids: Set[str]) -> Set[str]:
     assert len(negation) < 2, "cannot mix !ds_id with ds_id, found {}".format(ds_ids)
     forbidden_ds_id_chars = {":", ";", "|"}
     for ds_id in ds_ids:
-        assert isinstance(ds_id, str) and len(ds_id) > 0, "dataset id must be a string, found {}".format(ds_id)
+        assert isinstance(ds_id, str) and len(ds_id) > 0, \
+            f"dataset id must be a non-empty string, found {ds_id}"
         assert not any(char in ds_id for char in forbidden_ds_id_chars), \
             "dataset id should not contain forbidden characters like ':', ';', '|', found {}".format(ds_id)
     return ds_ids

--- a/fastestimator/util/data.py
+++ b/fastestimator/util/data.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Any, ChainMap, Dict, List, MutableMapping, Optional
+from typing import Any, ChainMap, List, MutableMapping, Optional
 
 
 class Data(ChainMap[str, Any]):

--- a/fastestimator/util/traceability_util.py
+++ b/fastestimator/util/traceability_util.py
@@ -516,8 +516,10 @@ def _trace_value(inp: Any, tables: Dict[FEID, FeSummaryTable], ret_ref: Flag, wr
                 # Prevent circular recursion
                 tables[inp_id] = FeSummaryTable(name=inp.__class__.__name__, target_type=type(inp), fe_id=inp_id)
                 # This object isn't @traceable but does have some stored variables that we can summarize.
-                kwargs = _trace_value({k: v
-                                       for k, v in inp.__dict__.items() if not k.startswith("_")},
+                kwargs = _trace_value({
+                    k: v
+                    for k, v in inp.__dict__.items() if not k.startswith("_")
+                },
                                       tables,
                                       ret_ref,
                                       wrap_str=False).raw_input
@@ -1026,6 +1028,7 @@ def fe_summary(self) -> List[FeSummaryTable]:
     from fastestimator.op.op import Op
     from fastestimator.pipeline import Pipeline
     from fastestimator.schedule.schedule import Scheduler
+    from fastestimator.slicer.slicer import Slicer
     from fastestimator.trace.trace import Trace
 
     # re-number the references for nicer viewing
@@ -1034,11 +1037,12 @@ def fe_summary(self) -> List[FeSummaryTable]:
         key=lambda x: 0 if issubclass(x[1].type, Estimator) else 1
         if issubclass(x[1].type, (TFNetwork, TorchNetwork)) else 2 if issubclass(x[1].type, Pipeline) else 3
         if issubclass(x[1].type, Scheduler) else 4 if issubclass(x[1].type, Trace) else 5
-        if issubclass(x[1].type, Op) else 6 if issubclass(x[1].type, (Dataset, tf.data.Dataset)) else 7
-        if issubclass(x[1].type, (tf.keras.Model, torch.nn.Module)) else 8
-        if issubclass(x[1].type, types.FunctionType) else 9
-        if issubclass(x[1].type, (np.ndarray, tf.Tensor, tf.Variable, torch.Tensor)) else 10)
-    key_mapping = {fe_id: f"@FE{idx}" for idx, (fe_id, val) in enumerate(ordered_items)}
+        if issubclass(x[1].type, Op) else 6 if issubclass(x[1].type, Slicer) else 7
+        if issubclass(x[1].type, (Dataset, tf.data.Dataset)) else 8
+        if issubclass(x[1].type, (tf.keras.Model, torch.nn.Module)) else 9
+        if issubclass(x[1].type, types.FunctionType) else 10
+        if issubclass(x[1].type, (np.ndarray, tf.Tensor, tf.Variable, torch.Tensor)) else 11)
+    key_mapping = {fe_id: f"@FE{idx}" for idx, (fe_id, _) in enumerate(ordered_items)}
     FEID.set_translation_dict(key_mapping)
     return [item[1] for item in ordered_items]
 

--- a/test/PR_test/integration_test/slicer/__init__.py
+++ b/test/PR_test/integration_test/slicer/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2023 The FastEstimator Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================

--- a/test/PR_test/integration_test/slicer/test_slicer.py
+++ b/test/PR_test/integration_test/slicer/test_slicer.py
@@ -1,0 +1,89 @@
+# Copyright 2023 The FastEstimator Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import tempfile
+import unittest
+from typing import List, Tuple
+
+import fastestimator as fe
+from fastestimator.op.tensorop.model import ModelOp
+from fastestimator.slicer import Slicer
+from fastestimator.test.unittest_util import sample_system_object, sample_system_object_torch
+from fastestimator.types import Array
+
+
+class FakeSlicer(Slicer):
+    def __init__(self, slice, unslice, mode, ds_id, var):
+        super().__init__(slice=slice, unslice=unslice, mode=mode, ds_id=ds_id)
+        self.var = var
+
+    def _slice_batch(self, batch: Array) -> List[Array]:
+        return [batch]
+
+    def _unslice_batch(self, slices: Tuple[Array, ...]) -> Array:
+        return slices[0]
+
+
+class TestSlicer(unittest.TestCase):
+    def test_save_and_load_state_tf(self):
+        def instantiate_system():
+            system = sample_system_object()
+            model = fe.build(model_fn=fe.architecture.tensorflow.LeNet, optimizer_fn='adam', model_name='tf')
+            system.network = fe.Network(
+                ops=[ModelOp(model=model, inputs="x_out", outputs="y_pred")],
+                slicers=FakeSlicer(slice="x", unslice=("x", "y_pred"), mode=None, ds_id=None, var=2.0))
+            return system
+
+        system = instantiate_system()
+
+        # make some changes
+        new_var = 4.0
+        system.network.slicers[0].var = new_var
+
+        # save the state
+        save_path = tempfile.mkdtemp()
+        system.save_state(save_path)
+
+        # reinstantiate system and load the state
+        system = instantiate_system()
+        system.load_state(save_path)
+        loaded_var = system.network.slicers[0].var
+
+        self.assertEqual(loaded_var, new_var)
+
+    def test_save_and_load_state_torch(self):
+        def instantiate_system():
+            system = sample_system_object()
+            model = fe.build(model_fn=fe.architecture.pytorch.LeNet, optimizer_fn='adam', model_name='torch')
+            system.network = fe.Network(
+                ops=[ModelOp(model=model, inputs="x_out", outputs="y_pred")],
+                slicers=FakeSlicer(slice="x", unslice=("x", "y_pred"), mode=None, ds_id=None, var=2.0))
+            return system
+
+        system = instantiate_system()
+
+        # make some changes
+        new_var = 4.0
+        system.network.slicers[0].var = new_var
+
+        # save the state
+        save_path = tempfile.mkdtemp()
+        system.save_state(save_path)
+
+        # reinstantiate system and load the state
+        system = instantiate_system()
+        system.load_state(save_path)
+        loaded_var = system.network.slicers[0].var
+
+        self.assertEqual(loaded_var, new_var)

--- a/test/PR_test/integration_test/slicer/test_slicer.py
+++ b/test/PR_test/integration_test/slicer/test_slicer.py
@@ -19,7 +19,7 @@ from typing import List, Tuple
 import fastestimator as fe
 from fastestimator.op.tensorop.model import ModelOp
 from fastestimator.slicer import Slicer
-from fastestimator.test.unittest_util import sample_system_object, sample_system_object_torch
+from fastestimator.test.unittest_util import sample_system_object
 from fastestimator.types import Array
 
 
@@ -31,7 +31,7 @@ class FakeSlicer(Slicer):
     def _slice_batch(self, batch: Array) -> List[Array]:
         return [batch]
 
-    def _unslice_batch(self, slices: Tuple[Array, ...]) -> Array:
+    def _unslice_batch(self, slices: Tuple[Array, ...], key: str) -> Array:
         return slices[0]
 
 

--- a/test/PR_test/unit_test/slicer/__init__.py
+++ b/test/PR_test/unit_test/slicer/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2023 The FastEstimator Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================

--- a/test/PR_test/unit_test/slicer/test_axis_slicer.py
+++ b/test/PR_test/unit_test/slicer/test_axis_slicer.py
@@ -1,0 +1,157 @@
+# Copyright 2023 The FastEstimator Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import unittest
+
+import numpy as np
+import tensorflow as tf
+import torch
+
+from fastestimator.slicer import AxisSlicer
+
+
+class TestAxisSlicer(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.batch = np.array([i for i in range(36)]).reshape((2, 3, 2, 3))
+
+    def test_d0_slice(self):
+        slicer = AxisSlicer(slice="x", axis=0)
+        with self.subTest("TF"):
+            batch = tf.convert_to_tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 2)
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[0])
+        with self.subTest("Torch"):
+            batch = torch.Tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 2)
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[0])
+
+    def test_d1_slice(self):
+        slicer = AxisSlicer(slice="x", axis=1)
+        with self.subTest("TF"):
+            batch = tf.convert_to_tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 3)
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0, :, :])
+        with self.subTest("Torch"):
+            batch = torch.Tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 3)
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0, :, :])
+
+    def test_d2_slice(self):
+        slicer = AxisSlicer(slice="x", axis=2)
+        with self.subTest("TF"):
+            batch = tf.convert_to_tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 2)
+            np.testing.assert_array_equal(minibatches[1].numpy(), self.batch[:, :, 1, :])
+        with self.subTest("Torch"):
+            batch = torch.Tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 2)
+            np.testing.assert_array_equal(minibatches[1].numpy(), self.batch[:, :, 1, :])
+
+    def test_dn1_slice(self):
+        slicer = AxisSlicer(slice="x", axis=-1)
+        with self.subTest("TF"):
+            batch = tf.convert_to_tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 3)
+            np.testing.assert_array_equal(minibatches[1].numpy(), self.batch[:, :, :, 1])
+        with self.subTest("Torch"):
+            batch = torch.Tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 3)
+            np.testing.assert_array_equal(minibatches[1].numpy(), self.batch[:, :, :, 1])
+
+    def test_dn3_slice(self):
+        slicer = AxisSlicer(slice="x", axis=-3)
+        with self.subTest("TF"):
+            batch = tf.convert_to_tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 3)
+            np.testing.assert_array_equal(minibatches[2].numpy(), self.batch[:, 2, :, :])
+        with self.subTest("Torch"):
+            batch = torch.Tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 3)
+            np.testing.assert_array_equal(minibatches[2].numpy(), self.batch[:, 2, :, :])
+
+    def test_d0_unslice(self):
+        slicer = AxisSlicer(slice="x", unslice="x", axis=0)
+        with self.subTest("TF"):
+            batch = tf.convert_to_tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            combined = slicer._unslice_batch(tuple(minibatches), key='x')
+            np.testing.assert_array_equal(combined, self.batch)
+        with self.subTest("Torch"):
+            batch = torch.Tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            combined = slicer._unslice_batch(tuple(minibatches), key='x')
+            np.testing.assert_array_equal(combined, self.batch)
+
+    def test_d1_unslice(self):
+        slicer = AxisSlicer(slice="x", unslice="x", axis=1)
+        with self.subTest("TF"):
+            batch = tf.convert_to_tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            combined = slicer._unslice_batch(tuple(minibatches), key='x')
+            np.testing.assert_array_equal(combined, self.batch)
+        with self.subTest("Torch"):
+            batch = torch.Tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            combined = slicer._unslice_batch(tuple(minibatches), key='x')
+            np.testing.assert_array_equal(combined, self.batch)
+
+    def test_d2_unslice(self):
+        slicer = AxisSlicer(slice="x", unslice="x", axis=2)
+        with self.subTest("TF"):
+            batch = tf.convert_to_tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            combined = slicer._unslice_batch(tuple(minibatches), key='x')
+            np.testing.assert_array_equal(combined, self.batch)
+        with self.subTest("Torch"):
+            batch = torch.Tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            combined = slicer._unslice_batch(tuple(minibatches), key='x')
+            np.testing.assert_array_equal(combined, self.batch)
+
+    def test_dn1_unslice(self):
+        slicer = AxisSlicer(slice="x", unslice="x", axis=-1)
+        with self.subTest("TF"):
+            batch = tf.convert_to_tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            combined = slicer._unslice_batch(tuple(minibatches), key='x')
+            np.testing.assert_array_equal(combined, self.batch)
+        with self.subTest("Torch"):
+            batch = torch.Tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            combined = slicer._unslice_batch(tuple(minibatches), key='x')
+            np.testing.assert_array_equal(combined, self.batch)
+
+    def test_dn3_unslice(self):
+        slicer = AxisSlicer(slice="x", unslice="x", axis=-3)
+        with self.subTest("TF"):
+            batch = tf.convert_to_tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            combined = slicer._unslice_batch(tuple(minibatches), key='x')
+            np.testing.assert_array_equal(combined, self.batch)
+        with self.subTest("Torch"):
+            batch = torch.Tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            combined = slicer._unslice_batch(tuple(minibatches), key='x')
+            np.testing.assert_array_equal(combined, self.batch)

--- a/test/PR_test/unit_test/slicer/test_mean_slicer.py
+++ b/test/PR_test/unit_test/slicer/test_mean_slicer.py
@@ -1,0 +1,39 @@
+# Copyright 2023 The FastEstimator Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import unittest
+
+import numpy as np
+import tensorflow as tf
+import torch
+
+from fastestimator.slicer import MeanUnslicer
+
+
+class TestMeanUnslicer(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.minibatches = [np.array([0.3, 0.6, 0.9]), np.array([1.0, 1.0, 1.0]), np.array([2.0, 2.0, 2.0])]
+        cls.target = np.array([1.1, 1.2, 1.3])
+
+    def test_unslice(self):
+        slicer = MeanUnslicer(unslice="x")
+        with self.subTest("TF"):
+            minibatches = [tf.convert_to_tensor(elem) for elem in self.minibatches]
+            batch = slicer._unslice_batch(minibatches, key='x')
+            np.testing.assert_array_almost_equal(batch, self.target)
+        with self.subTest("Torch"):
+            minibatches = [torch.tensor(elem) for elem in self.minibatches]
+            batch = slicer._unslice_batch(minibatches, key='x')
+            np.testing.assert_array_almost_equal(batch, self.target)

--- a/test/PR_test/unit_test/slicer/test_slicer.py
+++ b/test/PR_test/unit_test/slicer/test_slicer.py
@@ -1,0 +1,100 @@
+# Copyright 2023 The FastEstimator Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import unittest
+from typing import List, Tuple
+
+import tensorflow as tf
+
+from fastestimator.slicer import Slicer
+from fastestimator.slicer.slicer import forward_slicers, reverse_slicers, sanity_assert_slicers
+from fastestimator.types import Array
+
+
+class MockSlicer(Slicer):
+    def _slice_batch(self, batch: Array) -> List[Array]:
+        return [batch]
+
+    def _unslice_batch(self, slices: Tuple[Array, ...], key: str) -> Array:
+        return slices[0]
+
+
+class MockSlicer2(Slicer):
+    def _slice_batch(self, batch: Array) -> List[Array]:
+        return [batch, batch]
+
+    def _unslice_batch(self, slices: Tuple[Array, ...], key: str) -> Array:
+        return slices[0]
+
+
+class MockSlicerSliceOnly(Slicer):
+    def _slice_batch(self, batch: Array) -> List[Array]:
+        return [batch]
+
+
+class MockSlicerUnSliceOnly(Slicer):
+    def _unslice_batch(self, slices: Tuple[Array, ...], key: str) -> Array:
+        return slices[0]
+
+
+class TestSlicer(unittest.TestCase):
+    def test_raise_from_init(self):
+        with self.subTest("No inputs"):
+            self.assertRaises(ValueError, lambda: MockSlicer(slice=()))
+        with self.subTest("Undefined Slice"):
+            self.assertRaises(NotImplementedError, lambda: MockSlicerUnSliceOnly(slice="x"))
+        with self.subTest("Undefined UnSlice"):
+            self.assertRaises(NotImplementedError, lambda: MockSlicerSliceOnly(slice="y", unslice="x"))
+
+
+class TestSanityAssert(unittest.TestCase):
+    def test_sanity(self):
+        with self.subTest("Mix slice keys"):
+            slicers = [MockSlicer(slice=("x", "y")), MockSlicer(slice="z"), MockSlicer(slice=("y", "b"))]
+            self.assertRaises(ValueError, lambda: sanity_assert_slicers(slicers))
+        with self.subTest("Mix unslice keys"):
+            slicers = [
+                MockSlicer(slice=("x", "y")),
+                MockSlicer(slice="z", unslice="z"),
+                MockSlicer(slice=("a", "b"), unslice="z")
+            ]
+            self.assertRaises(ValueError, lambda: sanity_assert_slicers(slicers))
+
+
+class TestForwardSlicers(unittest.TestCase):
+    def test_forward(self):
+        with self.subTest("Single Slice"):
+            slicers = [MockSlicer(slice="x"), MockSlicer(slice=("y", "z"))]
+            batch = {"x": tf.ones((3, 5, 5, 7)), "y": tf.ones((3, 10)), "z": tf.ones((3, 1)), "w": tf.ones((3, 2))}
+            minibatch = forward_slicers(slicers=slicers, data=batch)
+            self.assertEqual(len(minibatch), 1)
+            self.assertDictEqual(minibatch[0], batch)
+        with self.subTest("Multi Slice"):
+            slicers = [MockSlicer2(slice="x"), MockSlicer2(slice=("y", "z"))]
+            batch = {"x": tf.ones((3, 5, 5, 7)), "y": tf.ones((3, 10)), "z": tf.ones((3, 1)), "w": tf.ones((3, 2))}
+            minibatch = forward_slicers(slicers=slicers, data=batch)
+            self.assertEqual(len(minibatch), 2)
+            self.assertDictEqual(minibatch[0], batch)
+
+
+class TestReverseSlicers(unittest.TestCase):
+    def test_reverse(self):
+        slicers = [MockSlicer(slice="x"), MockSlicer(slice=("y", "z"))]
+        batch = {"x": tf.ones((3, 5, 5, 7)), "y": tf.ones((3, 10)), "z": tf.ones((3, 1)), "w": tf.ones((3, 2))}
+        minibatch = forward_slicers(slicers=slicers, data=batch)
+        for elem in minibatch:
+            elem.pop("z")  # simulate z being un-wanted later
+        final_batch = reverse_slicers(slicers=slicers, data=minibatch, original_data={})
+        batch.pop("z")
+        self.assertDictEqual(final_batch, batch)

--- a/test/PR_test/unit_test/slicer/test_sliding_slicer.py
+++ b/test/PR_test/unit_test/slicer/test_sliding_slicer.py
@@ -1,0 +1,422 @@
+# Copyright 2023 The FastEstimator Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import unittest
+
+import numpy as np
+import tensorflow as tf
+import torch
+
+from fastestimator.slicer import SlidingSlicer
+from fastestimator.slicer.slicer import forward_slicers, reverse_slicers
+
+
+class TestSlidingSlicer(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.batch = np.array([i for i in range(600)], dtype=np.int16).reshape((2, 10, 10, 3))
+        cls.padded_batch = np.zeros(shape=(2, 13, 13, 3), dtype=cls.batch.dtype)
+        cls.padded_batch[:, :10, :10, :] += cls.batch
+        cls.padded_batch[:, :, 10:, :] -= 1
+        cls.padded_batch[:, 10:, :, :] -= 1
+
+    def test_noop_slice(self):
+        slicer = SlidingSlicer(slice="x", window_size=(-1, 10, -1, 3))
+        with self.subTest("TF"):
+            batch = tf.convert_to_tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 1)
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch)
+        with self.subTest("Torch"):
+            batch = torch.Tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 1)
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch)
+
+    def test_tiled_slice(self):
+        slicer = SlidingSlicer(slice="x", window_size=(-1, 2, 2, 3))
+        with self.subTest("TF"):
+            batch = tf.convert_to_tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 25)
+            for mbatch in minibatches:
+                self.assertListEqual(list(mbatch.shape), [2, 2, 2, 3])
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:2, :])
+        with self.subTest("Torch"):
+            batch = torch.Tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 25)
+            for mbatch in minibatches:
+                self.assertListEqual(list(mbatch.shape), [2, 2, 2, 3])
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:2, :])
+
+    def test_tiled_unequal_slice(self):
+        slicer = SlidingSlicer(slice="x", window_size=(-1, 2, 5, 3))
+        with self.subTest("TF"):
+            batch = tf.convert_to_tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 10)
+            for mbatch in minibatches:
+                self.assertListEqual(list(mbatch.shape), [2, 2, 5, 3])
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:5, :])
+        with self.subTest("Torch"):
+            batch = torch.Tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 10)
+            for mbatch in minibatches:
+                self.assertListEqual(list(mbatch.shape), [2, 2, 5, 3])
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:5, :])
+
+    def test_drop_unequal_slice(self):
+        slicer = SlidingSlicer(slice="x", pad_mode='drop', window_size=(-1, 2, 4, 3))
+        with self.subTest("TF"):
+            batch = tf.convert_to_tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 10)
+            for mbatch in minibatches:
+                self.assertListEqual(list(mbatch.shape), [2, 2, 4, 3])
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:4, :])
+        with self.subTest("Torch"):
+            batch = torch.Tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 10)
+            for mbatch in minibatches:
+                self.assertListEqual(list(mbatch.shape), [2, 2, 4, 3])
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:4, :])
+
+    def test_partial_tiled_slice(self):
+        slicer = SlidingSlicer(slice="x", pad_mode='partial', window_size=(-1, 2, 2, 3))
+        with self.subTest("TF"):
+            batch = tf.convert_to_tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 25)
+            for mbatch in minibatches:
+                self.assertListEqual(list(mbatch.shape), [2, 2, 2, 3])
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:2, :])
+        with self.subTest("Torch"):
+            batch = torch.Tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 25)
+            for mbatch in minibatches:
+                self.assertListEqual(list(mbatch.shape), [2, 2, 2, 3])
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:2, :])
+
+    def test_partial_unequal_slice(self):
+        slicer = SlidingSlicer(slice="x", pad_mode='partial', window_size=(-1, 2, 4, 3))
+        with self.subTest("TF"):
+            batch = tf.convert_to_tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 15)
+            for idx, mbatch in enumerate(minibatches):
+                if idx % 3 == 2:
+                    self.assertListEqual(list(mbatch.shape), [2, 2, 2, 3])
+                else:
+                    self.assertListEqual(list(mbatch.shape), [2, 2, 4, 3])
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:4, :])
+        with self.subTest("Torch"):
+            batch = torch.Tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 15)
+            for idx, mbatch in enumerate(minibatches):
+                if idx % 3 == 2:
+                    self.assertListEqual(list(mbatch.shape), [2, 2, 2, 3])
+                else:
+                    self.assertListEqual(list(mbatch.shape), [2, 2, 4, 3])
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:4, :])
+
+    def test_pad_tiled_slice(self):
+        slicer = SlidingSlicer(slice="x", pad_mode='constant', pad_val=-1, window_size=(-1, 2, 2, 3))
+        with self.subTest("TF"):
+            batch = tf.convert_to_tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 25)
+            for mbatch in minibatches:
+                self.assertListEqual(list(mbatch.shape), [2, 2, 2, 3])
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:2, :])
+            np.testing.assert_array_equal(minibatches[-1].numpy(), self.batch[:, 8:10, 8:10, :])
+        with self.subTest("Torch"):
+            batch = torch.Tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 25)
+            for mbatch in minibatches:
+                self.assertListEqual(list(mbatch.shape), [2, 2, 2, 3])
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:2, :])
+            np.testing.assert_array_equal(minibatches[-1].numpy(), self.batch[:, 8:10, 8:10, :])
+
+    def test_pad_unequal_slice(self):
+        slicer = SlidingSlicer(slice="x", pad_mode='constant', pad_val=-1, window_size=(-1, 2, 4, 3))
+        with self.subTest("TF"):
+            batch = tf.convert_to_tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 15)
+            for mbatch in minibatches:
+                self.assertListEqual(list(mbatch.shape), [2, 2, 4, 3])
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:4, :])
+            np.testing.assert_array_equal(minibatches[-1].numpy(), self.padded_batch[:, 8:10, 8:12, :])
+        with self.subTest("Torch"):
+            batch = torch.Tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 15)
+            for mbatch in minibatches:
+                self.assertListEqual(list(mbatch.shape), [2, 2, 4, 3])
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:4, :])
+            np.testing.assert_array_equal(minibatches[-1].numpy(), self.padded_batch[:, 8:10, 8:12, :])
+
+    def test_overlapping_stride_pad(self):
+        slicer = SlidingSlicer(slice="x",
+                               pad_mode='constant',
+                               pad_val=-1,
+                               window_size=(-1, 2, 4, 3),
+                               strides=(0, 2, 3, 0))
+        with self.subTest("TF"):
+            batch = tf.convert_to_tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 20)
+            for mbatch in minibatches:
+                self.assertListEqual(list(mbatch.shape), [2, 2, 4, 3])
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:4, :])
+            np.testing.assert_array_equal(minibatches[-1].numpy(), self.padded_batch[:, 8:10, 9:13, :])
+        with self.subTest("Torch"):
+            batch = torch.Tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 20)
+            for mbatch in minibatches:
+                self.assertListEqual(list(mbatch.shape), [2, 2, 4, 3])
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:4, :])
+            np.testing.assert_array_equal(minibatches[-1].numpy(), self.padded_batch[:, 8:10, 9:13, :])
+
+    def test_overlapping_stride_drop(self):
+        slicer = SlidingSlicer(slice="x", pad_mode='drop', pad_val=-1, window_size=(-1, 2, 4, 3), strides=(0, 2, 3, 0))
+        with self.subTest("TF"):
+            batch = tf.convert_to_tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 15)
+            for mbatch in minibatches:
+                self.assertListEqual(list(mbatch.shape), [2, 2, 4, 3])
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:4, :])
+            np.testing.assert_array_equal(minibatches[-1].numpy(), self.batch[:, 8:10, 6:10, :])
+        with self.subTest("Torch"):
+            batch = torch.Tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 15)
+            for mbatch in minibatches:
+                self.assertListEqual(list(mbatch.shape), [2, 2, 4, 3])
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:4, :])
+            np.testing.assert_array_equal(minibatches[-1].numpy(), self.batch[:, 8:10, 6:10, :])
+
+    def test_overlapping_partial_unequal_slice(self):
+        slicer = SlidingSlicer(slice="x", pad_mode='partial', window_size=(-1, 2, 4, 3), strides=(0, 2, 3, 0))
+        with self.subTest("TF"):
+            batch = tf.convert_to_tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 20)
+            for idx, mbatch in enumerate(minibatches):
+                if idx % 4 == 3:
+                    self.assertListEqual(list(mbatch.shape), [2, 2, 1, 3])
+                else:
+                    self.assertListEqual(list(mbatch.shape), [2, 2, 4, 3])
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:4, :])
+        with self.subTest("Torch"):
+            batch = torch.Tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 20)
+            for idx, mbatch in enumerate(minibatches):
+                if idx % 4 == 3:
+                    self.assertListEqual(list(mbatch.shape), [2, 2, 1, 3])
+                else:
+                    self.assertListEqual(list(mbatch.shape), [2, 2, 4, 3])
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:4, :])
+
+    def test_gap_stride_pad(self):
+        slicer = SlidingSlicer(slice="x",
+                               pad_mode='constant',
+                               pad_val=-1,
+                               window_size=(-1, 2, 4, 3),
+                               strides=(0, 3, 5, 0))
+        with self.subTest("TF"):
+            batch = tf.convert_to_tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 8)
+            for mbatch in minibatches:
+                self.assertListEqual(list(mbatch.shape), [2, 2, 4, 3])
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:4, :])
+            np.testing.assert_array_equal(minibatches[-1].numpy(), self.padded_batch[:, 9:11, 5:9, :])
+        with self.subTest("Torch"):
+            batch = torch.Tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 8)
+            for mbatch in minibatches:
+                self.assertListEqual(list(mbatch.shape), [2, 2, 4, 3])
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:4, :])
+            np.testing.assert_array_equal(minibatches[-1].numpy(), self.padded_batch[:, 9:11, 5:9, :])
+
+    def test_gap_stride_drop(self):
+        slicer = SlidingSlicer(slice="x", pad_mode='drop', window_size=(-1, 2, 4, 3), strides=(0, 3, 5, 0))
+        with self.subTest("TF"):
+            batch = tf.convert_to_tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 6)
+            for mbatch in minibatches:
+                self.assertListEqual(list(mbatch.shape), [2, 2, 4, 3])
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:4, :])
+            np.testing.assert_array_equal(minibatches[-1].numpy(), self.batch[:, 6:8, 5:9, :])
+        with self.subTest("Torch"):
+            batch = torch.Tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 6)
+            for mbatch in minibatches:
+                self.assertListEqual(list(mbatch.shape), [2, 2, 4, 3])
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:4, :])
+            np.testing.assert_array_equal(minibatches[-1].numpy(), self.batch[:, 6:8, 5:9, :])
+
+    def test_gap_stride_partial(self):
+        slicer = SlidingSlicer(slice="x", pad_mode='partial', window_size=(-1, 2, 4, 3), strides=(0, 3, 5, 0))
+        with self.subTest("TF"):
+            batch = tf.convert_to_tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 8)
+            for idx, mbatch in enumerate(minibatches):
+                if idx in (6, 7):
+                    self.assertListEqual(list(mbatch.shape), [2, 1, 4, 3])
+                else:
+                    self.assertListEqual(list(mbatch.shape), [2, 2, 4, 3])
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:4, :])
+        with self.subTest("Torch"):
+            batch = torch.Tensor(self.batch)
+            minibatches = slicer._slice_batch(batch)
+            self.assertEqual(len(minibatches), 8)
+            for idx, mbatch in enumerate(minibatches):
+                if idx in (6, 7):
+                    self.assertListEqual(list(mbatch.shape), [2, 1, 4, 3])
+                else:
+                    self.assertListEqual(list(mbatch.shape), [2, 2, 4, 3])
+            np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:4, :])
+
+    def test_tiled_unslice(self):
+        slicer = SlidingSlicer(slice="x", window_size=(-1, 2, 2, 3))
+        with self.subTest("TF"):
+            batch = tf.convert_to_tensor(self.batch)
+            minibatches = forward_slicers([slicer], data={'x': batch})
+            self.assertEqual(len(minibatches), 25)
+            combined = reverse_slicers([slicer], minibatches, original_data={})
+            combined = combined['x']
+            self.assertListEqual(list(combined.shape), [2, 10, 10, 3])
+            np.testing.assert_array_equal(combined.numpy(), self.batch)
+        with self.subTest("Torch"):
+            batch = torch.Tensor(self.batch)
+            minibatches = forward_slicers([slicer], data={'x': batch})
+            self.assertEqual(len(minibatches), 25)
+            combined = reverse_slicers([slicer], minibatches, original_data={})
+            combined = combined['x']
+            self.assertListEqual(list(combined.shape), [2, 10, 10, 3])
+            np.testing.assert_array_equal(combined.numpy(), self.batch)
+
+    def test_overlapping_drop_avg_unslice(self):
+        slicer = SlidingSlicer(slice="x",
+                               window_size=(-1, 2, 4, -1),
+                               strides=(0, 2, 3, 0),
+                               pad_mode='drop',
+                               pad_val=-1.0,
+                               unslice_mode="avg")
+        with self.subTest("TF"):
+            batch = tf.convert_to_tensor(self.batch)
+            minibatches = forward_slicers([slicer], data={'x': batch})
+            self.assertEqual(len(minibatches), 15)
+            combined = reverse_slicers([slicer], minibatches, original_data={})
+            combined = combined['x']
+            self.assertListEqual(list(combined.shape), [2, 10, 10, 3])
+            np.testing.assert_array_equal(combined.numpy(), self.batch)
+        with self.subTest("Torch"):
+            batch = torch.Tensor(self.batch)
+            minibatches = forward_slicers([slicer], data={'x': batch})
+            self.assertEqual(len(minibatches), 15)
+            combined = reverse_slicers([slicer], minibatches, original_data={})
+            combined = combined['x']
+            self.assertListEqual(list(combined.shape), [2, 10, 10, 3])
+            np.testing.assert_array_equal(combined.numpy(), self.batch)
+
+    def test_overlapping_partial_avg_unslice(self):
+        slicer = SlidingSlicer(slice="x",
+                               window_size=(-1, 2, 4, -1),
+                               strides=(0, 2, 3, 0),
+                               pad_mode='partial',
+                               pad_val=-1.0,
+                               unslice_mode="avg")
+        with self.subTest("TF"):
+            batch = tf.convert_to_tensor(self.batch)
+            minibatches = forward_slicers([slicer], data={'x': batch})
+            self.assertEqual(len(minibatches), 20)
+            combined = reverse_slicers([slicer], minibatches, original_data={})
+            combined = combined['x']
+            self.assertListEqual(list(combined.shape), [2, 10, 10, 3])
+            np.testing.assert_array_equal(combined.numpy(), self.batch)
+        with self.subTest("Torch"):
+            batch = torch.Tensor(self.batch)
+            minibatches = forward_slicers([slicer], data={'x': batch})
+            self.assertEqual(len(minibatches), 20)
+            combined = reverse_slicers([slicer], minibatches, original_data={})
+            combined = combined['x']
+            self.assertListEqual(list(combined.shape), [2, 10, 10, 3])
+            np.testing.assert_array_equal(combined.numpy(), self.batch)
+
+    def test_overlapping_pad_avg_unslice(self):
+        slicer = SlidingSlicer(slice="x",
+                               window_size=(-1, 2, 4, -1),
+                               strides=(0, 2, 3, 0),
+                               pad_mode='constant',
+                               pad_val=-1.0,
+                               unslice_mode="avg")
+        with self.subTest("TF"):
+            batch = tf.convert_to_tensor(self.batch)
+            minibatches = forward_slicers([slicer], data={'x': batch})
+            self.assertEqual(len(minibatches), 20)
+            combined = reverse_slicers([slicer], minibatches, original_data={})
+            combined = combined['x']
+            self.assertListEqual(list(combined.shape), [2, 10, 10, 3])
+            np.testing.assert_array_equal(combined.numpy(), self.batch)
+        with self.subTest("Torch"):
+            batch = torch.Tensor(self.batch)
+            minibatches = forward_slicers([slicer], data={'x': batch})
+            self.assertEqual(len(minibatches), 20)
+            combined = reverse_slicers([slicer], minibatches, original_data={})
+            combined = combined['x']
+            self.assertListEqual(list(combined.shape), [2, 10, 10, 3])
+            np.testing.assert_array_equal(combined.numpy(), self.batch)
+
+    def test_gap_stride_partial_unslice(self):
+        pad_val = -2
+        gap_batch = self.batch.copy()
+        gap_batch[:, :, 4::5, :] = pad_val
+        gap_batch[:, 2::3, :, :] = pad_val
+        slicer = SlidingSlicer(slice="x",
+                               pad_mode='partial',
+                               pad_val=pad_val,
+                               window_size=(-1, 2, 4, 3),
+                               strides=(0, 3, 5, 0))
+        with self.subTest("TF"):
+            batch = tf.convert_to_tensor(self.batch)
+            minibatches = forward_slicers([slicer], data={'x': batch})
+            self.assertEqual(len(minibatches), 8)
+            combined = reverse_slicers([slicer], minibatches, original_data={})
+            combined = combined['x']
+            self.assertListEqual(list(combined.shape), [2, 10, 10, 3])
+            np.testing.assert_array_equal(combined.numpy(), gap_batch)
+        with self.subTest("Torch"):
+            batch = torch.Tensor(self.batch)
+            minibatches = forward_slicers([slicer], data={'x': batch})
+            self.assertEqual(len(minibatches), 8)
+            combined = reverse_slicers([slicer], minibatches, original_data={})
+            combined = combined['x']
+            self.assertListEqual(list(combined.shape), [2, 10, 10, 3])
+            np.testing.assert_array_equal(combined.numpy(), gap_batch)

--- a/tutorial/advanced/t17_slicer.ipynb
+++ b/tutorial/advanced/t17_slicer.ipynb
@@ -1,0 +1,736 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Advanced Tutorial 17: Slicer\n",
+    "\n",
+    "## Overview\n",
+    "In this tutorial, we will talk about the following topics:\n",
+    "* [Slicer Overview](#ta17overview)\n",
+    "* [Example Usecase 1: 3D to 2D](#ta17axis)\n",
+    "* [Example Usecase 2: Sliding Windows](#ta17slide)\n",
+    "* [Building Your Own Slicer](#ta17customize)\n",
+    "\n",
+    "This tutorial will demonstrate modifications to the [UNet3D Apphub](../../apphub/semantic_segmentation/unet3d_3plus/unet3d_3plus.ipynb), so you may want to look at that first to get more context for the problem setting."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='ta17overview'></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Slicer Overview\n",
+    "\n",
+    "Suppose you have a single batch of data, but for whatever reason you can't / don't want to run the entire thing through your model at once. `Slicers` allow you to cut a batch of data apart and run it through your `Network` in chunks. `Slicers` then re-combine the output before passing it along to `Network` post-processing and `Trace` functions. \n",
+    "\n",
+    "In this tutorial we will take a look at this through the lens of an [electronic microscopy 3D cell dataset](https://leapmanlab.github.io/dense-cell/). This dataset contains only 2 images: one of size 800x800x50 and the other 800x800x24. These would be rather large images to feed through a network in a single step. \n",
+    "\n",
+    "In our [UNet3D Apphub](../../apphub/semantic_segmentation/unet3d_3plus/unet3d_3plus.ipynb) we took advantage of the FE dataset implementation to automatically convert the data volumes into around 75 training images and 25 validation images, each of size 256x256x24. That was fine for our 3D model, but what if you want to pass the data directly into a 2D network? Or what if you think side lengths of 256 are too boring and you want to try something else instead? Well, in that case you have come to the right place. Let's see how to make it happen..."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='ta17axis'></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "editable": true,
+    "slideshow": {
+     "slide_type": ""
+    },
+    "tags": []
+   },
+   "source": [
+    "## Example Usecase 1: 3D data into a 2D Network\n",
+    "\n",
+    "One reason that you might want to slice data apart is if you have 3D image volumes, but you want to inference them slice-by-slice using a 2D network architecture. This can be accommodated using an `AxisSlicer`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "tags": []
+   },
+   "source": [
+    "#### The Data\n",
+    "\n",
+    "First let's load up some 3D data and have a look:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training Samples: 75\n",
+      "Eval Samples: 25\n",
+      "Sample Shape: (256, 256, 24)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from fastestimator.dataset.data.em_3d import load_data\n",
+    "\n",
+    "train_data, eval_data = load_data()\n",
+    "print(f\"Training Samples: {len(train_data)}\")\n",
+    "print(f\"Eval Samples: {len(eval_data)}\")\n",
+    "print(f\"Sample Shape: {train_data[0]['image'].shape}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll feed this data through a pretty straightforward pre-processing pipeline:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import fastestimator as fe\n",
+    "from fastestimator.op.numpyop.meta import Sometimes\n",
+    "from fastestimator.op.numpyop.multivariate import HorizontalFlip, VerticalFlip\n",
+    "from fastestimator.op.numpyop.univariate import Minmax\n",
+    "from fastestimator.op.numpyop.univariate.expand_dims import ExpandDims\n",
+    "\n",
+    "pipeline = fe.Pipeline(\n",
+    "    train_data=train_data,\n",
+    "    eval_data=eval_data,\n",
+    "    batch_size=1,\n",
+    "    ops=[\n",
+    "        Sometimes(numpy_op=HorizontalFlip(image_in=\"image\", mask_in=\"label\", mode='train')),\n",
+    "        Sometimes(numpy_op=VerticalFlip(image_in=\"image\", mask_in=\"label\", mode='train')),\n",
+    "        Minmax(inputs=\"image\", outputs=\"image\"),\n",
+    "        ExpandDims(inputs=\"image\", outputs=\"image\"),  # We'll add a channel dimension to the images\n",
+    "    ])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Image Batch Shape: torch.Size([1, 256, 256, 24, 1])\n",
+      "Label Batch Shape: torch.Size([1, 256, 256, 24, 6])\n"
+     ]
+    }
+   ],
+   "source": [
+    "sample_batch = pipeline.get_results()\n",
+    "print(f\"Image Batch Shape: {sample_batch['image'].shape}\")\n",
+    "print(f\"Label Batch Shape: {sample_batch['label'].shape}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### The Network\n",
+    "\n",
+    "In our apphub we spent quite a lot of time defining a 3D model architecture that could handle this data. But what if you just want to use a basic 2D UNet Model? In that case you'll want to use an `AxisSlicer`. The `AxisSlicer` slices our input data along a given axis and then runs each slice through the network separately. The slices are then put back together again before being passed on to subsequent `Network` post-processing `Ops` or `Traces`. You'll also need to specify how to un-slice (re-combine) the data which is generated during the repeated forward passes over the `Network`. In this case we will use a `MeanUnslicer` in order to merge our loss terms together for log printing, and re-use our `AxisSlicer` to stack the network predictions back into a 3D volume:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Metal device set to: Apple M2 Max\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2023-06-27 17:45:47.879720: I tensorflow/core/common_runtime/pluggable_device/pluggable_device_factory.cc:306] Could not identify NUMA node of platform GPU ID 0, defaulting to 0. Your kernel may not have been built with NUMA support.\n",
+      "2023-06-27 17:45:47.879753: I tensorflow/core/common_runtime/pluggable_device/pluggable_device_factory.cc:272] Created TensorFlow device (/job:localhost/replica:0/task:0/device:GPU:0 with 0 MB memory) -> physical PluggableDevice (device: 0, name: METAL, pci bus id: <undefined>)\n"
+     ]
+    }
+   ],
+   "source": [
+    "import tensorflow as tf\n",
+    "\n",
+    "from fastestimator.architecture.tensorflow import UNet\n",
+    "from fastestimator.op.tensorop.loss import CrossEntropy\n",
+    "from fastestimator.op.tensorop.model import ModelOp, UpdateOp\n",
+    "from fastestimator.slicer import AxisSlicer, MeanUnslicer\n",
+    "\n",
+    "model = fe.build(model_fn=lambda: UNet(input_size=(256, 256, 1), output_channel=6),\n",
+    "                 optimizer_fn=lambda: tf.optimizers.legacy.Adam(learning_rate=0.0001),)\n",
+    "network = fe.Network(\n",
+    "    ops=[\n",
+    "        ModelOp(inputs=\"image\", model=model, outputs=\"pred\"),\n",
+    "        CrossEntropy(inputs=(\"pred\", \"label\"), outputs=\"loss\", form=\"binary\"),\n",
+    "        UpdateOp(model=model, loss_name=\"loss\")\n",
+    "    ], \n",
+    "    slicers=[\n",
+    "        AxisSlicer(slice=[\"image\", \"label\"], unslice=[\"pred\"], axis=3), \n",
+    "        MeanUnslicer(unslice=\"loss\")\n",
+    "    ])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Image Batch Shape: (1, 256, 256, 24, 1)\n",
+      "Label Batch Shape: (1, 256, 256, 24, 6)\n",
+      "Prediction Batch Shape: (1, 256, 256, 24, 6)\n",
+      "Mean Loss Value: 1.1275629997253418\n"
+     ]
+    }
+   ],
+   "source": [
+    "sample_prediction = network.transform(data=sample_batch, mode='eval')\n",
+    "print(f\"Image Batch Shape: {sample_prediction['image'].shape}\")\n",
+    "print(f\"Label Batch Shape: {sample_prediction['label'].shape}\")\n",
+    "print(f\"Prediction Batch Shape: {sample_prediction['pred'].shape}\")\n",
+    "print(f\"Mean Loss Value: {sample_prediction['loss']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, let's add in a metric trace and see the training:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from fastestimator.trace.metric import Dice\n",
+    "\n",
+    "channel_mapping={0: 'Cell', 1: 'Mitochondria', 2: 'AlphaGranule',\n",
+    "                 3: 'CanalicularVessel', 4: 'GranuleBody', 5: 'GranuleCore'}\n",
+    "\n",
+    "traces=[Dice(true_key=\"label\", pred_key=\"pred\", channel_mapping=channel_mapping)]\n",
+    "\n",
+    "estimator = fe.Estimator(\n",
+    "    pipeline=pipeline,\n",
+    "    network=network,\n",
+    "    traces=traces,\n",
+    "    log_steps=75,\n",
+    "    eval_log_steps=[-1],\n",
+    "    epochs=10)  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    ______           __  ______     __  _                 __            \n",
+      "   / ____/___ ______/ /_/ ____/____/ /_(_)___ ___  ____ _/ /_____  _____\n",
+      "  / /_  / __ `/ ___/ __/ __/ / ___/ __/ / __ `__ \\/ __ `/ __/ __ \\/ ___/\n",
+      " / __/ / /_/ (__  ) /_/ /___(__  ) /_/ / / / / / / /_/ / /_/ /_/ / /    \n",
+      "/_/    \\__,_/____/\\__/_____/____/\\__/_/_/ /_/ /_/\\__,_/\\__/\\____/_/     \n",
+      "                                                                        \n",
+      "\n",
+      "\u001b[93mFastEstimator-Warn: No ModelSaver Trace detected. Models will not be saved.\u001b[00m\n",
+      "FastEstimator-Start: step: 1; logging_interval: 75; num_device: 1;\n",
+      "FastEstimator-Train: step: 1; loss: 0.35076174;\n",
+      "FastEstimator-Train: step: 75; loss: 0.06861534; steps/sec: 0.45;\n",
+      "FastEstimator-Train: step: 75; epoch: 1; epoch_time(sec): 173.2;\n",
+      "FastEstimator-Eval: step: 75; epoch: 1; Dice: 0.1650141; Dice_AlphaGranule: 0.0; Dice_CanalicularVessel: 0.0; Dice_Cell: 0.56379896; Dice_GranuleBody: 0.0; Dice_GranuleCore: 0.41382408; Dice_Mitochondria: 0.012461557; loss: 0.22645305;\n",
+      "FastEstimator-Train: step: 150; loss: 0.036027152; steps/sec: 0.41;\n",
+      "FastEstimator-Train: step: 150; epoch: 2; epoch_time(sec): 182.15;\n",
+      "FastEstimator-Eval: step: 150; epoch: 2; Dice: 0.28468058; Dice_AlphaGranule: 0.22724058; Dice_CanalicularVessel: 0.0; Dice_Cell: 0.84920985; Dice_GranuleBody: 0.0; Dice_GranuleCore: 0.59404886; Dice_Mitochondria: 0.037584234; loss: 0.11351043;\n",
+      "FastEstimator-Train: step: 225; loss: 0.019175015; steps/sec: 0.43;\n",
+      "FastEstimator-Train: step: 225; epoch: 3; epoch_time(sec): 173.2;\n",
+      "FastEstimator-Eval: step: 225; epoch: 3; Dice: 0.27223733; Dice_AlphaGranule: 0.14862165; Dice_CanalicularVessel: 0.0; Dice_Cell: 0.87892294; Dice_GranuleBody: 0.0; Dice_GranuleCore: 0.57796216; Dice_Mitochondria: 0.027917214; loss: 0.10777818;\n",
+      "FastEstimator-Train: step: 300; loss: 0.038775463; steps/sec: 0.43;\n",
+      "FastEstimator-Train: step: 300; epoch: 4; epoch_time(sec): 175.43;\n",
+      "FastEstimator-Eval: step: 300; epoch: 4; Dice: 0.26352742; Dice_AlphaGranule: 0.06612307; Dice_CanalicularVessel: 0.0; Dice_Cell: 0.85590476; Dice_GranuleBody: 0.0; Dice_GranuleCore: 0.6462211; Dice_Mitochondria: 0.012915753; loss: 0.15005614;\n",
+      "FastEstimator-Train: step: 375; loss: 0.041875094; steps/sec: 0.42;\n",
+      "FastEstimator-Train: step: 375; epoch: 5; epoch_time(sec): 179.78;\n",
+      "FastEstimator-Eval: step: 375; epoch: 5; Dice: 0.25157312; Dice_AlphaGranule: 0.09126292; Dice_CanalicularVessel: 0.0; Dice_Cell: 0.8459115; Dice_GranuleBody: 0.0; Dice_GranuleCore: 0.5518494; Dice_Mitochondria: 0.020414837; loss: 0.14314592;\n",
+      "FastEstimator-Train: step: 450; loss: 0.036384713; steps/sec: 0.42;\n",
+      "FastEstimator-Train: step: 450; epoch: 6; epoch_time(sec): 179.49;\n",
+      "FastEstimator-Eval: step: 450; epoch: 6; Dice: 0.24621534; Dice_AlphaGranule: 0.07902191; Dice_CanalicularVessel: 0.0016777955; Dice_Cell: 0.81178457; Dice_GranuleBody: 0.0; Dice_GranuleCore: 0.5809567; Dice_Mitochondria: 0.0038511453; loss: 0.19332533;\n",
+      "FastEstimator-Train: step: 525; loss: 0.032831687; steps/sec: 0.42;\n",
+      "FastEstimator-Train: step: 525; epoch: 7; epoch_time(sec): 177.97;\n",
+      "FastEstimator-Eval: step: 525; epoch: 7; Dice: 0.36281154; Dice_AlphaGranule: 0.3231712; Dice_CanalicularVessel: 0.15168218; Dice_Cell: 0.92331016; Dice_GranuleBody: 0.010409508; Dice_GranuleCore: 0.75507385; Dice_Mitochondria: 0.013222287; loss: 0.099501915;\n",
+      "FastEstimator-Train: step: 600; loss: 0.039932176; steps/sec: 0.42;\n",
+      "FastEstimator-Train: step: 600; epoch: 8; epoch_time(sec): 178.89;\n",
+      "FastEstimator-Eval: step: 600; epoch: 8; Dice: 0.40107933; Dice_AlphaGranule: 0.43582454; Dice_CanalicularVessel: 0.15312457; Dice_Cell: 0.9320569; Dice_GranuleBody: 0.11979302; Dice_GranuleCore: 0.76528555; Dice_Mitochondria: 0.0003915782; loss: 0.07295823;\n",
+      "FastEstimator-Train: step: 675; loss: 0.025439756; steps/sec: 0.42;\n",
+      "FastEstimator-Train: step: 675; epoch: 9; epoch_time(sec): 180.04;\n",
+      "FastEstimator-Eval: step: 675; epoch: 9; Dice: 0.39481708; Dice_AlphaGranule: 0.3910953; Dice_CanalicularVessel: 0.14935504; Dice_Cell: 0.930211; Dice_GranuleBody: 0.118480444; Dice_GranuleCore: 0.7636419; Dice_Mitochondria: 0.016118763; loss: 0.094853036;\n",
+      "FastEstimator-Train: step: 750; loss: 0.016932765; steps/sec: 0.42;\n",
+      "FastEstimator-Train: step: 750; epoch: 10; epoch_time(sec): 180.29;\n",
+      "FastEstimator-Eval: step: 750; epoch: 10; Dice: 0.3541808; Dice_AlphaGranule: 0.17112847; Dice_CanalicularVessel: 0.16391844; Dice_Cell: 0.8922416; Dice_GranuleBody: 0.14522946; Dice_GranuleCore: 0.7323538; Dice_Mitochondria: 0.020212961; loss: 0.15120216;\n",
+      "FastEstimator-Finish: step: 750; model_lr: 1e-04; total_time(sec): 2069.42;\n"
+     ]
+    }
+   ],
+   "source": [
+    "# estimator.fit()  # Uncomment this if you want to re-run the training yourself"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that your steps/sec as reported by logging will be much lower when using slicers than you might normally expect, since each 'step' is now actually 24 mini-steps."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='ta17slide'></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Example Usecase 2: Using a sliding window to work around GPU memory limits\n",
+    "\n",
+    "Let's imagine a world where you wanted to work with this cell data, but in which FE had not implemented it's convenient dataset tiling feature for you. Instead you are confronted with some gigantic images:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Training Samples: 1\n",
+      "Eval Samples: 1\n",
+      "Train Image Shape: (800, 800, 50)\n",
+      "Train Label Shape: (800, 800, 50, 6)\n",
+      "Eval Sample Shape: (800, 800, 24)\n",
+      "Eval Label Shape: (800, 800, 24, 6)\n"
+     ]
+    }
+   ],
+   "source": [
+    "from fastestimator.dataset.data.em_3d import load_data\n",
+    "\n",
+    "train_data, eval_data = load_data(tile=False)\n",
+    "print(f\"Training Samples: {len(train_data)}\")\n",
+    "print(f\"Eval Samples: {len(eval_data)}\")\n",
+    "print(f\"Train Image Shape: {train_data[0]['image'].shape}\")\n",
+    "print(f\"Train Label Shape: {train_data[0]['label'].shape}\")\n",
+    "print(f\"Eval Sample Shape: {eval_data[0]['image'].shape}\")\n",
+    "print(f\"Eval Label Shape: {eval_data[0]['label'].shape}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll use the same pipeline processing from our first usecase:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import fastestimator as fe\n",
+    "from fastestimator.op.numpyop.meta import Sometimes\n",
+    "from fastestimator.op.numpyop.multivariate import HorizontalFlip, VerticalFlip\n",
+    "from fastestimator.op.numpyop.univariate import Minmax\n",
+    "from fastestimator.op.numpyop.univariate.expand_dims import ExpandDims\n",
+    "\n",
+    "pipeline = fe.Pipeline(\n",
+    "    train_data=train_data,\n",
+    "    eval_data=eval_data,\n",
+    "    batch_size=1,\n",
+    "    ops=[\n",
+    "        Sometimes(numpy_op=HorizontalFlip(image_in=\"image\", mask_in=\"label\", mode='train')),\n",
+    "        Sometimes(numpy_op=VerticalFlip(image_in=\"image\", mask_in=\"label\", mode='train')),\n",
+    "        Minmax(inputs=\"image\", outputs=\"image\"),\n",
+    "        ExpandDims(inputs=\"image\", outputs=\"image\"),  # We'll add a channel dimension to the images\n",
+    "    ], \n",
+    "    num_process=0)  # Since we only have 1 image to work with we'll turn off multi-processing"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Image Batch Shape: torch.Size([1, 800, 800, 50, 1])\n",
+      "Label Batch Shape: torch.Size([1, 800, 800, 50, 6])\n"
+     ]
+    }
+   ],
+   "source": [
+    "sample_batch = pipeline.get_results()\n",
+    "print(f\"Image Batch Shape: {sample_batch['image'].shape}\")\n",
+    "print(f\"Label Batch Shape: {sample_batch['label'].shape}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### The Network\n",
+    "\n",
+    "Rather than cutting the data beforehand, we can use a `SlidingSlicer` to move over it in a sliding-window fashion. Each chunk of data is run through the network separately and then re-combined before being passed on to subsequent `Network` post-processing `Ops` or `Traces`. You'll also need to specify how to un-slice (re-combine) the data which is generated during the repeated forward passes over the `Network`. In this case we will use a `MeanUnslicer` in order to merge our loss terms together for log printing, and re-use our `SlidingSlicer` to paste the network predictions back into a 3D volume.\n",
+    "\n",
+    "Let's cut our image into windows of size (256, 256, 1) and then run them through a 2D network. In this case we don't want to cut along the batch or channel dimensions, so we will set their values to -1 in the `SlidingSlicer` window_size argument. Note that 256 does not evenly divide into 800. SlidingSlicer gives you several ways to handle this. By default it will simply drop any leftover data along each window axis. You can instead keep partial slices by switching the 'pad_mode' to 'partial', or using padding to fill out the final slices by switching 'pad_mode' to 'constant'. You could also consider customizing the 'strides' such that each window partially overlaps with the previous in such a way that your overall output properly tiles. In our example, you could stride by 136 to achieve this (136*4+256=800). When overlapping strides are re-combined later, any values where there is overlap will be averaged together. If you prefer a simple sum you can change this by modifying the 'unslice_mode' option.\n",
+    "\n",
+    "Let's use the stride method here for the sake of example. Since we are feeding our data into a 2D network, we'll also use the 'squeeze_window' ability of our SlidingSlicer to automatically remove our z axis during forward passes: "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "import tensorflow as tf\n",
+    "\n",
+    "from fastestimator.architecture.tensorflow import UNet\n",
+    "from fastestimator.op.tensorop.loss import CrossEntropy\n",
+    "from fastestimator.op.tensorop.model import ModelOp, UpdateOp\n",
+    "from fastestimator.slicer import SlidingSlicer, MeanUnslicer\n",
+    "\n",
+    "model = fe.build(model_fn=lambda: UNet(input_size=(256, 256, 1), output_channel=6),\n",
+    "                 optimizer_fn=lambda: tf.optimizers.legacy.Adam(learning_rate=0.0001),)\n",
+    "network = fe.Network(\n",
+    "    ops=[\n",
+    "        ModelOp(inputs=\"image\", model=model, outputs=\"pred\"),\n",
+    "        CrossEntropy(inputs=(\"pred\", \"label\"), outputs=\"loss\", form=\"binary\"),\n",
+    "        UpdateOp(model=model, loss_name=\"loss\")\n",
+    "    ], \n",
+    "    slicers=[\n",
+    "        SlidingSlicer(slice=[\"image\", \"label\"], \n",
+    "                      unslice=[\"pred\"], \n",
+    "                      window_size=(-1, 256, 256, 1, -1), \n",
+    "                      strides=(0, 136, 136, 1, 0),\n",
+    "                      squeeze_window=True,\n",
+    "                     ),\n",
+    "        MeanUnslicer(unslice=\"loss\")\n",
+    "    ])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's take a look at a sample prediction after running through the network. This is going to take a while, since a single step is now responsible for processing 5x5x50=1250 mini-batches."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Image Batch Shape: (1, 800, 800, 50, 1)\n",
+      "Label Batch Shape: (1, 800, 800, 50, 6)\n",
+      "Prediction Batch Shape: (1, 800, 800, 50, 6)\n",
+      "Mean Loss Value: 0.9557278156280518\n"
+     ]
+    }
+   ],
+   "source": [
+    "# sample_prediction = network.transform(data=sample_batch, mode='eval')  # Uncomment this if you want to inspect the shapes yourself\n",
+    "# print(f\"Image Batch Shape: {sample_prediction['image'].shape}\")\n",
+    "# print(f\"Label Batch Shape: {sample_prediction['label'].shape}\")\n",
+    "# print(f\"Prediction Batch Shape: {sample_prediction['pred'].shape}\")\n",
+    "# print(f\"Mean Loss Value: {sample_prediction['loss']}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, let's add in a metric trace and see the training:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "from fastestimator.trace.metric import Dice\n",
+    "\n",
+    "channel_mapping={0: 'Cell', 1: 'Mitochondria', 2: 'AlphaGranule',\n",
+    "                 3: 'CanalicularVessel', 4: 'GranuleBody', 5: 'GranuleCore'}\n",
+    "\n",
+    "traces=[Dice(true_key=\"label\", pred_key=\"pred\", channel_mapping=channel_mapping)]\n",
+    "\n",
+    "estimator = fe.Estimator(\n",
+    "    pipeline=pipeline,\n",
+    "    network=network,\n",
+    "    traces=traces,\n",
+    "    log_steps=1,\n",
+    "    eval_log_steps=[-1],\n",
+    "    epochs=10) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "    ______           __  ______     __  _                 __            \n",
+      "   / ____/___ ______/ /_/ ____/____/ /_(_)___ ___  ____ _/ /_____  _____\n",
+      "  / /_  / __ `/ ___/ __/ __/ / ___/ __/ / __ `__ \\/ __ `/ __/ __ \\/ ___/\n",
+      " / __/ / /_/ (__  ) /_/ /___(__  ) /_/ / / / / / / /_/ / /_/ /_/ / /    \n",
+      "/_/    \\__,_/____/\\__/_____/____/\\__/_/_/ /_/ /_/\\__,_/\\__/\\____/_/     \n",
+      "                                                                        \n",
+      "\n",
+      "\u001b[93mFastEstimator-Warn: No ModelSaver Trace detected. Models will not be saved.\u001b[00m\n",
+      "FastEstimator-Start: step: 1; logging_interval: 1; num_device: 1;\n",
+      "FastEstimator-Train: step: 1; loss: 0.09241561;\n",
+      "FastEstimator-Train: step: 1; epoch: 1; epoch_time(sec): 187.88;\n",
+      "FastEstimator-Eval: step: 1; epoch: 1; Dice: 0.19790895; Dice_AlphaGranule: 0.0; Dice_CanalicularVessel: 0.0; Dice_Cell: 0.76499873; Dice_GranuleBody: 0.0; Dice_GranuleCore: 0.42245498; Dice_Mitochondria: 0.0; loss: 0.17678283;\n",
+      "FastEstimator-Train: step: 2; loss: 0.05950647; steps/sec: 0.0;\n",
+      "FastEstimator-Train: step: 2; epoch: 2; epoch_time(sec): 207.26;\n",
+      "FastEstimator-Eval: step: 2; epoch: 2; Dice: 0.31357098; Dice_AlphaGranule: 0.27818844; Dice_CanalicularVessel: 0.0; Dice_Cell: 0.91047233; Dice_GranuleBody: 0.0; Dice_GranuleCore: 0.68593067; Dice_Mitochondria: 0.006834461; loss: 0.09680609;\n",
+      "FastEstimator-Train: step: 3; loss: 0.047980543; steps/sec: 0.0;\n",
+      "FastEstimator-Train: step: 3; epoch: 3; epoch_time(sec): 225.46;\n",
+      "FastEstimator-Eval: step: 3; epoch: 3; Dice: 0.2589626; Dice_AlphaGranule: 0.00012370278; Dice_CanalicularVessel: 0.0; Dice_Cell: 0.87941015; Dice_GranuleBody: 0.0; Dice_GranuleCore: 0.6742417; Dice_Mitochondria: 0.0; loss: 0.13281296;\n",
+      "FastEstimator-Train: step: 4; loss: 0.03970469; steps/sec: 0.0;\n",
+      "FastEstimator-Train: step: 4; epoch: 4; epoch_time(sec): 303.56;\n",
+      "FastEstimator-Eval: step: 4; epoch: 4; Dice: 0.2699795; Dice_AlphaGranule: 0.0039450238; Dice_CanalicularVessel: 0.0; Dice_Cell: 0.87593764; Dice_GranuleBody: 0.0; Dice_GranuleCore: 0.738118; Dice_Mitochondria: 0.0018762958; loss: 0.15984353;\n",
+      "FastEstimator-Train: step: 5; loss: 0.035081092; steps/sec: 0.0;\n",
+      "FastEstimator-Train: step: 5; epoch: 5; epoch_time(sec): 343.57;\n",
+      "FastEstimator-Eval: step: 5; epoch: 5; Dice: 0.28861472; Dice_AlphaGranule: 0.10057701; Dice_CanalicularVessel: 0.0; Dice_Cell: 0.878825; Dice_GranuleBody: 0.0; Dice_GranuleCore: 0.73525584; Dice_Mitochondria: 0.017030539; loss: 0.15729764;\n",
+      "FastEstimator-Train: step: 6; loss: 0.030691482; steps/sec: 0.0;\n",
+      "FastEstimator-Train: step: 6; epoch: 6; epoch_time(sec): 373.16;\n",
+      "FastEstimator-Eval: step: 6; epoch: 6; Dice: 0.2974657; Dice_AlphaGranule: 0.10909026; Dice_CanalicularVessel: 0.0; Dice_Cell: 0.91101515; Dice_GranuleBody: 0.0; Dice_GranuleCore: 0.74959046; Dice_Mitochondria: 0.0150984535; loss: 0.134259;\n",
+      "FastEstimator-Train: step: 7; loss: 0.040506963; steps/sec: 0.0;\n",
+      "FastEstimator-Train: step: 7; epoch: 7; epoch_time(sec): 384.6;\n",
+      "FastEstimator-Eval: step: 7; epoch: 7; Dice: 0.3132342; Dice_AlphaGranule: 0.36752912; Dice_CanalicularVessel: 0.10559372; Dice_Cell: 0.8301301; Dice_GranuleBody: 0.0; Dice_GranuleCore: 0.55129784; Dice_Mitochondria: 0.02485453; loss: 0.1310871;\n",
+      "FastEstimator-Train: step: 8; loss: 0.03810389; steps/sec: 0.0;\n",
+      "FastEstimator-Train: step: 8; epoch: 8; epoch_time(sec): 488.05;\n",
+      "FastEstimator-Eval: step: 8; epoch: 8; Dice: 0.3384758; Dice_AlphaGranule: 0.10329177; Dice_CanalicularVessel: 0.3118691; Dice_Cell: 0.8723342; Dice_GranuleBody: 0.0; Dice_GranuleCore: 0.69752693; Dice_Mitochondria: 0.045832805; loss: 0.1552314;\n",
+      "FastEstimator-Train: step: 9; loss: 0.030884113; steps/sec: 0.0;\n",
+      "FastEstimator-Train: step: 9; epoch: 9; epoch_time(sec): 550.86;\n",
+      "FastEstimator-Eval: step: 9; epoch: 9; Dice: 0.34353375; Dice_AlphaGranule: 0.12995201; Dice_CanalicularVessel: 0.033380825; Dice_Cell: 0.87134874; Dice_GranuleBody: 0.25112656; Dice_GranuleCore: 0.74927706; Dice_Mitochondria: 0.026117384; loss: 0.15764695;\n",
+      "FastEstimator-Train: step: 10; loss: 0.027712101; steps/sec: 0.0;\n",
+      "FastEstimator-Train: step: 10; epoch: 10; epoch_time(sec): 572.82;\n",
+      "FastEstimator-Eval: step: 10; epoch: 10; Dice: 0.4659363; Dice_AlphaGranule: 0.08518501; Dice_CanalicularVessel: 0.6543881; Dice_Cell: 0.8772722; Dice_GranuleBody: 0.37757555; Dice_GranuleCore: 0.7437467; Dice_Mitochondria: 0.057450105; loss: 0.14906605;\n",
+      "FastEstimator-Finish: step: 10; model1_lr: 1e-04; total_time(sec): 5205.04;\n"
+     ]
+    }
+   ],
+   "source": [
+    "# estimator.fit()  # Uncomment this if you want to re-run the training yourself"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that your steps/sec as reported by logging will be much lower when using slicers than you might normally expect, since each 'step' is now actually 1250 mini-steps."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='ta17customize'></a>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Building Your Own Slicer\n",
+    "\n",
+    "If the existing Slicers don't meet your needs, you can always customize your own. To do so, simply inherit the base class and implement one or both of the abstract methods defined there:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from fastestimator.slicer.slicer import Slicer\n",
+    "\n",
+    "class DoubleBatchSlicer(Slicer):\n",
+    "    def _slice_batch(self, batch):\n",
+    "        # Implement this method if you want your slicer to be able to cut keys apart\n",
+    "        # In this toy example we just duplicate the batch tensor twice\n",
+    "        return [batch, batch]\n",
+    "    \n",
+    "    def _unslice_batch(self, slices, key):\n",
+    "        # Implement this method if you want your slicer to be able to put keys back together\n",
+    "        # In our toy example we just ignore the second mini-batch that we created\n",
+    "        return slices[0]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As a slightly more practical example, suppose that when recording loss values while using a slicer, you want to get the maximum loss rather than the mean. You could implement a MaxUnslicer as follows:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "class MaxUnslicer(Slicer):\n",
+    "    def __init__(self, unslice, mode=None, ds_id=None):\n",
+    "        super().__init__(slice=None, unslice=unslice, mode=mode, ds_id=ds_id)\n",
+    "    def _unslice_batch(self, slices, key):\n",
+    "        maks = slices[0]\n",
+    "        for minibatch in slices[1:]:\n",
+    "            maks = max(maks, minibatch)\n",
+    "        return maks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's test out our new creation:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "loss values: [[0.7506162 ]\n",
+      " [0.07465518]\n",
+      " [0.4861052 ]\n",
+      " [0.9194704 ]\n",
+      " [0.28890288]]\n",
+      "number of slices: 5\n",
+      "max loss: [0.9194704]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from fastestimator.slicer.slicer import forward_slicers, reverse_slicers\n",
+    "\n",
+    "loss = tf.random.uniform((5,1))\n",
+    "print(f\"loss values: {loss}\")\n",
+    "batch = {\"loss\": loss}\n",
+    "\n",
+    "axis_slicer = AxisSlicer(slice=\"loss\", unslice=None, axis=0)\n",
+    "max_unslicer = MaxUnslicer(unslice=\"loss\")\n",
+    "\n",
+    "mini_batches = forward_slicers(slicers=[axis_slicer, max_unslicer], data=batch)\n",
+    "print(f\"number of slices: {len(mini_batches)}\")\n",
+    "output = reverse_slicers(slicers=[axis_slicer, max_unslicer], data=mini_batches, original_data=batch)\n",
+    "\n",
+    "print(f\"max loss: {output['loss']}\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
slicer tutorial (+9 squashed commits)
Squashed commits:
[2daffb8d] fix slicers to return original data when no un-slicer is assigned [58882c01] fix slicer w/ multi input keys
[56bd6638] make labels float32 rather than float64 in em_3d dataset [32d733f2] add an un-slicing implementation to the SlidingSlicer [e3aecf82] fix padding to work with strides, corresponding tests [3565e5f4] preliminary sliding window slicer implementation [120187d6] fix lockup when user creates a new array after batching their pipeline data and needing a partial final batch [706180d5] block un-slicing if no slicing is performed [580c374a] add slicers to traceability report diagram (+11 squashed commits) Squashed commits:
[cc8c5f5e] get slicers in traceability tables
[8df6116c] hook up slicers to RestoreWizard
[e1c8f0dd] PR test for slicer
[0aa52ef4] unit tests
[e9cf1c57] mean slicer
[23a0f65a] clean up nuances with key checking
[4f0ecca8] feed data properly into slicers when there are multiple keys [7cbce1af] modify network to enforce proper usage
[6d2f0459] start shifting key checking around
[85c3ccee] enhance slicer to work on inputs & outputs [c0e629cc] preliminary slicer implementation. need to re-design to figure out how to handle keys which are generated during network ops rather than just taking the zeroth element and calling it a day