### PR TITLE
remove assertion to allow original call method signature

### DIFF
--- a/fastestimator/op/tensorop/model/model.py
+++ b/fastestimator/op/tensorop/model/model.py
@@ -116,7 +116,6 @@ class ModelOp(TensorOp):
                 self.multi_inputs = len(inspect.signature(self.model.forward).parameters.keys()) > 1
         elif framework == "tf" and "keras.engine" not in str(type(self.model)):
             model_call_args = {x for x in inspect.signature(self.model.call).parameters.keys()}
-            assert len({"training", "mask"} & model_call_args) == 0, "Cannot use 'training' nor 'mask' as input args"
             self.multi_inputs = len(model_call_args) > 1
 
     def get_fe_models(self) -> Set[Model]:


### PR DESCRIPTION
The assertion in place is currently blocking the use of original `call` method for a subclassed tf.keras model.

The assertion's original purpose was to prevent user from accidentally using the same default argument name `mask` and `training` in their own call method.  This has come with a cost of blocking a significantly more common use case. Therefore removing the assertion is the right way to go. 