### PR TITLE
adding new min and new max to minmax operator

### DIFF
--- a/fastestimator/op/numpyop/univariate/minmax.py
+++ b/fastestimator/op/numpyop/univariate/minmax.py
@@ -49,6 +49,7 @@ class Minmax(NumpyOp):
         self.new_min = new_min
         self.new_max = new_max
         self.in_list, self.out_list = True, True
+        assert new_max > new_min, "the new_max should be greater than new_min."
 
     def forward(self, data: List[np.ndarray], state: Dict[str, Any]) -> List[np.ndarray]:
         return [self._apply_minmax(elem) for elem in data]

--- a/fastestimator/op/numpyop/univariate/minmax.py
+++ b/fastestimator/op/numpyop/univariate/minmax.py
@@ -33,15 +33,21 @@ class Minmax(NumpyOp):
         ds_id: What dataset id(s) to execute this Op in. To execute regardless of ds_id, pass None. To execute in all
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         epsilon: A small value to prevent numeric instability in the division.
+        new_min: The desired minimum value after the minmax operation.
+        new_max: The desired maximum value after the minmax operation.
     """
     def __init__(self,
                  inputs: Union[str, Iterable[str]],
                  outputs: Union[str, Iterable[str]],
                  mode: Union[None, str, Iterable[str]] = None,
                  ds_id: Union[None, str, Iterable[str]] = None,
-                 epsilon: float = 1e-7):
+                 epsilon: float = 1e-7,
+                 new_min: float = 0.0,
+                 new_max: float = 1.0):
         super().__init__(inputs=inputs, outputs=outputs, mode=mode, ds_id=ds_id)
         self.epsilon = epsilon
+        self.new_min = new_min
+        self.new_max = new_max
         self.in_list, self.out_list = True, True
 
     def forward(self, data: List[np.ndarray], state: Dict[str, Any]) -> List[np.ndarray]:
@@ -50,5 +56,6 @@ class Minmax(NumpyOp):
     def _apply_minmax(self, data: np.ndarray) -> np.ndarray:
         data_max = np.max(data)
         data_min = np.min(data)
-        data = (data - data_min) / max((data_max - data_min), self.epsilon)
+        data_rescaled = (data - data_min) / max((data_max - data_min), self.epsilon)
+        data = data_rescaled * (self.new_max - self.new_min) + self.new_min
         return data.astype(np.float32)

--- a/test/PR_test/unit_test/op/numpyop/univariate/test_minmax.py
+++ b/test/PR_test/unit_test/op/numpyop/univariate/test_minmax.py
@@ -25,6 +25,7 @@ class TestMinmax(unittest.TestCase):
     def setUpClass(cls):
         cls.single_input = [np.array([1, 2, 3, 5])]
         cls.single_output = [np.array([0, 0.25, 0.5, 1])]
+        cls.single_output_new_min_new_max = [np.array([-10, -5, 0, 10])]
         cls.multi_input = [np.array([2, 2]), np.array([0, 1, 2])]
         cls.multi_output = [np.array([0, 0]), np.array([0, 0.5, 1])]
 
@@ -37,3 +38,8 @@ class TestMinmax(unittest.TestCase):
         op = Minmax(inputs='x', outputs='x')
         data = op.forward(data=self.multi_input, state={})
         self.assertTrue(is_equal(data, self.multi_output))
+
+    def test_new_min_new_max(self):
+        op = Minmax(inputs='x', outputs='x', new_min=-10, new_max=10)
+        data = op.forward(data=self.single_input, state={})
+        self.assertTrue(is_equal(data, self.single_output_new_min_new_max))


### PR DESCRIPTION
# Requirements

`Minmax` should be able to output results in arbitrary min and max value defined by user. 

# Target Audience

* Users

# Design / Implementation Details

Adding new arguments: `new_min` and `new_max` to `Minmax`, such that the results will be further scaled by the `new_min` and `new_max`. 

# Known Issues / Limitations

Nope, not at all 😉 . 

Except when AGI is ready it would obsolete everything, including this PR. 