### PR TITLE
Add a delete tensorOp

### DIFF
--- a/fastestimator/op/tensorop/__init__.py
+++ b/fastestimator/op/tensorop/__init__.py
@@ -25,7 +25,7 @@ __getattr__, __dir__, __all__ = lazy.attach(__name__,
                                                           'permute': ['Permute'],
                                                           'reshape': ['Reshape'],
                                                           'resize3d': ['Resize3D'],
-                                                          'tensorop': ['LambdaOp', 'TensorOp'],
+                                                          'tensorop': ['Delete', 'LambdaOp', 'TensorOp'],
                                                           'un_hadamard': ['UnHadamard']})
 
 if TYPE_CHECKING:
@@ -37,5 +37,5 @@ if TYPE_CHECKING:
     from fastestimator.op.tensorop.permute import Permute
     from fastestimator.op.tensorop.reshape import Reshape
     from fastestimator.op.tensorop.resize3d import Resize3D
-    from fastestimator.op.tensorop.tensorop import LambdaOp, TensorOp
+    from fastestimator.op.tensorop.tensorop import Delete, LambdaOp, TensorOp
     from fastestimator.op.tensorop.un_hadamard import UnHadamard

--- a/fastestimator/op/tensorop/tensorop.py
+++ b/fastestimator/op/tensorop/tensorop.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Any, Callable, Dict, Iterable, List, Optional, Set, TypeVar, Union
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, TypeVar, Union
 
 import tensorflow as tf
 import torch
@@ -131,3 +131,27 @@ class LambdaOp(TensorOp):
 
     def forward(self, data: List[Tensor], state: Dict[str, Any]) -> Union[Tensor, List[Tensor]]:
         return self.fn(*data)
+
+
+@traceable()
+class Delete(TensorOp):
+    """Delete key(s) and their associated values from the data dictionary.
+
+    The system has special logic to detect instances of this Op and delete its `inputs` from the data dictionary.
+
+    Args:
+        keys: Existing key(s) to be deleted from the data dictionary.
+        mode: What mode(s) to execute this Op in. For example, "train", "eval", "test", or "infer". To execute
+            regardless of mode, pass None. To execute in all modes except for a particular one, you can pass an argument
+            like "!infer" or "!train".
+        ds_id: What dataset id(s) to execute this Op in. To execute regardless of ds_id, pass None. To execute in all
+            ds_ids except for a particular one, you can pass an argument like "!ds1".
+    """
+    def __init__(self,
+                 keys: Union[str, Sequence[str]],
+                 mode: Union[None, str, Iterable[str]] = None,
+                 ds_id: Union[None, str, Iterable[str]] = None) -> None:
+        super().__init__(inputs=keys, mode=mode, ds_id=ds_id)
+
+    def forward(self, data: Union[Tensor, List[Tensor]], state: Dict[str, Any]) -> None:
+        pass

