### PR TITLE
updating masks_in for multivariate

### DIFF
--- a/fastestimator/op/numpyop/multivariate/affine.py
+++ b/fastestimator/op/numpyop/multivariate/affine.py
@@ -15,7 +15,6 @@
 from typing import Iterable, List, Optional, Tuple, TypeVar, Union
 
 from albumentations import BboxParams, KeypointParams
-
 from albumentations.augmentations import Affine as AffineAlb
 
 from fastestimator.op.numpyop.multivariate.multivariate import MultiVariateAlbumentation
@@ -63,12 +62,12 @@ class Affine(MultiVariateAlbumentation):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         image_in: The key of an image to be modified.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
         bbox_in: The key of a bounding box(es) to be modified (with the same random factors as the image).
         keypoints_in: The key of keypoints to be modified (with the same random factors as the image).
         image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         bbox_out: The key to write the modified bounding box(es) (defaults to `bbox_in` if None).
         keypoints_out: The key to write the modified keypoints (defaults to `keypoints_in` if None).
         bbox_params: Parameters defining the type of bounding box ('coco', 'pascal_voc', 'albumentations' or 'yolo').
@@ -94,18 +93,18 @@ class Affine(MultiVariateAlbumentation):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  bbox_in: Optional[str] = None,
                  keypoints_in: Optional[str] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None,
+                 masks_out: Optional[Iterable[str]] = None,
                  bbox_out: Optional[str] = None,
                  keypoints_out: Optional[str] = None,
                  bbox_params: Union[BboxParams, str, None] = None,
                  keypoint_params: Union[KeypointParams, str, None] = None):
         order = {'nearest_neighbor': 0, 'bilinear': 1, 'bicubic': 3, 'biquartic': 4, 'biquintic': 5}
-        border = {'constant':0, 'reflect':1}[border_handling]
+        border = {'constant': 0, 'reflect': 1}[border_handling]
         if not fill_value_mask:
             fill_value_mask = fill_value
         if isinstance(translate, int) or (isinstance(translate, Tuple) and isinstance(translate[0], int)):

--- a/fastestimator/op/numpyop/multivariate/bbox_safe_random_crop.py
+++ b/fastestimator/op/numpyop/multivariate/bbox_safe_random_crop.py
@@ -33,12 +33,12 @@ class BBoxSafeRandomCrop(MultiVariateAlbumentation):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         image_in: The key of an image to be modified.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
         bbox_in: The key of a bounding box(es) to be modified (with the same random factors as the image).
         keypoints_in: The key of keypoints to be modified (with the same random factors as the image).
         image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         bbox_out: The key to write the modified bounding box(es) (defaults to `bbox_in` if None).
         keypoints_out: The key to write the modified keypoints (defaults to `keypoints_in` if None).
         bbox_params: Parameters defining the type of bounding box ('coco', 'pascal_voc', 'albumentations' or 'yolo').
@@ -54,12 +54,12 @@ class BBoxSafeRandomCrop(MultiVariateAlbumentation):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  bbox_in: Optional[str] = None,
                  keypoints_in: Optional[str] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None,
+                 masks_out: Optional[Iterable[str]] = None,
                  bbox_out: Optional[str] = None,
                  keypoints_out: Optional[str] = None,
                  bbox_params: Union[BboxParams, str, None] = None,

--- a/fastestimator/op/numpyop/multivariate/center_crop.py
+++ b/fastestimator/op/numpyop/multivariate/center_crop.py
@@ -33,12 +33,12 @@ class CenterCrop(MultiVariateAlbumentation):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         image_in: The key of an image to be modified.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
         bbox_in: The key of a bounding box(es) to be modified (with the same random factors as the image).
         keypoints_in: The key of keypoints to be modified (with the same random factors as the image).
         image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         bbox_out: The key to write the modified bounding box(es) (defaults to `bbox_in` if None).
         keypoints_out: The key to write the modified keypoints (defaults to `keypoints_in` if None).
         bbox_params: Parameters defining the type of bounding box ('coco', 'pascal_voc', 'albumentations' or 'yolo').
@@ -56,12 +56,12 @@ class CenterCrop(MultiVariateAlbumentation):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  bbox_in: Optional[str] = None,
                  keypoints_in: Optional[str] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None,
+                 masks_out: Optional[Iterable[str]] = None,
                  bbox_out: Optional[str] = None,
                  keypoints_out: Optional[str] = None,
                  bbox_params: Union[BboxParams, str, None] = None,

--- a/fastestimator/op/numpyop/multivariate/crop.py
+++ b/fastestimator/op/numpyop/multivariate/crop.py
@@ -33,12 +33,12 @@ class Crop(MultiVariateAlbumentation):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         image_in: The key of an image to be modified.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
         bbox_in: The key of a bounding box(es) to be modified (with the same random factors as the image).
         keypoints_in: The key of keypoints to be modified (with the same random factors as the image).
         image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         bbox_out: The key to write the modified bounding box(es) (defaults to `bbox_in` if None).
         keypoints_out: The key to write the modified keypoints (defaults to `keypoints_in` if None).
         bbox_params: Parameters defining the type of bounding box ('coco', 'pascal_voc', 'albumentations' or 'yolo').
@@ -60,12 +60,12 @@ class Crop(MultiVariateAlbumentation):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  bbox_in: Optional[str] = None,
                  keypoints_in: Optional[str] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None,
+                 masks_out: Optional[Iterable[str]] = None,
                  bbox_out: Optional[str] = None,
                  keypoints_out: Optional[str] = None,
                  bbox_params: Union[BboxParams, str, None] = None,

--- a/fastestimator/op/numpyop/multivariate/crop_and_pad.py
+++ b/fastestimator/op/numpyop/multivariate/crop_and_pad.py
@@ -33,10 +33,10 @@ class CropAndPad(MultiVariateAlbumentation):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         image_in: The key of an image to be modified.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
         image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         px: The number of pixels to crop (negative values) or pad (positive values) on each side of the image.
             Either this or the parameter percent may be set, not both at the same time.
         percent: The number of pixels to crop (negative values) or pad (positive values) on each side of the image given
@@ -65,10 +65,10 @@ class CropAndPad(MultiVariateAlbumentation):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None):
+                 masks_out: Optional[Iterable[str]] = None):
         order = {'nearest_neighbor': 0, 'bilinear': 1, 'bicubic': 3, 'biquartic': 4, 'biquintic': 5}[interpolation]
         border = {'constant':0, 'reflect':1}[pad_mode]
         if not pad_cval_mask:

