### PR TITLE
Supposedly fixing the LoRA Apphub nightly test

### DIFF
--- a/apphub/foundation_model/lora/lora.ipynb
+++ b/apphub/foundation_model/lora/lora.ipynb
@@ -61,7 +61,8 @@
     "from fastestimator.op.tensorop.model import ModelOp, UpdateOp\n",
     "from fastestimator.trace.io import BestModelSaver\n",
     "from fastestimator.trace.metric import Dice\n",
-    "from fastestimator.util.google_download_util import download_file_from_google_drive"
+    "from fastestimator.util.google_download_util import download_file_from_google_drive\n",
+    "from fastestimator.util.util import get_num_gpus"
    ]
   },
   {
@@ -84,7 +85,7 @@
    "outputs": [],
    "source": [
     "epochs = 1\n",
-    "batch_size = 2\n",
+    "batch_size_per_gpu = 2\n",
     "train_steps_per_epoch = None\n",
     "eval_steps_per_epoch = None\n",
     "base_encoder_weights = \"sam_b\"\n",
@@ -123,7 +124,7 @@
     "pipeline = fe.Pipeline(\n",
     "    train_data=ds_train,\n",
     "    eval_data=ds_eval,\n",
-    "    batch_size=batch_size,\n",
+    "    batch_size=get_num_gpus() * batch_size_per_gpu,\n",
     "    ops=[\n",
     "        ReadImage(inputs=\"image\", parent_path=ds_train.parent_path, outputs=\"image\"),\n",
     "        ReadImage(inputs=\"mask_left\", parent_path=ds_train.parent_path, outputs=\"mask_left\", color_flag='gray'),\n",
@@ -545,8 +546,7 @@
     "\n",
     "    def load_lora_weights(self, save_path):\n",
     "        print(\"Loading LoRA weights from {}...\".format(save_path))\n",
-    "        self.lora_modules.load_state_dict(\n",
-    "            torch.load(save_path, map_location='cpu' if torch.cuda.device_count() == 0 else None))\n",
+    "        self.lora_modules.load_state_dict(torch.load(save_path, map_location='cpu' if get_num_gpus() == 0 else None))\n",
     "\n",
     "    def save_lora_weights(self, save_dir, name=\"lora\"):\n",
     "        save_path = os.path.join(save_dir, \"{}.pt\".format(name))\n",

--- a/apphub/foundation_model/lora/lora_torch.py
+++ b/apphub/foundation_model/lora/lora_torch.py
@@ -510,7 +510,7 @@ def download_sam_encoder_b(save_dir):
 
 
 def get_estimator(epochs=1,
-                  batch_size=2,
+                  batch_size_per_gpu=2,
                   train_steps_per_epoch=None,
                   eval_steps_per_epoch=None,
                   base_encoder_weights="sam_b",
@@ -523,7 +523,7 @@ def get_estimator(epochs=1,
     pipeline = fe.Pipeline(
         train_data=ds_train,
         eval_data=ds_eval,
-        batch_size=batch_size,
+        batch_size=get_num_gpus() * batch_size_per_gpu,
         ops=[
             ReadImage(inputs="image", parent_path=ds_train.parent_path, outputs="image"),
             ReadImage(inputs="mask_left", parent_path=ds_train.parent_path, outputs="mask_left", color_flag='gray'),

--- a/test/apphub_scripts/foundation_model/lora/run_nb.sh
+++ b/test/apphub_scripts/foundation_model/lora/run_nb.sh
@@ -24,7 +24,7 @@ dir_path="$(dirname "$full_path")"
 # 2. The expression for the above setup is "-p epochs 2 -p batch_size 8 -p train_steps_per_epoch 2"
 # 3. The arguement will re-declare the variable right after the jupyter notebook cell with "parameters" tag (there \
 # must be one and only cell with "parameters" tag)
-train_info=(-p epochs 1 -p train_steps_per_epoch 2 -p eval_steps_per_epoch 2 -p batch_size 2 -p base_encoder_weights None)
+train_info=(-p epochs 1 -p train_steps_per_epoch 2 -p eval_steps_per_epoch 2 -p batch_size_per_gpu 1 -p base_encoder_weights None)
 
 # ==============================================================================================
 

--- a/test/apphub_scripts/foundation_model/lora/run_torch.sh
+++ b/test/apphub_scripts/foundation_model/lora/run_torch.sh
@@ -21,7 +21,7 @@ example_name="lora"
 # 1. Usually we set the epochs:2, batch_size:2, train_steps_per_epoch:2
 # 2. The expression for the following setup is "--epochs 2 --batch_size 8 --train_steps_per_epoch 2"
 # 3. The syntax of this expression is different from run_notebook.py
-train_info=(--epochs 1 --train_steps_per_epoch 2 --eval_steps_per_epoch 2 --batch_size 2 --base_encoder_weights None)
+train_info=(--epochs 1 --train_steps_per_epoch 2 --eval_steps_per_epoch 2 --batch_size_per_gpu 1 --base_encoder_weights None)
 
 # Do you want to run "fastestimator test"? (bool)
 need_test=0


### PR DESCRIPTION
# Requirements

Our current nightly test gpu machines have limited GPU memory to test SAM architecture. This code change will make sure we use the minimal batch size for both single gpu and multi-gpu for the apphub.  

# Target Audience
* Developers


# Design / Implementation Details

Introduced a minimal `batch_size_per_gpu` during test so that it can scale accordingly with multi-gpu system. 

# Known Issues / Limitations

We will also need to change our gpu instances. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

Refactor:
- Updated the handling of batch sizes in the LoRa model to improve performance and efficiency. The `batch_size` parameter has been renamed to `batch_size_per_gpu`, allowing for different batch sizes per GPU. This change affects the `get_estimator` function and the `train_info` variable in both the notebook and Python script files.

Tests:
- Adjusted the `train_info` variable in the test scripts to align with the new `batch_size_per_gpu` parameter, ensuring accurate testing of the training process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->