--- a/test/PR_test/integration_test/op/tensorop/test_delete.py
+++ b/test/PR_test/integration_test/op/tensorop/test_delete.py
@@ -1,0 +1,95 @@
+# Copyright 2023 The FastEstimator Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+import unittest
+
+import numpy as np
+import torch
+import torch.nn as nn
+from tensorflow.keras.layers import Input
+from tensorflow.keras.models import Model
+
+import fastestimator as fe
+from fastestimator.op.tensorop import Delete, LambdaOp
+from fastestimator.op.tensorop.model import ModelOp
+
+
+def TFModel():
+    inputs = Input((1, 1))
+    return Model(inputs=inputs, outputs=inputs)
+
+
+class TorchModel(nn.Module):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.dense = nn.Linear(in_features=1, out_features=1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return x
+
+
+def _new_key_network(model):
+    return fe.Network(ops=[
+        ModelOp(inputs="x", outputs="y_pred", model=model),
+        LambdaOp(inputs="x", outputs="x", fn=lambda x: x + 1),
+        Delete(keys="y_pred")
+    ])
+
+
+def _old_key_network(model):
+    return fe.Network(ops=[
+        ModelOp(inputs="x", outputs="y_pred", model=model),
+        LambdaOp(inputs="x", outputs="x", fn=lambda x: x + 1),
+        Delete(keys="x")
+    ])
+
+
+def _torch_model():
+    return fe.build(
+        model_fn=lambda: TorchModel(),
+        optimizer_fn="adam",
+    )
+
+
+def _tf_model():
+    return fe.build(
+        model_fn=lambda: TFModel(),
+        optimizer_fn="adam",
+    )
+
+
+def _batch():
+    return {"x": np.ones((1, 1), dtype=np.float32), "y": np.zeros((1, 1), dtype=np.uint8)}
+
+
+class TestSlicer(unittest.TestCase):
+    def test_delete_new_key_transform_tf(self):
+        result = _new_key_network(model=_tf_model()).transform(data=_batch(), mode="test")
+        self.assertIn("x", result.maps[0])
+        self.assertNotIn("y_pred", result.maps[0])
+
+    def test_delete_old_key_transform_tf(self):
+        result = _old_key_network(model=_tf_model()).transform(data=_batch(), mode="test")
+        self.assertNotIn("x", result.maps[0])
+        self.assertIn("y_pred", result.maps[0])
+
+    def test_delete_new_key_transform_torch(self):
+        result = _new_key_network(model=_torch_model()).transform(data=_batch(), mode="test")
+        self.assertIn("x", result.maps[0])
+        self.assertNotIn("y_pred", result.maps[0])
+
+    def test_delete_old_key_transform_torch(self):
+        result = _old_key_network(model=_torch_model()).transform(data=_batch(), mode="test")
+        self.assertNotIn("x", result.maps[0])
+        self.assertIn("y_pred", result.maps[0])

--- a/test/PR_test/integration_test/op/tensorop/test_delete.py
+++ b/test/PR_test/integration_test/op/tensorop/test_delete.py
@@ -25,12 +25,12 @@ from fastestimator.op.tensorop import Delete, LambdaOp
 from fastestimator.op.tensorop.model import ModelOp
 
 
-def TFModel():
+def _TFModel():
     inputs = Input((1, 1))
     return Model(inputs=inputs, outputs=inputs)
 
 
-class TorchModel(nn.Module):
+class _TorchModel(nn.Module):
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.dense = nn.Linear(in_features=1, out_features=1)
@@ -57,14 +57,14 @@ def _old_key_network(model):
 
 def _torch_model():
     return fe.build(
-        model_fn=lambda: TorchModel(),
+        model_fn=_TorchModel,
         optimizer_fn="adam",
     )
 
 
 def _tf_model():
     return fe.build(
-        model_fn=lambda: TFModel(),
+        model_fn=_TFModel,
         optimizer_fn="adam",
     )
 


### PR DESCRIPTION
# Requirements

1. Suppose a user wants to use the new Slicer feature in conjunction with network.transform(). Further suppose that the user has created some intermediate keys in the network which they don't care about afterwards. During training these keys would be automatically pruned, but during transform() we don't know we can prune them and so the slicer logic demands that you specify how to unslice them. It would be convenient if the user could work around this without having to actually unslice the keys they don't care about.

# Target Audience

* Users

# Design / Implementation Details

This PR introduces a Delete TensorOp which is analogous to the Delete NumpyOp. 

# Known Issues / Limitations

Suppose the user provides a key "x" as input into the network. Then Delete("x") will remove any network-based modifications to "x", but the original "x" will still be available downstream of the network. This is because of a nuance of TensorFlow where we can't edit the original input dictionary from within the forward pass of the network. This may be confusing for users who happen to run into it, but it won't break what they're trying to do and the entire situation is already an edge-case of an edge-case anyways.