--- a/fastestimator/op/numpyop/multivariate/crop_non_empty_mask_if_exists.py
+++ b/fastestimator/op/numpyop/multivariate/crop_non_empty_mask_if_exists.py
@@ -33,12 +33,12 @@ class CropNonEmptyMaskIfExists(MultiVariateAlbumentation):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         image_in: The key of an image to be modified.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
         bbox_in: The key of a bounding box(es) to be modified (with the same random factors as the image).
         keypoints_in: The key of keypoints to be modified (with the same random factors as the image).
         image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         bbox_out: The key to write the modified bounding box(es) (defaults to `bbox_in` if None).
         keypoints_out: The key to write the modified keypoints (defaults to `keypoints_in` if None).
         bbox_params: Parameters defining the type of bounding box ('coco', 'pascal_voc', 'albumentations' or 'yolo').
@@ -62,12 +62,12 @@ class CropNonEmptyMaskIfExists(MultiVariateAlbumentation):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  bbox_in: Optional[str] = None,
                  keypoints_in: Optional[str] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None,
+                 masks_out: Optional[Iterable[str]] = None,
                  bbox_out: Optional[str] = None,
                  keypoints_out: Optional[str] = None,
                  bbox_params: Union[BboxParams, str, None] = None,

--- a/fastestimator/op/numpyop/multivariate/elastic_transform.py
+++ b/fastestimator/op/numpyop/multivariate/elastic_transform.py
@@ -33,10 +33,10 @@ class ElasticTransform(MultiVariateAlbumentation):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         image_in: The key of an image to be modified.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
         image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         alpha: Scaling factor during point translation.
         sigma: Gaussian filter parameter. The effect (small to large) is: random -> elastic -> affine -> translation.
         alpha_affine: The range will be (-alpha_affine, alpha_affine).
