### PR TITLE
update sliding slicer

### DIFF
--- a/fastestimator/slicer/sliding_slicer.py
+++ b/fastestimator/slicer/sliding_slicer.py
@@ -149,7 +149,6 @@ class SlidingSlicer(Slicer):
     def _get_cuts(self, data_shape: List[int], stride_template: List[Optional[slice]]) -> List[List[slice]]:
         results = []
         for axis, cut_template in enumerate(stride_template):
-            pad_break = False
             if cut_template is None:
                 target_shape = data_shape[axis]
                 for start in range(0, target_shape, self.strides[axis]):
@@ -161,13 +160,13 @@ class SlidingSlicer(Slicer):
                             stop = target_shape
                         else:
                             # Padding the input
-                            pad_break = True
+                            pass
 
                     new_cut = slice(start, stop)
                     new_template = list(stride_template)
                     new_template[axis] = new_cut
                     results.extend(self._get_cuts(data_shape, new_template))
-                    if pad_break or stop:
+                    if stop >= target_shape:
                         break
                 # Each level of recursion should only solve one axis, so break here
                 break
@@ -185,7 +184,7 @@ class SlidingSlicer(Slicer):
                     for start in list(range(0, tru, stride)):
                         stop = start + win
                         if stop >= tru:
-                            axis_pad = stop - tru
+                            axis_pad = int(stop - tru)
                             break
                 paddings.append([0, axis_pad])
             if isinstance(batch, torch.Tensor):

--- a/test/PR_test/unit_test/slicer/test_sliding_slicer.py
+++ b/test/PR_test/unit_test/slicer/test_sliding_slicer.py
@@ -182,19 +182,19 @@ class TestSlidingSlicer(unittest.TestCase):
         with self.subTest("TF"):
             batch = tf.convert_to_tensor(self.batch)
             minibatches = slicer._slice_batch(batch)
-            self.assertEqual(len(minibatches), 20)
+            self.assertEqual(len(minibatches), 15)
             for mbatch in minibatches:
                 self.assertListEqual(list(mbatch.shape), [2, 2, 4, 3])
             np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:4, :])
-            np.testing.assert_array_equal(minibatches[-1].numpy(), self.padded_batch[:, 8:10, 9:13, :])
+            np.testing.assert_array_equal(minibatches[-1].numpy(), self.padded_batch[:, 8:10, 6:10, :])
         with self.subTest("Torch"):
             batch = torch.Tensor(self.batch)
             minibatches = slicer._slice_batch(batch)
-            self.assertEqual(len(minibatches), 20)
+            self.assertEqual(len(minibatches), 15)
             for mbatch in minibatches:
                 self.assertListEqual(list(mbatch.shape), [2, 2, 4, 3])
             np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:4, :])
-            np.testing.assert_array_equal(minibatches[-1].numpy(), self.padded_batch[:, 8:10, 9:13, :])
+            np.testing.assert_array_equal(minibatches[-1].numpy(), self.padded_batch[:, 8:10, 6:10, :])
 
     def test_overlapping_stride_drop(self):
         slicer = SlidingSlicer(slice="x", pad_mode='drop', pad_val=-1, window_size=(-1, 2, 4, 3), strides=(0, 2, 3, 0))
@@ -220,22 +220,16 @@ class TestSlidingSlicer(unittest.TestCase):
         with self.subTest("TF"):
             batch = tf.convert_to_tensor(self.batch)
             minibatches = slicer._slice_batch(batch)
-            self.assertEqual(len(minibatches), 20)
+            self.assertEqual(len(minibatches), 15)
             for idx, mbatch in enumerate(minibatches):
-                if idx % 4 == 3:
-                    self.assertListEqual(list(mbatch.shape), [2, 2, 1, 3])
-                else:
-                    self.assertListEqual(list(mbatch.shape), [2, 2, 4, 3])
+                self.assertListEqual(list(mbatch.shape), [2, 2, 4, 3])
             np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:4, :])
         with self.subTest("Torch"):
             batch = torch.Tensor(self.batch)
             minibatches = slicer._slice_batch(batch)
-            self.assertEqual(len(minibatches), 20)
+            self.assertEqual(len(minibatches), 15)
             for idx, mbatch in enumerate(minibatches):
-                if idx % 4 == 3:
-                    self.assertListEqual(list(mbatch.shape), [2, 2, 1, 3])
-                else:
-                    self.assertListEqual(list(mbatch.shape), [2, 2, 4, 3])
+                self.assertListEqual(list(mbatch.shape), [2, 2, 4, 3])
             np.testing.assert_array_equal(minibatches[0].numpy(), self.batch[:, 0:2, 0:4, :])
 
     def test_gap_stride_pad(self):
@@ -356,7 +350,7 @@ class TestSlidingSlicer(unittest.TestCase):
         with self.subTest("TF"):
             batch = tf.convert_to_tensor(self.batch)
             minibatches = forward_slicers([slicer], data={'x': batch})
-            self.assertEqual(len(minibatches), 20)
+            self.assertEqual(len(minibatches), 15)
             combined = reverse_slicers([slicer], minibatches, original_data={})
             combined = combined['x']
             self.assertListEqual(list(combined.shape), [2, 10, 10, 3])
@@ -364,7 +358,7 @@ class TestSlidingSlicer(unittest.TestCase):
         with self.subTest("Torch"):
             batch = torch.Tensor(self.batch)
             minibatches = forward_slicers([slicer], data={'x': batch})
-            self.assertEqual(len(minibatches), 20)
+            self.assertEqual(len(minibatches), 15)
             combined = reverse_slicers([slicer], minibatches, original_data={})
             combined = combined['x']
             self.assertListEqual(list(combined.shape), [2, 10, 10, 3])
@@ -380,7 +374,7 @@ class TestSlidingSlicer(unittest.TestCase):
         with self.subTest("TF"):
             batch = tf.convert_to_tensor(self.batch)
             minibatches = forward_slicers([slicer], data={'x': batch})
-            self.assertEqual(len(minibatches), 20)
+            self.assertEqual(len(minibatches), 15)
             combined = reverse_slicers([slicer], minibatches, original_data={})
             combined = combined['x']
             self.assertListEqual(list(combined.shape), [2, 10, 10, 3])
@@ -388,7 +382,7 @@ class TestSlidingSlicer(unittest.TestCase):
         with self.subTest("Torch"):
             batch = torch.Tensor(self.batch)
             minibatches = forward_slicers([slicer], data={'x': batch})
-            self.assertEqual(len(minibatches), 20)
+            self.assertEqual(len(minibatches), 15)
             combined = reverse_slicers([slicer], minibatches, original_data={})
             combined = combined['x']
             self.assertListEqual(list(combined.shape), [2, 10, 10, 3])


### PR DESCRIPTION
# Requirements

1. slicer stop padding the first time we encounter it

# Target Audience

* Data Scientists

# Design / Implementation Details

Requirement 1 was addressed by updating padding logic to take, window_size into consideration and breaking when the end is reached for the first time.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Introduced a new control mechanism to break the loop in the sliding slicer for improved performance.
	- Enhanced the padding calculation in the sliding slicer for better accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->