### PR TITLE
update tests b/c TF multi-gpu doesn't return chainmaps

### DIFF
--- a/test/PR_test/integration_test/op/tensorop/test_delete.py
+++ b/test/PR_test/integration_test/op/tensorop/test_delete.py
@@ -76,13 +76,15 @@ def _batch():
 class TestSlicer(unittest.TestCase):
     def test_delete_new_key_transform_tf(self):
         result = _new_key_network(model=_tf_model()).transform(data=_batch(), mode="test")
-        self.assertIn("x", result.maps[0])
-        self.assertNotIn("y_pred", result.maps[0])
+        self.assertIn("x", result)
+        np.testing.assert_array_almost_equal(result['x'], [[2]])
+        self.assertNotIn("y_pred", result)
 
     def test_delete_old_key_transform_tf(self):
         result = _old_key_network(model=_tf_model()).transform(data=_batch(), mode="test")
-        self.assertNotIn("x", result.maps[0])
-        self.assertIn("y_pred", result.maps[0])
+        # X will still be in the response, but it's value should be the old input value rather than the updated value
+        np.testing.assert_array_almost_equal(result["x"], [[1]])
+        self.assertIn("y_pred", result)
 
     def test_delete_new_key_transform_torch(self):
         result = _new_key_network(model=_torch_model()).transform(data=_batch(), mode="test")


### PR DESCRIPTION
# Requirements

1. Fix the Delete TensorOp multi-gpu tests

```
======================================================================
ERROR: test_delete_new_key_transform_tf (integration_test.op.tensorop.test_delete.TestSlicer)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ubuntu/jenkins/workspace/nightly/test/PR_test/integration_test/op/tensorop/test_delete.py", line 79, in test_delete_new_key_transform_tf
    self.assertIn("x", result.maps[0])
AttributeError: 'dict' object has no attribute 'maps'
======================================================================
ERROR: test_delete_old_key_transform_tf (integration_test.op.tensorop.test_delete.TestSlicer)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/ubuntu/jenkins/workspace/nightly/test/PR_test/integration_test/op/tensorop/test_delete.py", line 84, in test_delete_old_key_transform_tf
    self.assertNotIn("x", result.maps[0])
AttributeError: 'dict' object has no attribute 'maps'
```

# Target Audience

* Developers

# Design / Implementation Details

TensorFlow multi-gpu parses the .transform() output into a dictionary rather than returning a chain map due to the way that it needs to prune batches that didn't divide evening over the GPUs. Modify the tests to not assume that TF will return a chain map.

# Known Issues / Limitations

None.