@@ -68,10 +68,10 @@ class ElasticTransform(MultiVariateAlbumentation):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None):
+                 masks_out: Optional[Iterable[str]] = None):
         super().__init__(
             ElasticTransformAlb(alpha=alpha,
                                 sigma=sigma,

--- a/fastestimator/op/numpyop/multivariate/flip.py
+++ b/fastestimator/op/numpyop/multivariate/flip.py
@@ -33,12 +33,12 @@ class Flip(MultiVariateAlbumentation):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         image_in: The key of an image to be modified.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
         bbox_in: The key of a bounding box(es) to be modified (with the same random factors as the image).
         keypoints_in: The key of keypoints to be modified (with the same random factors as the image).
         image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         bbox_out: The key to write the modified bounding box(es) (defaults to `bbox_in` if None).
         keypoints_out: The key to write the modified keypoints (defaults to `keypoints_in` if None).
         bbox_params: Parameters defining the type of bounding box ('coco', 'pascal_voc', 'albumentations' or 'yolo').
@@ -52,12 +52,12 @@ class Flip(MultiVariateAlbumentation):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  bbox_in: Optional[str] = None,
                  keypoints_in: Optional[str] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None,
+                 masks_out: Optional[Iterable[str]] = None,
                  bbox_out: Optional[str] = None,
                  keypoints_out: Optional[str] = None,
                  bbox_params: Union[BboxParams, str, None] = None,

--- a/fastestimator/op/numpyop/multivariate/grid_distortion.py
+++ b/fastestimator/op/numpyop/multivariate/grid_distortion.py
@@ -33,10 +33,10 @@ class GridDistortion(MultiVariateAlbumentation):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         image_in: The key of an image to be modified.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
         image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         num_steps: count of grid cells on each side.
         distort_limit: If distort_limit is a single float, the range will be (-distort_limit, distort_limit).
         interpolation: Flag that is used to specify the interpolation algorithm. Should be one of:
@@ -60,10 +60,10 @@ class GridDistortion(MultiVariateAlbumentation):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None):
+                 masks_out: Optional[Iterable[str]] = None):
         super().__init__(
             GridDistortionAlb(num_steps=num_steps,
                               distort_limit=distort_limit,

--- a/fastestimator/op/numpyop/multivariate/horizontal_flip.py
+++ b/fastestimator/op/numpyop/multivariate/horizontal_flip.py
@@ -33,12 +33,12 @@ class HorizontalFlip(MultiVariateAlbumentation):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         image_in: The key of an image to be modified.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
         bbox_in: The key of a bounding box(es) to be modified (with the same random factors as the image).
         keypoints_in: The key of keypoints to be modified (with the same random factors as the image).
         image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         bbox_out: The key to write the modified bounding box(es) (defaults to `bbox_in` if None).
         keypoints_out: The key to write the modified keypoints (defaults to `keypoints_in` if None).
         bbox_params: Parameters defining the type of bounding box ('coco', 'pascal_voc', 'albumentations' or 'yolo').
@@ -52,12 +52,12 @@ class HorizontalFlip(MultiVariateAlbumentation):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  bbox_in: Optional[str] = None,
                  keypoints_in: Optional[str] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None,
+                 masks_out: Optional[Iterable[str]] = None,
                  bbox_out: Optional[str] = None,
                  keypoints_out: Optional[str] = None,
                  bbox_params: Union[BboxParams, str, None] = None,

--- a/fastestimator/op/numpyop/multivariate/longest_max_size.py
+++ b/fastestimator/op/numpyop/multivariate/longest_max_size.py
@@ -34,12 +34,12 @@ class LongestMaxSize(MultiVariateAlbumentation):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         image_in: The key of an image to be modified.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
         bbox_in: The key of a bounding box(es) to be modified (with the same random factors as the image).
         keypoints_in: The key of keypoints to be modified (with the same random factors as the image).
         image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         bbox_out: The key to write the modified bounding box(es) (defaults to `bbox_in` if None).
         keypoints_out: The key to write the modified keypoints (defaults to `keypoints_in` if None).
         bbox_params: Parameters defining the type of bounding box ('coco', 'pascal_voc', 'albumentations' or 'yolo').
@@ -58,12 +58,12 @@ class LongestMaxSize(MultiVariateAlbumentation):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  bbox_in: Optional[str] = None,
                  keypoints_in: Optional[str] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None,
+                 masks_out: Optional[Iterable[str]] = None,
                  bbox_out: Optional[str] = None,
                  keypoints_out: Optional[str] = None,
                  bbox_params: Union[BboxParams, str, None] = None,

--- a/fastestimator/op/numpyop/multivariate/mask_dropout.py
+++ b/fastestimator/op/numpyop/multivariate/mask_dropout.py
@@ -36,10 +36,10 @@ class MaskDropout(MultiVariateAlbumentation):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         image_in: The key of an image to be modified.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
-                image_out: The key to write the modified image (defaults to `image_in` if None).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
+        image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         max_objects: Maximum number of labels that can be zeroed out. Can be tuple, in this case it's [min, max]
         image_fill_value: Fill value to use when filling image.
             Can be 'inpaint' to apply in-painting (works only  for 3-channel images)
@@ -56,10 +56,10 @@ class MaskDropout(MultiVariateAlbumentation):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None):
+                 masks_out: Optional[Iterable[str]] = None):
         super().__init__(
             MaskDropoutAlb(max_objects=max_objects,
                            image_fill_value=image_fill_value,

--- a/fastestimator/op/numpyop/multivariate/multivariate.py
+++ b/fastestimator/op/numpyop/multivariate/multivariate.py
@@ -105,8 +105,10 @@ class MultiVariateAlbumentation(NumpyOp):
 
     def forward(self, data: List[np.ndarray], state: Dict[str, Any]) -> List[Union[np.ndarray, List[np.ndarray]]]:
         mul_input = {}
+        ind = 0
         for key in self.keys_in.keys():
             key_length = self.get_num_items(self.keys_in[key])
-            mul_input[key] = data.pop(0) if key_length == 1 else [data.pop(0) for i in range(key_length)]
+            mul_input[key] = data[ind] if key_length == 1 else data[ind:ind + key_length]
+            ind = ind + key_length
         result = self.func(**mul_input)
         return [result[k] for k in self.keys_out.keys()]

--- a/fastestimator/op/numpyop/multivariate/multivariate.py
+++ b/fastestimator/op/numpyop/multivariate/multivariate.py
@@ -42,12 +42,12 @@ class MultiVariateAlbumentation(NumpyOp):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         image_in: The key of an image to be modified.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
         bbox_in: The key of a bounding box(es) to be modified (with the same random factors as the image).
         keypoints_in: The key of keypoints to be modified (with the same random factors as the image).
         image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         bbox_out: The key to write the modified bounding box(es) (defaults to `bbox_in` if None).
         keypoints_out: The key to write the modified keypoints (defaults to `keypoints_in` if None).
         bbox_params: Parameters defining the type of bounding box ('coco', 'pascal_voc', 'albumentations' or 'yolo').
@@ -62,12 +62,12 @@ class MultiVariateAlbumentation(NumpyOp):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  bbox_in: Optional[str] = None,
                  keypoints_in: Optional[str] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None,
+                 masks_out: Optional[Iterable[str]] = None,
                  bbox_out: Optional[str] = None,
                  keypoints_out: Optional[str] = None,
                  bbox_params: Union[BboxParams, str, None] = None,
@@ -100,6 +100,13 @@ class MultiVariateAlbumentation(NumpyOp):
             keypoint_params = KeypointParams(keypoint_params)
         self.func = Compose(transforms=[func], bbox_params=bbox_params, keypoint_params=keypoint_params)
 
-    def forward(self, data: List[np.ndarray], state: Dict[str, Any]) -> List[np.ndarray]:
-        result = self.func(**{k: v for k, v in zip(self.keys_in.keys(), data)})
+    def get_num_items(self, value):
+        return 1 if isinstance(value, str) else len(value)
+
+    def forward(self, data: List[np.ndarray], state: Dict[str, Any]) -> List[Union[np.ndarray, List[np.ndarray]]]:
+        mul_input = {}
+        for key in self.keys_in.keys():
+            key_length = self.get_num_items(self.keys_in[key])
+            mul_input[key] = data.pop(0) if key_length == 1 else [data.pop(0) for i in range(key_length)]
+        result = self.func(**mul_input)
         return [result[k] for k in self.keys_out.keys()]

--- a/fastestimator/op/numpyop/multivariate/optical_distortion.py
+++ b/fastestimator/op/numpyop/multivariate/optical_distortion.py
@@ -33,10 +33,10 @@ class OpticalDistortion(MultiVariateAlbumentation):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         image_in: The key of an image to be modified.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
         image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         distort_limit: If distort_limit is a single float, the range will be (-distort_limit, distort_limit).
         shift_limit: If shift_limit is a single float, the range will be (-shift_limit, shift_limit).
         interpolation: Flag that is used to specify the interpolation algorithm. Should be one of:
@@ -60,10 +60,10 @@ class OpticalDistortion(MultiVariateAlbumentation):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None):
+                 masks_out: Optional[Iterable[str]] = None):
         super().__init__(
             OpticalDistortionAlb(distort_limit=distort_limit,
                                  shift_limit=shift_limit,

--- a/fastestimator/op/numpyop/multivariate/pad_if_needed.py
+++ b/fastestimator/op/numpyop/multivariate/pad_if_needed.py
@@ -34,12 +34,12 @@ class PadIfNeeded(MultiVariateAlbumentation):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         image_in: The key of an image to be modified.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
         bbox_in: The key of a bounding box(es) to be modified (with the same random factors as the image).
         keypoints_in: The key of keypoints to be modified (with the same random factors as the image).
         image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         bbox_out: The key to write the modified bounding box(es) (defaults to `bbox_in` if None).
         keypoints_out: The key to write the modified keypoints (defaults to `keypoints_in` if None).
         bbox_params: Parameters defining the type of bounding box ('coco', 'pascal_voc', 'albumentations' or 'yolo').
@@ -64,12 +64,12 @@ class PadIfNeeded(MultiVariateAlbumentation):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  bbox_in: Optional[str] = None,
                  keypoints_in: Optional[str] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None,
+                 masks_out: Optional[Iterable[str]] = None,
                  bbox_out: Optional[str] = None,
                  keypoints_out: Optional[str] = None,
                  bbox_params: Union[BboxParams, str, None] = None,

--- a/fastestimator/op/numpyop/multivariate/random_crop.py
+++ b/fastestimator/op/numpyop/multivariate/random_crop.py
@@ -33,12 +33,12 @@ class RandomCrop(MultiVariateAlbumentation):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         image_in: The key of an image to be modified.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
         bbox_in: The key of a bounding box(es) to be modified (with the same random factors as the image).
         keypoints_in: The key of keypoints to be modified (with the same random factors as the image).
         image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         bbox_out: The key to write the modified bounding box(es) (defaults to `bbox_in` if None).
         keypoints_out: The key to write the modified keypoints (defaults to `keypoints_in` if None).
         bbox_params: Parameters defining the type of bounding box ('coco', 'pascal_voc', 'albumentations' or 'yolo').
@@ -56,12 +56,12 @@ class RandomCrop(MultiVariateAlbumentation):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  bbox_in: Optional[str] = None,
                  keypoints_in: Optional[str] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None,
+                 masks_out: Optional[Iterable[str]] = None,
                  bbox_out: Optional[str] = None,
                  keypoints_out: Optional[str] = None,
                  bbox_params: Union[BboxParams, str, None] = None,

--- a/fastestimator/op/numpyop/multivariate/random_crop_from_borders.py
+++ b/fastestimator/op/numpyop/multivariate/random_crop_from_borders.py
@@ -33,12 +33,12 @@ class RandomCropFromBorders(MultiVariateAlbumentation):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         image_in: The key of an image to be modified.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
         bbox_in: The key of a bounding box(es) to be modified (with the same random factors as the image).
         keypoints_in: The key of keypoints to be modified (with the same random factors as the image).
         image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         bbox_out: The key to write the modified bounding box(es) (defaults to `bbox_in` if None).
         keypoints_out: The key to write the modified keypoints (defaults to `keypoints_in` if None).
         bbox_params: Parameters defining the type of bounding box ('coco', 'pascal_voc', 'albumentations' or 'yolo').
@@ -60,32 +60,33 @@ class RandomCropFromBorders(MultiVariateAlbumentation):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  bbox_in: Optional[str] = None,
                  keypoints_in: Optional[str] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None,
+                 masks_out: Optional[Iterable[str]] = None,
                  bbox_out: Optional[str] = None,
                  keypoints_out: Optional[str] = None,
                  bbox_params: Union[BboxParams, str, None] = None,
                  keypoint_params: Union[KeypointParams, str, None] = None):
-        super().__init__(RandomCropFromBordersAlb(crop_left=crop_left,
-                                                  crop_right=crop_right,
-                                                  crop_top=crop_top,
-                                                  crop_bottom=crop_bottom,
-                                                  always_apply=True),
-                         image_in=image_in,
-                         mask_in=mask_in,
-                         masks_in=masks_in,
-                         bbox_in=bbox_in,
-                         keypoints_in=keypoints_in,
-                         image_out=image_out,
-                         mask_out=mask_out,
-                         masks_out=masks_out,
-                         bbox_out=bbox_out,
-                         keypoints_out=keypoints_out,
-                         bbox_params=bbox_params,
-                         keypoint_params=keypoint_params,
-                         mode=mode,
-                         ds_id=ds_id)
+        super().__init__(
+            RandomCropFromBordersAlb(crop_left=crop_left,
+                                     crop_right=crop_right,
+                                     crop_top=crop_top,
+                                     crop_bottom=crop_bottom,
+                                     always_apply=True),
+            image_in=image_in,
+            mask_in=mask_in,
+            masks_in=masks_in,
+            bbox_in=bbox_in,
+            keypoints_in=keypoints_in,
+            image_out=image_out,
+            mask_out=mask_out,
+            masks_out=masks_out,
+            bbox_out=bbox_out,
+            keypoints_out=keypoints_out,
+            bbox_params=bbox_params,
+            keypoint_params=keypoint_params,
+            mode=mode,
+            ds_id=ds_id)

--- a/fastestimator/op/numpyop/multivariate/random_crop_near_bbox.py
+++ b/fastestimator/op/numpyop/multivariate/random_crop_near_bbox.py
@@ -34,12 +34,12 @@ class RandomCropNearBBox(MultiVariateAlbumentation):
         image_in: The key of an image to be modified.
         cropping_bbox_in: The key of the cropping box, in [x1, y1, x2, y2] format.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
         bbox_in: The key of a bounding box(es) to be modified (with the same random factors as the image).
         keypoints_in: The key of keypoints to be modified (with the same random factors as the image).
         image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         bbox_out: The key to write the modified bounding box(es) (defaults to `bbox_in` if None).
         keypoints_out: The key to write the modified keypoints (defaults to `keypoints_in` if None).
         bbox_params: Parameters defining the type of bounding box ('coco', 'pascal_voc', 'albumentations' or 'yolo').
@@ -56,12 +56,12 @@ class RandomCropNearBBox(MultiVariateAlbumentation):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  bbox_in: Optional[str] = None,
                  keypoints_in: Optional[str] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None,
+                 masks_out: Optional[Iterable[str]] = None,
                  bbox_out: Optional[str] = None,
                  keypoints_out: Optional[str] = None,
                  bbox_params: Union[BboxParams, str, None] = None,

--- a/fastestimator/op/numpyop/multivariate/random_grid_shuffle.py
+++ b/fastestimator/op/numpyop/multivariate/random_grid_shuffle.py
@@ -32,10 +32,10 @@ class RandomGridShuffle(MultiVariateAlbumentation):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         image_in: The key of an image to be modified.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
         image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         grid: size of grid for splitting image (height, width).
 
     Image types:
@@ -47,10 +47,10 @@ class RandomGridShuffle(MultiVariateAlbumentation):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None):
+                 masks_out: Optional[Iterable[str]] = None):
         import numpy as np  # Albumentations 1.3.0 is relying on deprecated np.int alias.
         np.int = np.int32  # TODO - Remove this after they upgrade
         super().__init__(RandomGridShuffleAlb(grid=grid, always_apply=True),

--- a/fastestimator/op/numpyop/multivariate/random_resized_crop.py
+++ b/fastestimator/op/numpyop/multivariate/random_resized_crop.py
@@ -34,12 +34,12 @@ class RandomResizedCrop(MultiVariateAlbumentation):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         image_in: The key of an image to be modified.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
         bbox_in: The key of a bounding box(es) to be modified (with the same random factors as the image).
         keypoints_in: The key of keypoints to be modified (with the same random factors as the image).
         image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         bbox_out: The key to write the modified bounding box(es) (defaults to `bbox_in` if None).
         keypoints_out: The key to write the modified keypoints (defaults to `keypoints_in` if None).
         bbox_params: Parameters defining the type of bounding box ('coco', 'pascal_voc', 'albumentations' or 'yolo').
@@ -64,12 +64,12 @@ class RandomResizedCrop(MultiVariateAlbumentation):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  bbox_in: Optional[str] = None,
                  keypoints_in: Optional[str] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None,
+                 masks_out: Optional[Iterable[str]] = None,
                  bbox_out: Optional[str] = None,
                  keypoints_out: Optional[str] = None,
                  bbox_params: Union[BboxParams, str, None] = None,

--- a/fastestimator/op/numpyop/multivariate/random_rotate_90.py
+++ b/fastestimator/op/numpyop/multivariate/random_rotate_90.py
@@ -33,12 +33,12 @@ class RandomRotate90(MultiVariateAlbumentation):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         image_in: The key of an image to be modified.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
         bbox_in: The key of a bounding box(es) to be modified (with the same random factors as the image).
         keypoints_in: The key of keypoints to be modified (with the same random factors as the image).
         image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         bbox_out: The key to write the modified bounding box(es) (defaults to `bbox_in` if None).
         keypoints_out: The key to write the modified keypoints (defaults to `keypoints_in` if None).
         bbox_params: Parameters defining the type of bounding box ('coco', 'pascal_voc', 'albumentations' or 'yolo').
@@ -52,12 +52,12 @@ class RandomRotate90(MultiVariateAlbumentation):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  bbox_in: Optional[str] = None,
                  keypoints_in: Optional[str] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None,
+                 masks_out: Optional[Iterable[str]] = None,
                  bbox_out: Optional[str] = None,
                  keypoints_out: Optional[str] = None,
                  bbox_params: Union[BboxParams, str, None] = None,

--- a/fastestimator/op/numpyop/multivariate/random_scale.py
+++ b/fastestimator/op/numpyop/multivariate/random_scale.py
@@ -34,12 +34,12 @@ class RandomScale(MultiVariateAlbumentation):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         image_in: The key of an image to be modified.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
         bbox_in: The key of a bounding box(es) to be modified (with the same random factors as the image).
         keypoints_in: The key of keypoints to be modified (with the same random factors as the image).
         image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         bbox_out: The key to write the modified bounding box(es) (defaults to `bbox_in` if None).
         keypoints_out: The key to write the modified keypoints (defaults to `keypoints_in` if None).
         bbox_params: Parameters defining the type of bounding box ('coco', 'pascal_voc', 'albumentations' or 'yolo').
@@ -59,12 +59,12 @@ class RandomScale(MultiVariateAlbumentation):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  bbox_in: Optional[str] = None,
                  keypoints_in: Optional[str] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None,
+                 masks_out: Optional[Iterable[str]] = None,
                  bbox_out: Optional[str] = None,
                  keypoints_out: Optional[str] = None,
                  bbox_params: Union[BboxParams, str, None] = None,

--- a/fastestimator/op/numpyop/multivariate/random_sized_bbox_safe_crop.py
+++ b/fastestimator/op/numpyop/multivariate/random_sized_bbox_safe_crop.py
@@ -34,11 +34,11 @@ class RandomSizedBBoxSafeCrop(MultiVariateAlbumentation):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         image_in: The key of an image to be modified.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
         bbox_in: The key of a bounding box(es) to be modified (with the same random factors as the image).
         image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         bbox_out: The key to write the modified bounding box(es) (defaults to `bbox_in` if None).
         bbox_params: Parameters defining the type of bounding box ('coco', 'pascal_voc', 'albumentations' or 'yolo').
         height: Height after crop and resize.
@@ -59,11 +59,11 @@ class RandomSizedBBoxSafeCrop(MultiVariateAlbumentation):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  bbox_in: Optional[str] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None,
+                 masks_out: Optional[Iterable[str]] = None,
                  bbox_out: Optional[str] = None,
                  bbox_params: Union[BboxParams, str, None] = None):
         super().__init__(

--- a/fastestimator/op/numpyop/multivariate/random_sized_crop.py
+++ b/fastestimator/op/numpyop/multivariate/random_sized_crop.py
@@ -34,12 +34,12 @@ class RandomSizedCrop(MultiVariateAlbumentation):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         image_in: The key of an image to be modified.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
         bbox_in: The key of a bounding box(es) to be modified (with the same random factors as the image).
         keypoints_in: The key of keypoints to be modified (with the same random factors as the image).
         image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         bbox_out: The key to write the modified bounding box(es) (defaults to `bbox_in` if None).
         keypoints_out: The key to write the modified keypoints (defaults to `keypoints_in` if None).
         bbox_params: Parameters defining the type of bounding box ('coco', 'pascal_voc', 'albumentations' or 'yolo').
@@ -64,12 +64,12 @@ class RandomSizedCrop(MultiVariateAlbumentation):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  bbox_in: Optional[str] = None,
                  keypoints_in: Optional[str] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None,
+                 masks_out: Optional[Iterable[str]] = None,
                  bbox_out: Optional[str] = None,
                  keypoints_out: Optional[str] = None,
                  bbox_params: Union[BboxParams, str, None] = None,

--- a/fastestimator/op/numpyop/multivariate/resize.py
+++ b/fastestimator/op/numpyop/multivariate/resize.py
@@ -34,12 +34,12 @@ class Resize(MultiVariateAlbumentation):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         image_in: The key of an image to be modified.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
         bbox_in: The key of a bounding box(es) to be modified (with the same random factors as the image).
         keypoints_in: The key of keypoints to be modified (with the same random factors as the image).
         image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         bbox_out: The key to write the modified bounding box(es) (defaults to `bbox_in` if None).
         keypoints_out: The key to write the modified keypoints (defaults to `keypoints_in` if None).
         bbox_params: Parameters defining the type of bounding box ('coco', 'pascal_voc', 'albumentations' or 'yolo').
@@ -60,12 +60,12 @@ class Resize(MultiVariateAlbumentation):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  bbox_in: Optional[str] = None,
                  keypoints_in: Optional[str] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None,
+                 masks_out: Optional[Iterable[str]] = None,
                  bbox_out: Optional[str] = None,
                  keypoints_out: Optional[str] = None,
                  bbox_params: Union[BboxParams, str, None] = None,

--- a/fastestimator/op/numpyop/multivariate/rotate.py
+++ b/fastestimator/op/numpyop/multivariate/rotate.py
@@ -34,12 +34,12 @@ class Rotate(MultiVariateAlbumentation):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         image_in: The key of an image to be modified.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
         bbox_in: The key of a bounding box(es) to be modified (with the same random factors as the image).
         keypoints_in: The key of keypoints to be modified (with the same random factors as the image).
         image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         bbox_out: The key to write the modified bounding box(es) (defaults to `bbox_in` if None).
         keypoints_out: The key to write the modified keypoints (defaults to `keypoints_in` if None).
         bbox_params: Parameters defining the type of bounding box ('coco', 'pascal_voc', 'albumentations' or 'yolo').
@@ -66,12 +66,12 @@ class Rotate(MultiVariateAlbumentation):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  bbox_in: Optional[str] = None,
                  keypoints_in: Optional[str] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None,
+                 masks_out: Optional[Iterable[str]] = None,
                  bbox_out: Optional[str] = None,
                  keypoints_out: Optional[str] = None,
                  bbox_params: Union[BboxParams, str, None] = None,

--- a/fastestimator/op/numpyop/multivariate/shift_scale_rotate.py
+++ b/fastestimator/op/numpyop/multivariate/shift_scale_rotate.py
@@ -34,12 +34,12 @@ class ShiftScaleRotate(MultiVariateAlbumentation):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         image_in: The key of an image to be modified.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
         bbox_in: The key of a bounding box(es) to be modified (with the same random factors as the image).
         keypoints_in: The key of keypoints to be modified (with the same random factors as the image).
         image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         bbox_out: The key to write the modified bounding box(es) (defaults to `bbox_in` if None).
         keypoints_out: The key to write the modified keypoints (defaults to `keypoints_in` if None).
         bbox_params: Parameters defining the type of bounding box ('coco', 'pascal_voc', 'albumentations' or 'yolo').
@@ -72,12 +72,12 @@ class ShiftScaleRotate(MultiVariateAlbumentation):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  bbox_in: Optional[str] = None,
                  keypoints_in: Optional[str] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None,
+                 masks_out: Optional[Iterable[str]] = None,
                  bbox_out: Optional[str] = None,
                  keypoints_out: Optional[str] = None,
                  bbox_params: Union[BboxParams, str, None] = None,

--- a/fastestimator/op/numpyop/multivariate/smallest_max_size.py
+++ b/fastestimator/op/numpyop/multivariate/smallest_max_size.py
@@ -34,12 +34,12 @@ class SmallestMaxSize(MultiVariateAlbumentation):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         image_in: The key of an image to be modified.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
         bbox_in: The key of a bounding box(es) to be modified (with the same random factors as the image).
         keypoints_in: The key of keypoints to be modified (with the same random factors as the image).
         image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         bbox_out: The key to write the modified bounding box(es) (defaults to `bbox_in` if None).
         keypoints_out: The key to write the modified keypoints (defaults to `keypoints_in` if None).
         bbox_params: Parameters defining the type of bounding box ('coco', 'pascal_voc', 'albumentations' or 'yolo').
@@ -58,12 +58,12 @@ class SmallestMaxSize(MultiVariateAlbumentation):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  bbox_in: Optional[str] = None,
                  keypoints_in: Optional[str] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None,
+                 masks_out: Optional[Iterable[str]] = None,
                  bbox_out: Optional[str] = None,
                  keypoints_out: Optional[str] = None,
                  bbox_params: Union[BboxParams, str, None] = None,

--- a/fastestimator/op/numpyop/multivariate/transpose.py
+++ b/fastestimator/op/numpyop/multivariate/transpose.py
@@ -33,12 +33,12 @@ class Transpose(MultiVariateAlbumentation):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         image_in: The key of an image to be modified.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
         bbox_in: The key of a bounding box(es) to be modified (with the same random factors as the image).
         keypoints_in: The key of keypoints to be modified (with the same random factors as the image).
         image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         bbox_out: The key to write the modified bounding box(es) (defaults to `bbox_in` if None).
         keypoints_out: The key to write the modified keypoints (defaults to `keypoints_in` if None).
         bbox_params: Parameters defining the type of bounding box ('coco', 'pascal_voc', 'albumentations' or 'yolo').
@@ -52,12 +52,12 @@ class Transpose(MultiVariateAlbumentation):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  bbox_in: Optional[str] = None,
                  keypoints_in: Optional[str] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None,
+                 masks_out: Optional[Iterable[str]] = None,
                  bbox_out: Optional[str] = None,
                  keypoints_out: Optional[str] = None,
                  bbox_params: Union[BboxParams, str, None] = None,

--- a/fastestimator/op/numpyop/multivariate/vertical_flip.py
+++ b/fastestimator/op/numpyop/multivariate/vertical_flip.py
@@ -33,12 +33,12 @@ class VerticalFlip(MultiVariateAlbumentation):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         image_in: The key of an image to be modified.
         mask_in: The key of a mask to be modified (with the same random factors as the image).
-        masks_in: The key of masks to be modified (with the same random factors as the image).
+        masks_in: The list of mask keys to be modified (with the same random factors as the image).
         bbox_in: The key of a bounding box(es) to be modified (with the same random factors as the image).
         keypoints_in: The key of keypoints to be modified (with the same random factors as the image).
         image_out: The key to write the modified image (defaults to `image_in` if None).
         mask_out: The key to write the modified mask (defaults to `mask_in` if None).
-        masks_out: The key to write the modified masks (defaults to `masks_in` if None).
+        masks_out: The list of keys to write the modified masks (defaults to `masks_in` if None).
         bbox_out: The key to write the modified bounding box(es) (defaults to `bbox_in` if None).
         keypoints_out: The key to write the modified keypoints (defaults to `keypoints_in` if None).
         bbox_params: Parameters defining the type of bounding box ('coco', 'pascal_voc', 'albumentations' or 'yolo').
@@ -52,12 +52,12 @@ class VerticalFlip(MultiVariateAlbumentation):
                  ds_id: Union[None, str, Iterable[str]] = None,
                  image_in: Optional[str] = None,
                  mask_in: Optional[str] = None,
-                 masks_in: Optional[str] = None,
+                 masks_in: Optional[Iterable[str]] = None,
                  bbox_in: Optional[str] = None,
                  keypoints_in: Optional[str] = None,
                  image_out: Optional[str] = None,
                  mask_out: Optional[str] = None,
-                 masks_out: Optional[str] = None,
+                 masks_out: Optional[Iterable[str]] = None,
                  bbox_out: Optional[str] = None,
                  keypoints_out: Optional[str] = None,
                  bbox_params: Union[BboxParams, str, None] = None,

--- a/fastestimator/trace/io/best_model_saver.py
+++ b/fastestimator/trace/io/best_model_saver.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from operator import lt, gt
+from operator import gt, lt
 from typing import Optional, Union
 
 import numpy as np
@@ -35,6 +35,7 @@ class BestModelSaver(Trace):
         save_dir: Folder path into which to save the model.
         metric: Eval metric name to monitor. If None, the model's loss will be used.
         save_best_mode: Can be 'min' or 'max'.
+        model_name: Prefix to be used for the saved output model.
         load_best_final: Whether to automatically reload the best model (if available) after training.
         save_architecture: Whether to save the full model architecture in addition to the model weights. This option is
             only available for TensorFlow models at present, and will generate a folder containing several files. The
@@ -50,6 +51,7 @@ class BestModelSaver(Trace):
                  save_dir: str,
                  metric: Optional[str] = None,
                  save_best_mode: str = "min",
+                 model_name: Optional[str] = None,
                  load_best_final: bool = False,
                  save_architecture: bool = False) -> None:
         if not metric:
