### PR TITLE
docstrings updated for expected display on website

### DIFF
--- a/fastestimator/op/tensorop/loss/cross_entropy.py
+++ b/fastestimator/op/tensorop/loss/cross_entropy.py
@@ -31,7 +31,7 @@ class CrossEntropy(LossOp):
     """Calculate Element-Wise CrossEntropy (binary, categorical or sparse categorical).
 
     Args:
-        inputs: A tuple or list like: [<y_pred>, <y_true>].
+        inputs: A tuple or list like: [y_pred, y_true].
         outputs: String key under which to store the computed loss value.
         mode: What mode(s) to execute this Op in. For example, "train", "eval", "test", or "infer". To execute
             regardless of mode, pass None. To execute in all modes except for a particular one, you can pass an argument

--- a/fastestimator/op/tensorop/loss/focal_loss.py
+++ b/fastestimator/op/tensorop/loss/focal_loss.py
@@ -32,7 +32,7 @@ class FocalLoss(LossOp):
     Loss used in RetinaNet for dense detection: https://arxiv.org/abs/1708.02002.
 
     Args:
-        inputs: A tuple or list like: [<y_pred>, <y_true>].
+        inputs: A tuple or list like: [y_pred, y_true].
         outputs: String key under which to store the computed loss value.
         alpha: Weighting factor in range (0,1) to balance
                 positive vs negative examples or -1 to ignore. Default = 0.25

--- a/fastestimator/op/tensorop/loss/hinge.py
+++ b/fastestimator/op/tensorop/loss/hinge.py
@@ -30,7 +30,7 @@ class Hinge(LossOp):
     """Calculate the hinge loss between two tensors.
 
     Args:
-        inputs: A tuple or list like: [<y_pred>, <y_true>].
+        inputs: A tuple or list like: [y_pred, y_true].
         outputs: String key under which to store the computed loss.
         mode: What mode(s) to execute this Op in. For example, "train", "eval", "test", or "infer". To execute
             regardless of mode, pass None. To execute in all modes except for a particular one, you can pass an argument

--- a/fastestimator/op/tensorop/loss/loss.py
+++ b/fastestimator/op/tensorop/loss/loss.py
@@ -24,7 +24,7 @@ class LossOp(TensorOp):
     training showcase for an example of when this is useful).
 
     Args:
-        inputs: A tuple or list like: [<y_pred>, <y_true>].
+        inputs: A tuple or list like: [y_pred, y_true].
         outputs: String key under which to store the computed loss.
         mode: What mode(s) to execute this Op in. For example, "train", "eval", "test", or "infer". To execute
             regardless of mode, pass None. To execute in all modes except for a particular one, you can pass an argument

--- a/fastestimator/op/tensorop/loss/mean_squared_error.py
+++ b/fastestimator/op/tensorop/loss/mean_squared_error.py
@@ -30,7 +30,7 @@ class MeanSquaredError(LossOp):
     """Calculate the mean squared error loss between two tensors.
 
     Args:
-        inputs: A tuple or list like: [<y_pred>, <y_true>].
+        inputs: A tuple or list like: [y_pred, y_true].
         outputs: String key under which to store the computed loss.
         mode: What mode(s) to execute this Op in. For example, "train", "eval", "test", or "infer". To execute
             regardless of mode, pass None. To execute in all modes except for a particular one, you can pass an argument


### PR DESCRIPTION
# Requirements

1. Metrices [y_pred, y_true] not displayed on website, but are part of codebase

# Target Audience

* Users
* Developers

# Design / Implementation Details

Docstrings were updated from [<y_pred>, <y_true>] to [y_pred, y_true]

# Known Issues / Limitations

None
