### PR TITLE
updating PR test timeout

### DIFF
--- a/CICD/PR_test/Jenkinsfile
+++ b/CICD/PR_test/Jenkinsfile
@@ -5,7 +5,7 @@ def customImage
 pipeline {
     agent {label 'master'}
     options {
-        timeout(time: 30, unit: 'MINUTES')
+        timeout(time: 60, unit: 'MINUTES')
     }
     environment {
         IMAGE_TAG = "$IMAGE_TAG"


### PR DESCRIPTION
# Requirements

1. updating PR-test timeout to avoid timeout error for PR test


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased the timeout for the customImage pipeline to enhance stability during build and deployment processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->