@@ -63,6 +65,13 @@ class BestModelSaver(Trace):
         self.fe_monitor_names.add(metric)
         self.model = model
         self.model_name = "{}_best_{}".format(self.model.model_name, self.metric)
+        if model_name is not None:
+            if isinstance(model_name, str) and len(model_name) > 0:
+                self.model_name = model_name
+            else:
+                raise ValueError(
+                    "Model name provided to BestModelSaver is not a string with atleast one character.")
+
         self.save_dir = save_dir
         self.save_best_mode = save_best_mode
         self.load_best_final = load_best_final

--- a/fastestimator/trace/io/best_model_saver.py
+++ b/fastestimator/trace/io/best_model_saver.py
@@ -35,7 +35,7 @@ class BestModelSaver(Trace):
         save_dir: Folder path into which to save the model.
         metric: Eval metric name to monitor. If None, the model's loss will be used.
         save_best_mode: Can be 'min' or 'max'.
-        model_name: Prefix to be used for the saved output model.
+        weights_name: The exact name used to save model weights. If None default model prefix will be used.
         load_best_final: Whether to automatically reload the best model (if available) after training.
         save_architecture: Whether to save the full model architecture in addition to the model weights. This option is
             only available for TensorFlow models at present, and will generate a folder containing several files. The
