### PR TITLE
updating-jupyter-version

### DIFF
--- a/docker/nightly/Dockerfile.cpu
+++ b/docker/nightly/Dockerfile.cpu
@@ -69,7 +69,7 @@ RUN pip install --no-cache-dir \
     papermill==2.4.0 \
     traitlets==5.14.0
 
-RUN pip install jupyter-client==8.6.0 notebook==7.0.6
+RUN pip install jupyter-client notebook
 
 RUN ipython kernel install --user --name nightly_build
 

--- a/docker/nightly/Dockerfile.gpu
+++ b/docker/nightly/Dockerfile.gpu
@@ -99,7 +99,7 @@ RUN pip install --no-cache-dir \
     papermill==2.4.0 \
     traitlets==5.14.0
 
-RUN pip install jupyter-client==8.6.0 notebook==7.0.6
+RUN pip install jupyter-client notebook
 
 RUN ipython kernel install --user --name nightly_build
 


### PR DESCRIPTION
remove Jupyter version dependency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated package installation in Docker files to use latest versions of `jupyter-client` and `notebook` without explicit version constraints
	- Simplified package installation process for nightly builds (CPU and GPU Dockerfiles)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->