### PR TITLE
increase nightly timeout period to 10 hours

### DIFF
--- a/CICD/nightly_test/Jenkinsfile
+++ b/CICD/nightly_test/Jenkinsfile
@@ -3,7 +3,7 @@ def IMAGE_TAG = 'fenightly'
 pipeline {
     agent {label 'master'}
     options {
-        timeout(time: 7, unit: 'HOURS')
+        timeout(time: 10, unit: 'HOURS')
     }
     environment {
         IMAGE_TAG = "${IMAGE_TAG}"


### PR DESCRIPTION
# Requirements

To increase the nightly build timeout period to accommodate all the apphub tests on multi-gpu. 

# Target Audience

* Users
* Developers

# Design / Implementation Details

The timeout period in the nightly jenkins file has been updated to 10 hours.

# Known Issues / Limitations

None


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Increased the timeout for nightly tests from 7 hours to 10 hours to ensure completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->