@@ -51,7 +51,7 @@ class BestModelSaver(Trace):
                  save_dir: str,
                  metric: Optional[str] = None,
                  save_best_mode: str = "min",
-                 model_name: Optional[str] = None,
+                 weights_name: Optional[str] = None,
                  load_best_final: bool = False,
                  save_architecture: bool = False) -> None:
         if not metric:
@@ -65,12 +65,11 @@ class BestModelSaver(Trace):
         self.fe_monitor_names.add(metric)
         self.model = model
         self.model_name = "{}_best_{}".format(self.model.model_name, self.metric)
-        if model_name is not None:
-            if isinstance(model_name, str) and len(model_name) > 0:
-                self.model_name = model_name
+        if weights_name is not None:
+            if isinstance(weights_name, str) and len(weights_name) > 0:
+                self.model_name = weights_name
             else:
-                raise ValueError(
-                    "Model name provided to BestModelSaver is not a string with atleast one character.")
+                raise ValueError("Weights name provided to BestModelSaver is not a string with atleast one character.")
 
         self.save_dir = save_dir
         self.save_best_mode = save_best_mode

--- a/fastestimator/trace/io/model_saver.py
+++ b/fastestimator/trace/io/model_saver.py
@@ -35,7 +35,7 @@ class ModelSaver(Trace):
         save_dir: Folder path into which to save the `model`.
         frequency: Model saving frequency in epoch(s).
         max_to_keep: Maximum number of latest saved files to keep. If 0 or None, all models will be saved.
-        model_name: Prefix to be used for the saved output model.
+        weights_name: The prefix used for saving model weights. If None model.model_name will be used as a prefix.
         save_architecture: Whether to save the full model architecture in addition to the model weights. This option is
             only available for TensorFlow models at present, and will generate a folder containing several files. The
             model can then be re-instantiated even without access to the original code by calling:
@@ -49,19 +49,17 @@ class ModelSaver(Trace):
                  save_dir: str,
                  frequency: int = 1,
                  max_to_keep: Optional[int] = None,
-                 model_name: Optional[str] = None,
+                 weights_name: Optional[str] = None,
                  save_architecture: bool = False) -> None:
         super().__init__(mode="train")
         self.model = model
         self.save_dir = save_dir
-        self.model_name = None
-        if model_name is not None:
-            if isinstance(model_name, str) and len(model_name) > 0:
-                self.model_name = model_name
+        self.weights_name = None
+        if weights_name is not None:
+            if isinstance(weights_name, str) and len(weights_name) > 0:
+                self.weights_name = weights_name
             else:
-                print(
-                    "Provided model name provided to ModelSaver is not a string with atleast one character, So using default model name "
-                )
+                raise ValueError("Weights name provided to ModelSaver is not a string with atleast one character.")
         self.frequency = frequency
         self.save_architecture = save_architecture
         if save_architecture and isinstance(model, torch.nn.Module):
@@ -73,7 +71,7 @@ class ModelSaver(Trace):
     def on_epoch_end(self, data: Data) -> None:
         # No model will be saved when save_dir is None, which makes smoke test easier.
         if self.save_dir and self.system.epoch_idx % self.frequency == 0:
-            model_name_prefix = self.model_name if self.model_name is not None else self.model.model_name
+            model_name_prefix = self.weights_name if self.weights_name is not None else self.model.model_name
             model_name = "{}_epoch_{}".format(model_name_prefix, self.system.epoch_idx)
             model_path = save_model(model=self.model,
                                     save_dir=self.save_dir,

--- a/fastestimator/util/base_util.py
+++ b/fastestimator/util/base_util.py
@@ -434,13 +434,16 @@ def get_type(obj: Any) -> str:
     return result
 
 
-def check_io_names(names: List[str]) -> List[str]:
+def check_io_names(names: Union[List[str], Any]) -> Union[List[str], Any]:
     forbidden_chars = {":", ";"}
     for name in names:
-        assert not any(char in name for char in forbidden_chars), \
-            "inputs/outputs name cannot contain characters like ':', ';', found {}".format(name)
-        assert len(name) > 0, "inputs/outputs cannot be an empty string"
-        assert len(name.split('|')) < 3, f"inputs/outputs cannot contain more than one '|' character, found {name}"
+        if isinstance(name, list):
+            check_io_names(name)
+        else:
+            assert not any(char in name for char in forbidden_chars), \
+                "inputs/outputs name cannot contain characters like ':', ';', found {}".format(name)
+            assert len(name) > 0, "inputs/outputs cannot be an empty string"
+            assert len(name.split('|')) < 3, f"inputs/outputs cannot contain more than one '|' character, found {name}"
     return names
 
 

--- a/test/PR_test/unit_test/op/numpyop/multivariate/test_affine.py
+++ b/test/PR_test/unit_test/op/numpyop/multivariate/test_affine.py
@@ -56,4 +56,4 @@ class TestAffine(unittest.TestCase):
         with self.subTest('Check output mask1 shape'):
             self.assertEqual(output[1][0].shape, self.image_and_mask_output_shape)
         with self.subTest('Check output mask2 shape'):
-            self.assertEqual(output[1][0].shape, self.image_and_mask_output_shape)
+            self.assertEqual(output[1][1].shape, self.image_and_mask_output_shape)

--- a/test/PR_test/unit_test/op/numpyop/multivariate/test_affine.py
+++ b/test/PR_test/unit_test/op/numpyop/multivariate/test_affine.py
@@ -25,6 +25,7 @@ class TestAffine(unittest.TestCase):
         cls.single_input = [np.random.rand(28, 28, 3)]
         cls.single_output_shape = (28, 28, 3)
         cls.input_image_and_mask = [np.random.rand(28, 28, 3), np.random.rand(28, 28, 3)]
+        cls.input_image_and_masks = [np.random.rand(28, 28, 3), np.random.rand(28, 28, 3), np.random.rand(28, 28, 3)]
         cls.image_and_mask_output_shape = (28, 28, 3)
 
     def test_single_input(self):
@@ -44,3 +45,15 @@ class TestAffine(unittest.TestCase):
             self.assertEqual(output[0].shape, self.image_and_mask_output_shape)
         with self.subTest('Check output mask shape'):
             self.assertEqual(output[1].shape, self.image_and_mask_output_shape)
+
+    def test_input_image_and_masks(self):
+        affine = Affine(image_in='x', masks_in=['x_mask1', 'x_mask2'])
+        output = affine.forward(data=self.input_image_and_masks, state={})
+        with self.subTest('Check output type'):
+            self.assertEqual(type(output), list)
+        with self.subTest('Check output image shape'):
+            self.assertEqual(output[0].shape, self.image_and_mask_output_shape)
+        with self.subTest('Check output mask1 shape'):
+            self.assertEqual(output[1][0].shape, self.image_and_mask_output_shape)
+        with self.subTest('Check output mask2 shape'):
+            self.assertEqual(output[1][0].shape, self.image_and_mask_output_shape)

--- a/test/PR_test/unit_test/op/numpyop/multivariate/test_rotate.py
+++ b/test/PR_test/unit_test/op/numpyop/multivariate/test_rotate.py
@@ -25,6 +25,7 @@ class TestRotate(unittest.TestCase):
         cls.single_input = [np.random.rand(28, 28, 3)]
         cls.single_output_shape = (28, 28, 3)
         cls.input_image_and_mask = [np.random.rand(28, 28, 3), np.random.rand(28, 28, 3)]
+        cls.input_image_and_mask = [np.random.rand(28, 28, 3), np.random.rand(28, 28, 3), np.random.rand(28, 28, 3)]
         cls.image_and_mask_output_shape = (28, 28, 3)
 
     def test_input(self):
@@ -44,3 +45,15 @@ class TestRotate(unittest.TestCase):
             self.assertEqual(output[0].shape, self.image_and_mask_output_shape)
         with self.subTest('Check output mask shape'):
             self.assertEqual(output[1].shape, self.image_and_mask_output_shape)
+
+    def test_input_image_and_masks(self):
+        rotate = Rotate(image_in='x', masks_in=['x_mask1', 'x_mask2'])
+        output = rotate.forward(data=self.input_image_and_mask, state={})
+        with self.subTest('Check output type'):
+            self.assertEqual(type(output), list)
+        with self.subTest('Check output image shape'):
+            self.assertEqual(output[0].shape, self.image_and_mask_output_shape)
+        with self.subTest('Check output mask shape'):
+            self.assertEqual(output[1][0].shape, self.image_and_mask_output_shape)
+        with self.subTest('Check output mask shape'):
+            self.assertEqual(output[1][1].shape, self.image_and_mask_output_shape)

--- a/test/PR_test/unit_test/op/numpyop/multivariate/test_rotate.py
+++ b/test/PR_test/unit_test/op/numpyop/multivariate/test_rotate.py
@@ -25,7 +25,7 @@ class TestRotate(unittest.TestCase):
         cls.single_input = [np.random.rand(28, 28, 3)]
         cls.single_output_shape = (28, 28, 3)
         cls.input_image_and_mask = [np.random.rand(28, 28, 3), np.random.rand(28, 28, 3)]
-        cls.input_image_and_mask = [np.random.rand(28, 28, 3), np.random.rand(28, 28, 3), np.random.rand(28, 28, 3)]
+        cls.input_image_and_masks = [np.random.rand(28, 28, 3), np.random.rand(28, 28, 3), np.random.rand(28, 28, 3)]
         cls.image_and_mask_output_shape = (28, 28, 3)
 
     def test_input(self):
@@ -48,7 +48,7 @@ class TestRotate(unittest.TestCase):
 
     def test_input_image_and_masks(self):
         rotate = Rotate(image_in='x', masks_in=['x_mask1', 'x_mask2'])
-        output = rotate.forward(data=self.input_image_and_mask, state={})
+        output = rotate.forward(data=self.input_image_and_masks, state={})
         with self.subTest('Check output type'):
             self.assertEqual(type(output), list)
         with self.subTest('Check output image shape'):


### PR DESCRIPTION
# Requirements

1. fixing the multivate masks_in 
2. Allowing custom names to BestModelSaver and ModelSaver

# Design / Implementation Details

Requirement 1 was addressed by updating the input reading logic in multivariate numpyop
Requirement 2 was addressed by updating the input args for BestModelSaver and ModelSaver


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced image processing operations to support multiple masks.
  - Introduced the ability to specify a prefix for saved model filenames.

- **Improvements**
  - Updated parameters to accept a wider range of input types for better flexibility in image transformations.

- **Bug Fixes**
  - Fixed issues related to handling of multiple masks during various image operations.

- **Tests**
  - Added new tests to verify handling of images with multiple masks in affine and rotate operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->