### PR TITLE
remove tensorflow backend in ops

### DIFF
--- a/fastestimator/op/numpyop/numpyop.py
+++ b/fastestimator/op/numpyop/numpyop.py
@@ -15,7 +15,6 @@
 from typing import Any, Callable, Dict, Iterable, List, MutableMapping, Optional, Sequence, TypeVar, Union
 
 import numpy as np
-import tensorflow as tf
 import torch
 from torch.utils.data.dataloader import default_collate
 
@@ -24,8 +23,6 @@ from fastestimator.op.op import Op, get_inputs_by_op, write_outputs_by_op
 from fastestimator.types import FilteredData
 from fastestimator.util.traceability_util import traceable
 from fastestimator.util.util import pad_batch
-
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor, np.ndarray)
 
 
 @traceable()
@@ -44,6 +41,7 @@ class NumpyOp(Op):
         ds_id: What dataset id(s) to execute this Op in. To execute regardless of ds_id, pass None. To execute in all
             ds_ids except for a particular one, you can pass an argument like "!ds1".
     """
+
     def __init__(self,
                  inputs: Union[None, str, Iterable[str]] = None,
                  outputs: Union[None, str, Iterable[str]] = None,
@@ -176,6 +174,7 @@ class Delete(NumpyOp):
         ds_id: What dataset id(s) to execute this Op in. To execute regardless of ds_id, pass None. To execute in all
             ds_ids except for a particular one, you can pass an argument like "!ds1".
     """
+
     def __init__(self,
                  keys: Union[str, Sequence[str]],
                  mode: Union[None, str, Iterable[str]] = None,
@@ -185,7 +184,7 @@ class Delete(NumpyOp):
     def forward(self, data: Union[np.ndarray, List[np.ndarray]], state: Dict[str, Any]) -> None:
         pass
 
-    def forward_batch(self, data: Union[Tensor, List[Tensor]], state: Dict[str, Any]) -> None:
+    def forward_batch(self, data: Union[torch.Tensor, List[torch.Tensor]], state: Dict[str, Any]) -> None:
         pass
 
 
@@ -203,6 +202,7 @@ class LambdaOp(NumpyOp):
         ds_id: What dataset id(s) to execute this Op in. To execute regardless of ds_id, pass None. To execute in all
             ds_ids except for a particular one, you can pass an argument like "!ds1".
     """
+
     def __init__(self,
                  fn: Callable,
                  inputs: Union[None, str, Iterable[str]] = None,
@@ -223,8 +223,8 @@ class LambdaOp(NumpyOp):
     def forward(self, data: List[np.ndarray], state: Dict[str, Any]) -> Union[np.ndarray, List[np.ndarray]]:
         return self.fn(*data)
 
-    def forward_batch(self, data: Union[Tensor, List[Tensor]], state: Dict[str,
-                                                                           Any]) -> Union[np.ndarray, List[np.ndarray]]:
+    def forward_batch(self, data: Union[torch.Tensor, List[torch.Tensor]],
+                      state: Dict[str, Any]) -> Union[np.ndarray, List[np.ndarray]]:
         return self.forward(data, state)
 
 
@@ -248,6 +248,7 @@ class RemoveIf(NumpyOp):
         ds_id: What dataset id(s) to execute this Op in. To execute regardless of ds_id, pass None. To execute in all
             ds_ids except for a particular one, you can pass an argument like "!ds1".
     """
+
     def __init__(self,
                  fn: Callable[..., bool],
                  replacement: bool = True,
@@ -264,7 +265,8 @@ class RemoveIf(NumpyOp):
             return FilteredData(replacement=self.replacement)
         return None
 
-    def forward_batch(self, data: Union[Tensor, List[Tensor]], state: Dict[str, Any]) -> Optional[FilteredData]:
+    def forward_batch(self, data: Union[torch.Tensor, List[torch.Tensor]], state: Dict[str,
+                                                                                       Any]) -> Optional[FilteredData]:
         return self.forward(data, state)
 
 

--- a/fastestimator/op/numpyop/numpyop.py
+++ b/fastestimator/op/numpyop/numpyop.py
@@ -24,6 +24,8 @@ from fastestimator.types import FilteredData
 from fastestimator.util.traceability_util import traceable
 from fastestimator.util.util import pad_batch
 
+Tensor = TypeVar('Tensor', torch.Tensor, np.ndarray)
+
 
 @traceable()
 class NumpyOp(Op):
@@ -223,8 +225,8 @@ class LambdaOp(NumpyOp):
     def forward(self, data: List[np.ndarray], state: Dict[str, Any]) -> Union[np.ndarray, List[np.ndarray]]:
         return self.fn(*data)
 
-    def forward_batch(self, data: Union[torch.Tensor, List[torch.Tensor]],
-                      state: Dict[str, Any]) -> Union[np.ndarray, List[np.ndarray]]:
+    def forward_batch(self, data: Union[Tensor, List[Tensor]], state: Dict[str,
+                                                                           Any]) -> Union[np.ndarray, List[np.ndarray]]:
         return self.forward(data, state)
 
 
@@ -265,8 +267,7 @@ class RemoveIf(NumpyOp):
             return FilteredData(replacement=self.replacement)
         return None
 
-    def forward_batch(self, data: Union[torch.Tensor, List[torch.Tensor]], state: Dict[str,
-                                                                                       Any]) -> Optional[FilteredData]:
+    def forward_batch(self, data: Union[Tensor, List[Tensor]], state: Dict[str, Any]) -> Optional[FilteredData]:
         return self.forward(data, state)
 
 

--- a/fastestimator/op/numpyop/univariate/calibate.py
+++ b/fastestimator/op/numpyop/univariate/calibate.py
@@ -24,7 +24,7 @@ from fastestimator.op.numpyop.numpyop import NumpyOp
 from fastestimator.util.traceability_util import traceable
 from fastestimator.util.util import to_number
 
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor, np.ndarray)
+Tensor = TypeVar('Tensor', torch.Tensor, np.ndarray)
 
 
 @traceable()

--- a/fastestimator/op/tensorop/argmax.py
+++ b/fastestimator/op/tensorop/argmax.py
@@ -14,14 +14,11 @@
 # ==============================================================================
 from typing import Any, Dict, Iterable, List, TypeVar, Union
 
-import tensorflow as tf
 import torch
 
 from fastestimator.backend._argmax import argmax
 from fastestimator.op.tensorop.tensorop import TensorOp
 from fastestimator.util.traceability_util import traceable
-
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor)
 
 
 @traceable()
@@ -38,6 +35,7 @@ class Argmax(TensorOp):
         ds_id: What dataset id(s) to execute this Op in. To execute regardless of ds_id, pass None. To execute in all
             ds_ids except for a particular one, you can pass an argument like "!ds1".
     """
+
     def __init__(self,
                  inputs: Union[str, List[str]],
                  outputs: Union[str, List[str]],
@@ -48,5 +46,5 @@ class Argmax(TensorOp):
         self.axis = axis
         self.in_list, self.out_list = True, True
 
-    def forward(self, data: List[Tensor], state: Dict[str, Any]) -> List[Tensor]:
+    def forward(self, data: List[torch.Tensor], state: Dict[str, Any]) -> List[torch.Tensor]:
         return [argmax(tensor=tensor, axis=self.axis) for tensor in data]

--- a/fastestimator/op/tensorop/augmentation/cutmix_batch.py
+++ b/fastestimator/op/tensorop/augmentation/cutmix_batch.py
@@ -14,20 +14,16 @@
 # ==============================================================================
 from typing import Any, Dict, Iterable, List, Optional, Tuple, TypeVar, Union
 
-import tensorflow as tf
-import tensorflow_probability as tfp
 import torch
 
 from fastestimator.backend._cast import cast
 from fastestimator.backend._clip_by_value import clip_by_value
-from fastestimator.backend._roll import roll
 from fastestimator.backend._get_image_dims import get_image_dims
 from fastestimator.backend._maximum import maximum
+from fastestimator.backend._roll import roll
 from fastestimator.backend._tensor_round import tensor_round
 from fastestimator.backend._tensor_sqrt import tensor_sqrt
 from fastestimator.op.tensorop.tensorop import TensorOp
-
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor)
 
 
 class CutMixBatch(TensorOp):
@@ -52,12 +48,13 @@ class CutMixBatch(TensorOp):
     Raises:
         AssertionError: If the provided inputs are invalid.
     """
+
     def __init__(self,
                  inputs: Iterable[str],
                  outputs: Iterable[str],
                  mode: Union[None, str, Iterable[str]] = 'train',
                  ds_id: Union[None, str, Iterable[str]] = None,
-                 alpha: Union[float, Tensor] = 1.0) -> None:
+                 alpha: Union[float, torch.Tensor] = 1.0) -> None:
         assert alpha > 0, "Alpha value must be greater than zero"
         assert len(inputs) == 2, "Cut-Mix must have exactly 2 inputs"
         assert len(outputs) == 2, "Cut-Mix must have exactly 2 outputs"
@@ -67,18 +64,16 @@ class CutMixBatch(TensorOp):
         self.uniform = None
 
     def build(self, framework: str, device: Optional[torch.device] = None) -> None:
-        if framework == 'tf':
-            self.beta = tfp.distributions.Beta(self.alpha, self.alpha)
-            self.uniform = tfp.distributions.Uniform()
-        elif framework == 'torch':
+        if framework == 'torch':
             self.beta = torch.distributions.beta.Beta(self.alpha, self.alpha)
             self.uniform = torch.distributions.uniform.Uniform(low=0, high=1)
         else:
             raise ValueError("unrecognized framework: {}".format(framework))
 
     @staticmethod
-    def _get_patch_coordinates(tensor: Tensor, x: Tensor, y: Tensor,
-                               lam: Tensor) -> Tuple[Tensor, Tensor, Tensor, Tensor, Tensor, Tensor]:
+    def _get_patch_coordinates(
+            tensor: torch.Tensor, x: torch.Tensor, y: torch.Tensor, lam: torch.Tensor
+    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
         """Randomly cut the patches from input images.
 
         If patches are going to be pasted in other image, combination ratio between two images is defined by `lam`.
@@ -99,12 +94,8 @@ class CutMixBatch(TensorOp):
         """
         _, img_height, img_width = get_image_dims(tensor)
 
-        if tf.is_tensor(tensor):
-            ht = cast(img_height, "float32")
-            wd = cast(img_width, "float32")
-        else:
-            ht = img_height
-            wd = img_width
+        ht = img_height
+        wd = img_width
 
         cut_x = wd * x
         cut_y = ht * y
@@ -123,16 +114,8 @@ class CutMixBatch(TensorOp):
         cut_x = self.uniform.sample()
         cut_y = self.uniform.sample()
         bbox_x1, bbox_x2, bbox_y1, bbox_y2, width, height = self._get_patch_coordinates(x, cut_x, cut_y, lam=lam)
-        if tf.is_tensor(x):
-            rolled_x = roll(x, shift=1, axis=0)
-            patches = rolled_x[:, bbox_y1:bbox_y2, bbox_x1:bbox_x2, :] - x[:, bbox_y1:bbox_y2, bbox_x1:bbox_x2, :]
-            patches = tf.pad(patches, [[0, 0], [bbox_y1, height - bbox_y2], [bbox_x1, width - bbox_x2], [0, 0]],
-                             mode="CONSTANT",
-                             constant_values=0)
-            x = x + patches
-        else:
-            rolled_x = roll(x, shift=1, axis=0)
-            x[:, :, bbox_y1:bbox_y2, bbox_x1:bbox_x2] = rolled_x[:, :, bbox_y1:bbox_y2, bbox_x1:bbox_x2]
+        rolled_x = roll(x, shift=1, axis=0)
+        x[:, :, bbox_y1:bbox_y2, bbox_x1:bbox_x2] = rolled_x[:, :, bbox_y1:bbox_y2, bbox_x1:bbox_x2]
         # adjust lambda to match pixel ratio
         lam = 1 - cast(((bbox_x2 - bbox_x1) * (bbox_y2 - bbox_y1)), dtype=y) / cast((width * height), dtype=y)
         rolled_y = roll(y, shift=1, axis=0) * (1. - lam)

--- a/fastestimator/op/tensorop/augmentation/cutmix_batch.py
+++ b/fastestimator/op/tensorop/augmentation/cutmix_batch.py
@@ -64,11 +64,8 @@ class CutMixBatch(TensorOp):
         self.uniform = None
 
     def build(self, framework: str, device: Optional[torch.device] = None) -> None:
-        if framework == 'torch':
-            self.beta = torch.distributions.beta.Beta(self.alpha, self.alpha)
-            self.uniform = torch.distributions.uniform.Uniform(low=0, high=1)
-        else:
-            raise ValueError("unrecognized framework: {}".format(framework))
+        self.beta = torch.distributions.beta.Beta(self.alpha, self.alpha)
+        self.uniform = torch.distributions.uniform.Uniform(low=0, high=1)
 
     @staticmethod
     def _get_patch_coordinates(

--- a/fastestimator/op/tensorop/augmentation/mixup_batch.py
+++ b/fastestimator/op/tensorop/augmentation/mixup_batch.py
@@ -14,8 +14,6 @@
 # ==============================================================================
 from typing import Any, Dict, Iterable, List, Optional, Tuple, TypeVar, Union
 
-import tensorflow as tf
-import tensorflow_probability as tfp
 import torch
 
 from fastestimator.backend._get_shape import get_shape
@@ -45,6 +43,7 @@ class MixUpBatch(TensorOp):
     Raises:
         AssertionError: If input arguments are invalid.
     """
+
     def __init__(self,
                  inputs: Iterable[str],
                  outputs: Iterable[str],
@@ -61,15 +60,13 @@ class MixUpBatch(TensorOp):
         self.shared_beta = shared_beta
 
     def build(self, framework: str, device: Optional[torch.device] = None) -> None:
-        if framework == 'tf':
-            self.beta = tfp.distributions.Beta(self.alpha, self.alpha)
-        elif framework == 'torch':
+        if framework == 'torch':
             self.beta = torch.distributions.beta.Beta(
                 torch.tensor([self.alpha]).to(device), torch.tensor([self.alpha]).to(device))
         else:
             raise ValueError("unrecognized framework: {}".format(framework))
 
-    def forward(self, data: List[Tensor], state: Dict[str, Any]) -> Tuple[Tensor, Tensor]:
+    def forward(self, data: List[torch.Tensor], state: Dict[str, Any]) -> Tuple[torch.Tensor, torch.Tensor]:
         x, y = data
 
         if self.shared_beta:

--- a/fastestimator/op/tensorop/augmentation/mixup_batch.py
+++ b/fastestimator/op/tensorop/augmentation/mixup_batch.py
@@ -22,8 +22,6 @@ from fastestimator.backend._reshape import reshape
 from fastestimator.backend._roll import roll
 from fastestimator.op.tensorop.tensorop import TensorOp
 
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor)
-
 
 class MixUpBatch(TensorOp):
     """MixUp augmentation for tensors.
@@ -60,11 +58,8 @@ class MixUpBatch(TensorOp):
         self.shared_beta = shared_beta
 
     def build(self, framework: str, device: Optional[torch.device] = None) -> None:
-        if framework == 'torch':
-            self.beta = torch.distributions.beta.Beta(
-                torch.tensor([self.alpha]).to(device), torch.tensor([self.alpha]).to(device))
-        else:
-            raise ValueError("unrecognized framework: {}".format(framework))
+        self.beta = torch.distributions.beta.Beta(
+            torch.tensor([self.alpha]).to(device), torch.tensor([self.alpha]).to(device))
 
     def forward(self, data: List[torch.Tensor], state: Dict[str, Any]) -> Tuple[torch.Tensor, torch.Tensor]:
         x, y = data

--- a/fastestimator/op/tensorop/average.py
+++ b/fastestimator/op/tensorop/average.py
@@ -14,14 +14,11 @@
 # ==============================================================================
 from typing import Any, Dict, Iterable, List, TypeVar, Union
 
-import tensorflow as tf
 import torch
 
 from fastestimator.backend._zeros_like import zeros_like
 from fastestimator.op.tensorop.tensorop import TensorOp
 from fastestimator.util.traceability_util import traceable
-
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor)
 
 
 @traceable()
@@ -37,6 +34,7 @@ class Average(TensorOp):
         ds_id: What dataset id(s) to execute this Op in. To execute regardless of ds_id, pass None. To execute in all
             ds_ids except for a particular one, you can pass an argument like "!ds1".
     """
+
     def __init__(self,
                  inputs: Union[str, Iterable[str]],
                  outputs: str,
@@ -45,7 +43,7 @@ class Average(TensorOp):
         super().__init__(inputs=inputs, outputs=outputs, mode=mode, ds_id=ds_id)
         self.in_list, self.out_list = True, False
 
-    def forward(self, data: List[Tensor], state: Dict[str, Any]) -> Tensor:
+    def forward(self, data: List[torch.Tensor], state: Dict[str, Any]) -> torch.Tensor:
         result = zeros_like(data[0])
         for tensor in data:
             result += tensor

--- a/fastestimator/op/tensorop/gather.py
+++ b/fastestimator/op/tensorop/gather.py
@@ -14,16 +14,13 @@
 # ==============================================================================
 from typing import Any, Dict, Iterable, List, TypeVar, Union
 
-import tensorflow as tf
 import torch
 
 from fastestimator.backend._gather_from_batch import gather_from_batch
 from fastestimator.backend._reduce_max import reduce_max
 from fastestimator.op.tensorop.tensorop import TensorOp
-from fastestimator.util.traceability_util import traceable
 from fastestimator.util.base_util import to_list
-
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor)
+from fastestimator.util.traceability_util import traceable
 
 
 @traceable()
@@ -42,6 +39,7 @@ class Gather(TensorOp):
         ds_id: What dataset id(s) to execute this Op in. To execute regardless of ds_id, pass None. To execute in all
             ds_ids except for a particular one, you can pass an argument like "!ds1".
     """
+
     def __init__(self,
                  inputs: Union[str, List[str]],
                  outputs: Union[str, List[str]],
@@ -55,13 +53,13 @@ class Gather(TensorOp):
         super().__init__(inputs=combined_inputs, outputs=outputs, mode=mode, ds_id=ds_id)
         self.in_list, self.out_list = True, True
 
-    def forward(self, data: List[Tensor], state: Dict[str, Any]) -> List[Tensor]:
+    def forward(self, data: List[torch.Tensor], state: Dict[str, Any]) -> List[torch.Tensor]:
         indices = data[:self.num_indices]
         inputs = data[self.num_indices:]
         results = []
         for idx, tensor in enumerate(inputs):
             # Check len(indices[0]) since an empty indices element is used to trigger the else
-            if tf.is_tensor(indices[0]) or isinstance(indices[0], torch.Tensor):
+            if isinstance(indices[0], torch.Tensor):
                 elem_len = indices[0].shape[0]
             else:
                 elem_len = len(indices[0])

--- a/fastestimator/op/tensorop/gradient/fgsm.py
+++ b/fastestimator/op/tensorop/gradient/fgsm.py
@@ -24,8 +24,6 @@ from fastestimator.backend._sign import sign
 from fastestimator.op.tensorop.tensorop import TensorOp
 from fastestimator.util.traceability_util import traceable
 
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor)
-
 
 @traceable()
 class FGSM(TensorOp):

--- a/fastestimator/op/tensorop/gradient/fgsm.py
+++ b/fastestimator/op/tensorop/gradient/fgsm.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 from typing import Any, Dict, Iterable, List, Optional, TypeVar, Union
 
-import tensorflow as tf
 import torch
 
 from fastestimator.backend._clip_by_value import clip_by_value
@@ -67,9 +66,9 @@ class FGSM(TensorOp):
             self.retain_graph = retain
         return self.retain_graph
 
-    def forward(self, data: List[Tensor], state: Dict[str, Any]) -> Tensor:
+    def forward(self, data: List[torch.Tensor], state: Dict[str, Any]) -> torch.Tensor:
         data, loss = data
-        grad = get_gradient(target=loss, sources=data, tape=state['tape'], retain_graph=self.retain_graph)
+        grad = get_gradient(target=loss, sources=data, retain_graph=self.retain_graph)
         adverse_data = clip_by_value(data + self.epsilon * sign(grad),
                                      min_value=self.clip_low or reduce_min(data),
                                      max_value=self.clip_high or reduce_max(data))

--- a/fastestimator/op/tensorop/gradient/gradient.py
+++ b/fastestimator/op/tensorop/gradient/gradient.py
@@ -19,10 +19,8 @@ import torch
 
 from fastestimator.backend._get_gradient import get_gradient
 from fastestimator.op.tensorop.tensorop import TensorOp
-from fastestimator.util.traceability_util import traceable
 from fastestimator.util.base_util import to_list
-
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor)
+from fastestimator.util.traceability_util import traceable
 
 
 @traceable()
@@ -40,11 +38,12 @@ class GradientOp(TensorOp):
         ds_id: What dataset id(s) to execute this Op in. To execute regardless of ds_id, pass None. To execute in all
             ds_ids except for a particular one, you can pass an argument like "!ds1".
     """
+
     def __init__(self,
                  finals: Union[str, List[str]],
                  outputs: Union[str, List[str]],
                  inputs: Union[None, str, List[str]] = None,
-                 model: Union[None, tf.keras.Model, torch.nn.Module] = None,
+                 model: Union[None, torch.nn.Module] = None,
                  mode: Union[None, str, Iterable[str]] = None,
                  ds_id: Union[None, str, Iterable[str]] = None):
         inputs = to_list(inputs)
@@ -55,7 +54,7 @@ class GradientOp(TensorOp):
             assert len(inputs) == len(finals) == len(outputs), \
                 "GradientOp requires the same number of inputs, finals, and outputs"
         else:
-            assert isinstance(model, (tf.keras.Model, torch.nn.Module)), "Unrecognized model format"
+            assert isinstance(model, torch.nn.Module), "Unrecognized model format"
             assert len(finals) == len(outputs), "GradientOp requires the same number of finals, and outputs"
         inputs.extend(finals)
         super().__init__(inputs=inputs, outputs=outputs, mode=mode, ds_id=ds_id)
@@ -70,7 +69,7 @@ class GradientOp(TensorOp):
     def build(self, framework: str, device: Optional[torch.device] = None) -> None:
         self.framework = framework
 
-    def forward(self, data: List[Tensor], state: Dict[str, Any]) -> List[Tensor]:
+    def forward(self, data: List[torch.Tensor], state: Dict[str, Any]) -> List[torch.Tensor]:
         results = []
         if self.model is None:
             initials = data[:len(data) // 2]
@@ -80,12 +79,7 @@ class GradientOp(TensorOp):
                 results.append(get_gradient(final, initial, tape=state['tape'], retain_graph=retain_graph))
         else:
             finals = data
-            if self.framework == "tf":
-                trainable_params = self.model.trainable_variables
-                for idx, final in enumerate(finals):
-                    gradient = get_gradient(final, trainable_params, tape=state['tape'])
-                    results.append(gradient)
-            elif self.framework == "torch":
+            if self.framework == "torch":
                 trainable_params = [p for p in self.model.parameters() if p.requires_grad]
                 for idx, final in enumerate(finals):
                     # get_gradient

--- a/fastestimator/op/tensorop/gradient/gradient.py
+++ b/fastestimator/op/tensorop/gradient/gradient.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 from typing import Any, Dict, Iterable, List, Optional, TypeVar, Union
 
-import tensorflow as tf
 import torch
 
 from fastestimator.backend._get_gradient import get_gradient
@@ -79,14 +78,10 @@ class GradientOp(TensorOp):
                 results.append(get_gradient(final, initial, tape=state['tape'], retain_graph=retain_graph))
         else:
             finals = data
-            if self.framework == "torch":
-                trainable_params = [p for p in self.model.parameters() if p.requires_grad]
-                for idx, final in enumerate(finals):
-                    # get_gradient
-                    retain_graph = self.retain_graph or not idx == len(finals) - 1
-                    gradient = get_gradient(final, trainable_params, retain_graph=retain_graph)
-                    results.append(gradient)
-            else:
-                raise ValueError(f"Unrecognized framework {self.framework}")
-
+            trainable_params = [p for p in self.model.parameters() if p.requires_grad]
+            for idx, final in enumerate(finals):
+                # get_gradient
+                retain_graph = self.retain_graph or not idx == len(finals) - 1
+                gradient = get_gradient(final, trainable_params, retain_graph=retain_graph)
+                results.append(gradient)
         return results

--- a/fastestimator/op/tensorop/gradient/watch.py
+++ b/fastestimator/op/tensorop/gradient/watch.py
@@ -14,14 +14,11 @@
 # ==============================================================================
 from typing import Any, Dict, Iterable, List, Optional, TypeVar, Union
 
-import tensorflow as tf
 import torch
 
 from fastestimator.backend._watch import watch
 from fastestimator.op.tensorop.tensorop import TensorOp
 from fastestimator.util.traceability_util import traceable
-
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor)
 
 
 @traceable()
@@ -36,6 +33,7 @@ class Watch(TensorOp):
         ds_id: What dataset id(s) to execute this Op in. To execute regardless of ds_id, pass None. To execute in all
             ds_ids except for a particular one, you can pass an argument like "!ds1".
     """
+
     def __init__(self,
                  inputs: Union[None, str, Iterable[str]],
                  mode: Union[None, str, Iterable[str]] = None,
@@ -49,7 +47,7 @@ class Watch(TensorOp):
             self.retain_graph = retain
         return self.retain_graph
 
-    def forward(self, data: List[Tensor], state: Dict[str, Any]) -> List[Tensor]:
+    def forward(self, data: List[torch.Tensor], state: Dict[str, Any]) -> List[torch.Tensor]:
         for idx, tensor in enumerate(data):
-            data[idx] = watch(tensor=tensor, tape=state['tape'])
+            data[idx] = watch(tensor=tensor)
         return data

--- a/fastestimator/op/tensorop/loss/cross_entropy.py
+++ b/fastestimator/op/tensorop/loss/cross_entropy.py
@@ -22,8 +22,6 @@ from fastestimator.backend._sparse_categorical_crossentropy import sparse_catego
 from fastestimator.op.tensorop.loss.loss import LossOp
 from fastestimator.util.traceability_util import traceable
 
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor)
-
 
 @traceable()
 class CrossEntropy(LossOp):
@@ -49,6 +47,7 @@ class CrossEntropy(LossOp):
     Raises:
         AssertionError: If `class_weights` or it's keys and values are of unacceptable data types.
     """
+
     def __init__(self,
                  inputs: Union[Tuple[str, str], List[str]],
                  outputs: str,
@@ -80,10 +79,7 @@ class CrossEntropy(LossOp):
 
     def build(self, framework: str, device: Optional[torch.device] = None) -> None:
         if self.class_weights:
-            if framework == 'torch':
-                self.class_dict = self.class_weights
-            else:
-                raise ValueError("unrecognized framework: {}".format(framework))
+            self.class_dict = self.class_weights
 
     def forward(self, data: List[torch.Tensor], state: Dict[str, Any]) -> torch.Tensor:
         y_pred, y_true = data

--- a/fastestimator/op/tensorop/loss/cross_entropy.py
+++ b/fastestimator/op/tensorop/loss/cross_entropy.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 from typing import Any, Dict, Iterable, List, Optional, Tuple, TypeVar, Union
 
-import tensorflow as tf
 import torch
 
 from fastestimator.backend._binary_crossentropy import binary_crossentropy
@@ -81,17 +80,12 @@ class CrossEntropy(LossOp):
 
     def build(self, framework: str, device: Optional[torch.device] = None) -> None:
         if self.class_weights:
-            if framework == 'tf':
-                keys_tensor = tf.constant(list(self.class_weights.keys()))
-                vals_tensor = tf.constant(list(self.class_weights.values()))
-                self.class_dict = tf.lookup.StaticHashTable(
-                    tf.lookup.KeyValueTensorInitializer(keys_tensor, vals_tensor), default_value=1.0)
-            elif framework == 'torch':
+            if framework == 'torch':
                 self.class_dict = self.class_weights
             else:
                 raise ValueError("unrecognized framework: {}".format(framework))
 
-    def forward(self, data: List[Tensor], state: Dict[str, Any]) -> Tensor:
+    def forward(self, data: List[torch.Tensor], state: Dict[str, Any]) -> torch.Tensor:
         y_pred, y_true = data
         form = self.form
         if form is None:

--- a/fastestimator/op/tensorop/loss/dice_loss.py
+++ b/fastestimator/op/tensorop/loss/dice_loss.py
@@ -79,12 +79,9 @@ class DiceLoss(LossOp):
                 self.weights[0, channel] = weight
 
     def build(self, framework: str, device: Optional[torch.device] = None) -> None:
-        if framework == 'torch':
-            if self.weights is not None:
-                self.weights = convert_tensor_precision(to_tensor(self.weights, 'torch'))
-                self.weights.to(device)
-        else:
-            raise ValueError("unrecognized framework: {}".format(framework))
+        if self.weights is not None:
+            self.weights = convert_tensor_precision(to_tensor(self.weights, 'torch'))
+            self.weights.to(device)
 
     def forward(self, data: List[Tensor], state: Dict[str, Any]) -> Tensor:
         y_pred, y_true = data

--- a/fastestimator/op/tensorop/loss/dice_loss.py
+++ b/fastestimator/op/tensorop/loss/dice_loss.py
@@ -15,7 +15,6 @@
 from typing import Any, Dict, Iterable, List, Optional, Tuple, TypeVar, Union
 
 import numpy as np
-import tensorflow as tf
 import torch
 
 from fastestimator.backend._convert_tensor_precision import convert_tensor_precision
@@ -23,7 +22,7 @@ from fastestimator.backend._dice_score import dice_score
 from fastestimator.backend._to_tensor import to_tensor
 from fastestimator.op.tensorop.loss.loss import LossOp
 
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor, np.array)
+Tensor = TypeVar('Tensor', torch.Tensor, np.array)
 
 
 class DiceLoss(LossOp):
@@ -80,10 +79,7 @@ class DiceLoss(LossOp):
                 self.weights[0, channel] = weight
 
     def build(self, framework: str, device: Optional[torch.device] = None) -> None:
-        if framework == 'tf':
-            if self.weights is not None:
-                self.weights = convert_tensor_precision(to_tensor(self.weights, 'tf'))
-        elif framework == 'torch':
+        if framework == 'torch':
             if self.weights is not None:
                 self.weights = convert_tensor_precision(to_tensor(self.weights, 'torch'))
                 self.weights.to(device)

--- a/fastestimator/op/tensorop/loss/focal_loss.py
+++ b/fastestimator/op/tensorop/loss/focal_loss.py
@@ -12,16 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Any, Dict, Iterable, List, Tuple, TypeVar, Union
+from typing import Any, Dict, Iterable, List, Tuple, Union
 
-import tensorflow as tf
 import torch
 
 from fastestimator.backend._focal_loss import focal_loss
 from fastestimator.op.tensorop.loss.loss import LossOp
 from fastestimator.util.traceability_util import traceable
-
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor)
 
 
 @traceable()
@@ -53,6 +50,7 @@ class FocalLoss(LossOp):
             regardless of mode, pass None. To execute in all modes except for a particular one, you can pass an
             argument like "!infer" or "!train".
     """
+
     def __init__(self,
                  inputs: Union[Tuple[str, str], List[str]],
                  outputs: str,
@@ -71,7 +69,7 @@ class FocalLoss(LossOp):
         self.from_logits = from_logits
         self.normalize = normalize
 
-    def forward(self, data: Union[Tensor, List[Tensor]], state: Dict[str, Any]) -> Tensor:
+    def forward(self, data: Union[torch.Tensor, List[torch.Tensor]], state: Dict[str, Any]) -> torch.Tensor:
         y_pred, y_true = data
         return focal_loss(y_true,
                           y_pred,

--- a/fastestimator/op/tensorop/loss/hinge.py
+++ b/fastestimator/op/tensorop/loss/hinge.py
@@ -12,17 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Any, Dict, Iterable, List, Tuple, TypeVar, Union
+from typing import Any, Dict, Iterable, List, Tuple, Union
 
-import tensorflow as tf
 import torch
 
 from fastestimator.backend._hinge import hinge
 from fastestimator.backend._reduce_mean import reduce_mean
 from fastestimator.op.tensorop.loss.loss import LossOp
 from fastestimator.util.traceability_util import traceable
-
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor)
 
 
 @traceable()
@@ -39,6 +36,7 @@ class Hinge(LossOp):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         average_loss: Whether to average the element-wise loss after the Loss Op.
     """
+
     def __init__(self,
                  inputs: Union[Tuple[str, str], List[str]],
                  outputs: str,
@@ -48,7 +46,7 @@ class Hinge(LossOp):
         super().__init__(inputs=inputs, outputs=outputs, mode=mode, ds_id=ds_id)
         self.average_loss = average_loss
 
-    def forward(self, data: List[Tensor], state: Dict[str, Any]) -> Tensor:
+    def forward(self, data: List[torch.Tensor], state: Dict[str, Any]) -> torch.Tensor:
         y_pred, y_true = data
         loss = hinge(y_true=y_true, y_pred=y_pred)
         if self.average_loss:

--- a/fastestimator/op/tensorop/loss/l1_loss.py
+++ b/fastestimator/op/tensorop/loss/l1_loss.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Any, Dict, Iterable, List, Tuple, TypeVar, Union
+from typing import Any, Dict, Iterable, List, Tuple, Union
 
-import tensorflow as tf
 import torch
 
 from fastestimator.backend._huber import huber
@@ -23,8 +22,6 @@ from fastestimator.backend._reduce_mean import reduce_mean
 from fastestimator.backend._smooth_l1_loss import smooth_l1_loss
 from fastestimator.op.tensorop.loss.loss import LossOp
 from fastestimator.util.traceability_util import traceable
-
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor)
 
 
 @traceable()
@@ -51,6 +48,7 @@ class L1_Loss(LossOp):
         loss_type: What type of L1 loss. Can either be 'L1' (L1 Loss), 'Smooth' (Smooth L1 Loss) or 'Huber' (Huber loss). Default:'L1'
         beta: A threshold at which to change between L1 and L2 loss. Needs to be a positive number. Default:1.0 . dtype: float16 or float32.
     """
+
     def __init__(self,
                  inputs: Union[Tuple[str, str], List[str]],
                  outputs: str,
@@ -64,7 +62,7 @@ class L1_Loss(LossOp):
         self.loss_type = loss_type
         self.beta = beta
 
-    def forward(self, data: List[Tensor], state: Dict[str, Any]) -> Tensor:
+    def forward(self, data: List[torch.Tensor], state: Dict[str, Any]) -> torch.Tensor:
         y_pred, y_true = data
         if self.loss_type == 'L1':
             loss = l1_loss(y_true=y_true, y_pred=y_pred)

--- a/fastestimator/op/tensorop/loss/l2_regularization.py
+++ b/fastestimator/op/tensorop/loss/l2_regularization.py
@@ -12,16 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Any, Dict, Iterable, List, TypeVar, Union
+from typing import Any, Dict, Iterable, List, Union
 
-import tensorflow as tf
 import torch
 
 from fastestimator.backend._l2_regularization import l2_regularization
 from fastestimator.op.tensorop.tensorop import TensorOp
 from fastestimator.util.traceability_util import traceable
-
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor)
 
 
 @traceable()
@@ -37,17 +34,18 @@ class L2Regularizaton(TensorOp):
         model: A tensorflow or pytorch model
         beta: The multiplicative factor, to weight the l2 regularization loss with the input loss
     """
+
     def __init__(self,
                  inputs: str,
                  outputs: str,
-                 model: Union[tf.keras.Model, torch.nn.Module],
+                 model: torch.nn.Module,
                  mode: Union[None, str, Iterable[str]] = None,
                  beta: float = 0.01):
         super().__init__(inputs=inputs, outputs=outputs, mode=mode)
         self.model = model
         self.beta = beta
 
-    def forward(self, data: Union[Tensor, List[Tensor]], state: Dict[str, Any]) -> Tensor:
+    def forward(self, data: Union[torch.Tensor, List[torch.Tensor]], state: Dict[str, Any]) -> torch.Tensor:
         loss = data
         total_loss = l2_regularization(self.model, self.beta) + loss
         return total_loss

--- a/fastestimator/op/tensorop/loss/l2_regularization.py
+++ b/fastestimator/op/tensorop/loss/l2_regularization.py
@@ -31,7 +31,7 @@ class L2Regularizaton(TensorOp):
         mode: What mode(s) to execute this Op in. For example, "train", "eval", "test", or "infer". To execute
             regardless of mode, pass None. To execute in all modes except for a particular one, you can pass an argument
             like "!infer" or "!train".
-        model: A tensorflow or pytorch model
+        model: A pytorch model
         beta: The multiplicative factor, to weight the l2 regularization loss with the input loss
     """
 

--- a/fastestimator/op/tensorop/loss/mean_squared_error.py
+++ b/fastestimator/op/tensorop/loss/mean_squared_error.py
@@ -12,17 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ==============================================================================
-from typing import Any, Dict, Iterable, List, Tuple, TypeVar, Union
+from typing import Any, Dict, Iterable, List, Tuple, Union
 
-import tensorflow as tf
 import torch
 
 from fastestimator.backend._mean_squared_error import mean_squared_error
 from fastestimator.backend._reduce_mean import reduce_mean
 from fastestimator.op.tensorop.loss.loss import LossOp
 from fastestimator.util.traceability_util import traceable
-
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor)
 
 
 @traceable()
@@ -39,6 +36,7 @@ class MeanSquaredError(LossOp):
             ds_ids except for a particular one, you can pass an argument like "!ds1".
         average_loss: Whether to average the element-wise loss after the Loss Op.
     """
+
     def __init__(self,
                  inputs: Union[Tuple[str, str], List[str]],
                  outputs: str,
@@ -48,7 +46,7 @@ class MeanSquaredError(LossOp):
         super().__init__(inputs=inputs, outputs=outputs, mode=mode, ds_id=ds_id)
         self.average_loss = average_loss
 
-    def forward(self, data: List[Tensor], state: Dict[str, Any]) -> Tensor:
+    def forward(self, data: List[torch.Tensor], state: Dict[str, Any]) -> torch.Tensor:
         y_pred, y_true = data
         loss = mean_squared_error(y_true=y_true, y_pred=y_pred)
         if self.average_loss:

--- a/fastestimator/op/tensorop/loss/super_loss.py
+++ b/fastestimator/op/tensorop/loss/super_loss.py
@@ -78,31 +78,28 @@ class SuperLoss(LossOp):
 
     def build(self, framework: str, device: Optional[torch.device] = None) -> None:
         self.loss.build(framework, device)
-        if framework == 'torch':
-            self.initialized = {
-                'train': torch.tensor(False).to(device),
-                'eval': torch.tensor(False).to(device),
-                'test': torch.tensor(False).to(device),
-                'infer': torch.tensor(False).to(device)
+        self.initialized = {
+            'train': torch.tensor(False).to(device),
+            'eval': torch.tensor(False).to(device),
+            'test': torch.tensor(False).to(device),
+            'infer': torch.tensor(False).to(device)
+        }
+        if self.tau_method == 'exp':
+            self.tau = {
+                'train': torch.tensor(0.0).to(device),
+                'eval': torch.tensor(0.0).to(device),
+                'test': torch.tensor(0.0).to(device),
+                'infer': torch.tensor(0.0).to(device)
             }
-            if self.tau_method == 'exp':
-                self.tau = {
-                    'train': torch.tensor(0.0).to(device),
-                    'eval': torch.tensor(0.0).to(device),
-                    'test': torch.tensor(0.0).to(device),
-                    'infer': torch.tensor(0.0).to(device)
-                }
-            else:
-                self.tau = {
-                    'train': torch.tensor(self.tau_method).to(device),
-                    'eval': torch.tensor(self.tau_method).to(device),
-                    'test': torch.tensor(self.tau_method).to(device),
-                    'infer': torch.tensor(self.tau_method).to(device)
-                }
-            self.cap = torch.tensor(self.cap).to(device)
-            self.lam = torch.tensor(self.lam).to(device)
         else:
-            raise ValueError("unrecognized framework: {}".format(framework))
+            self.tau = {
+                'train': torch.tensor(self.tau_method).to(device),
+                'eval': torch.tensor(self.tau_method).to(device),
+                'test': torch.tensor(self.tau_method).to(device),
+                'infer': torch.tensor(self.tau_method).to(device)
+            }
+        self.cap = torch.tensor(self.cap).to(device)
+        self.lam = torch.tensor(self.lam).to(device)
 
     def forward(self, data: List[torch.Tensor], state: Dict[str, Any]) -> Union[torch.Tensor, List[torch.Tensor]]:
         base_loss = self.loss.forward(data, state)

--- a/fastestimator/op/tensorop/loss/super_loss.py
+++ b/fastestimator/op/tensorop/loss/super_loss.py
@@ -15,7 +15,6 @@
 from math import e
 from typing import Any, Dict, List, Optional, TypeVar, Union
 
-import tensorflow as tf
 import torch
 
 from fastestimator.backend._exp import exp
@@ -26,8 +25,6 @@ from fastestimator.backend._pow import pow
 from fastestimator.backend._reduce_mean import reduce_mean
 from fastestimator.op.tensorop.loss.loss import LossOp
 from fastestimator.util.util import to_number
-
-Tensor = TypeVar('Tensor', tf.Tensor, tf.Variable, torch.Tensor)
 
 
 class SuperLoss(LossOp):
@@ -51,6 +48,7 @@ class SuperLoss(LossOp):
         ValueError: If the provided `loss` has multiple outputs or the `regularization` / `threshold` parameters are
             invalid.
     """
+
     def __init__(self,
                  loss: LossOp,
                  threshold: Union[float, str] = 'exp',
@@ -80,29 +78,7 @@ class SuperLoss(LossOp):
 
     def build(self, framework: str, device: Optional[torch.device] = None) -> None:
         self.loss.build(framework, device)
-        if framework == 'tf':
-            self.initialized = {
-                'train': tf.Variable(False, trainable=False),
-                'eval': tf.Variable(False, trainable=False),
-                'test': tf.Variable(False, trainable=False),
-                'infer': tf.Variable(False, trainable=False)
-            }
-            if self.tau_method == 'exp':
-                self.tau = {
-                    'train': tf.Variable(0.0, trainable=False),
-                    'eval': tf.Variable(0.0, trainable=False),
-                    'test': tf.Variable(0.0, trainable=False),
-                    'infer': tf.Variable(0.0, trainable=False)
-                }
-            else:
-                self.tau = {
-                    'train': tf.Variable(self.tau_method, trainable=False),
-                    'eval': tf.Variable(self.tau_method, trainable=False),
-                    'test': tf.Variable(self.tau_method, trainable=False),
-                    'infer': tf.Variable(self.tau_method, trainable=False)
-                }
-            self.cap = tf.constant(self.cap)
-        elif framework == 'torch':
+        if framework == 'torch':
             self.initialized = {
                 'train': torch.tensor(False).to(device),
                 'eval': torch.tensor(False).to(device),
@@ -128,7 +104,7 @@ class SuperLoss(LossOp):
         else:
             raise ValueError("unrecognized framework: {}".format(framework))
 
-    def forward(self, data: List[Tensor], state: Dict[str, Any]) -> Union[Tensor, List[Tensor]]:
+    def forward(self, data: List[torch.Tensor], state: Dict[str, Any]) -> Union[torch.Tensor, List[torch.Tensor]]:
         base_loss = self.loss.forward(data, state)
         tau = self._accumulate_tau(base_loss, state['mode'], state['warmup'])
         beta = (base_loss - tau) / self.lam
@@ -145,7 +121,7 @@ class SuperLoss(LossOp):
 
         return super_loss
 
-    def _accumulate_tau(self, loss: Tensor, mode: str, warmup: bool) -> Tensor:
+    def _accumulate_tau(self, loss: torch.Tensor, mode: str, warmup: bool) -> torch.Tensor:
         """Determine an average loss value based on a particular method chosen during __init__.
 
         Right now this only supports constant values or exponential averaging. The original paper also proposed global
@@ -170,7 +146,7 @@ class SuperLoss(LossOp):
         return self.tau[mode]
 
 
-def _read_variable(variable: Tensor) -> Tensor:
+def _read_variable(variable: torch.Tensor) -> torch.Tensor:
     """Read a variable.
 
     For some unknown reason, tf.Variable(False) on a multi-gpu machine will evaluate as True during an if-check, so need
@@ -182,19 +158,14 @@ def _read_variable(variable: Tensor) -> Tensor:
     Returns:
         The `variable` value.
     """
-    if isinstance(variable, torch.Tensor):
-        return variable
-    return variable.read_value()
+    return variable
 
 
-def _assign(variable: Tensor, value: Tensor) -> None:
+def _assign(variable: torch.Tensor, value: torch.Tensor) -> None:
     """In place assignment of `value` to a `variable`.
 
     Args:
         variable: The tensor to be modified.
         value: The new value to be inserted into the `variable`.
     """
-    if isinstance(variable, torch.Tensor):
-        variable.copy_(value.detach())
-    else:
-        variable.assign(value)
+    variable.copy_(value.detach())

--- a/fastestimator/op/tensorop/meta/fuse.py
+++ b/fastestimator/op/tensorop/meta/fuse.py
@@ -14,16 +14,12 @@
 # ==============================================================================
 from typing import Any, Dict, List, Optional, Set, TypeVar, Union
 
-import tensorflow as tf
 import torch
 
 from fastestimator.network import BaseNetwork
 from fastestimator.op.tensorop.tensorop import TensorOp
-from fastestimator.util.traceability_util import traceable
 from fastestimator.util.base_util import to_list
-
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor)
-Model = TypeVar('Model', tf.keras.Model, torch.nn.Module)
+from fastestimator.util.traceability_util import traceable
 
 
 @traceable()
@@ -37,6 +33,7 @@ class Fuse(TensorOp):
     Raises:
         ValueError: If `ops` are invalid.
     """
+
     def __init__(self, ops: Union[TensorOp, List[TensorOp]]) -> None:
         ops = to_list(ops)
         if len(ops) < 1:
@@ -70,7 +67,7 @@ class Fuse(TensorOp):
         for op in self.ops:
             op.build(framework, device)
 
-    def get_fe_models(self) -> Set[Model]:
+    def get_fe_models(self) -> Set[torch.nn.Module]:
         return self.models
 
     def get_fe_loss_keys(self) -> Set[str]:
@@ -82,7 +79,7 @@ class Fuse(TensorOp):
     def __getstate__(self) -> Dict[str, List[Dict[Any, Any]]]:
         return {'ops': [elem.__getstate__() if hasattr(elem, '__getstate__') else {} for elem in self.ops]}
 
-    def forward(self, data: List[Tensor], state: Dict[str, Any]) -> List[Tensor]:
+    def forward(self, data: List[torch.Tensor], state: Dict[str, Any]) -> List[torch.Tensor]:
         data = {key: elem for key, elem in zip(self.inputs, data)}
         BaseNetwork._forward_batch(data, state, self.ops)
         return [data[key] for key in self.outputs]

--- a/fastestimator/op/tensorop/meta/one_of.py
+++ b/fastestimator/op/tensorop/meta/one_of.py
@@ -15,15 +15,11 @@
 from typing import Any, Dict, List, Optional, Set, TypeVar, Union
 
 import numpy as np
-import tensorflow as tf
 import torch
 
 from fastestimator.backend._cast import cast
 from fastestimator.op.tensorop.tensorop import TensorOp
 from fastestimator.util.traceability_util import traceable
-
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor)
-Model = TypeVar('Model', tf.keras.Model, torch.nn.Module)
 
 
 @traceable()
@@ -34,6 +30,7 @@ class OneOf(TensorOp):
         *tensor_ops: Ops to choose between with a specified (or uniform) probability.
         probs: List of probabilities, must sum to 1. When None, the probabilities will be equally distributed.
     """
+
     def __init__(self, *tensor_ops: TensorOp, probs: Optional[List[float]] = None) -> None:
         inputs = tensor_ops[0].inputs
         outputs = tensor_ops[0].outputs
@@ -59,7 +56,7 @@ class OneOf(TensorOp):
         self.framework = None
 
     def build(self, framework: str, device: Optional[torch.device] = None) -> None:
-        assert framework in {"tf", "torch"}, "unrecognized framework: {}".format(framework)
+        assert framework == "torch", "unrecognized framework: {}".format(framework)
         self.framework = framework
         for op in self.ops:
             op.build(framework, device)
@@ -67,7 +64,7 @@ class OneOf(TensorOp):
     def get_fe_loss_keys(self) -> Set[str]:
         return set.union(*[op.get_fe_loss_keys() for op in self.ops])
 
-    def get_fe_models(self) -> Set[Model]:
+    def get_fe_models(self) -> Set[torch.nn.Module]:
         return set.union(*[op.get_fe_models() for op in self.ops])
 
     def fe_retain_graph(self, retain: Optional[bool] = None) -> Optional[bool]:
@@ -79,7 +76,8 @@ class OneOf(TensorOp):
     def __getstate__(self) -> Dict[str, List[Dict[Any, Any]]]:
         return {'ops': [elem.__getstate__() if hasattr(elem, '__getstate__') else {} for elem in self.ops]}
 
-    def forward(self, data: Union[Tensor, List[Tensor]], state: Dict[str, Any]) -> Union[Tensor, List[Tensor]]:
+    def forward(self, data: Union[torch.Tensor, List[torch.Tensor]],
+                state: Dict[str, Any]) -> Union[torch.Tensor, List[torch.Tensor]]:
         """Execute a randomly selected op from the list of `numpy_ops`.
 
         Args:
@@ -89,9 +87,5 @@ class OneOf(TensorOp):
         Returns:
             The `data` after application of one of the available numpyOps.
         """
-        if self.framework == 'tf':
-            idx = cast(tf.random.categorical(tf.math.log([self.probs]), 1), dtype='int32')[0, 0]
-            results = tf.switch_case(idx, [lambda op=op: op.forward(data, state) for op in self.ops])
-        else:
-            results = np.random.choice(self.ops, p=self.probs).forward(data, state)
+        results = np.random.choice(self.ops, p=self.probs).forward(data, state)
         return results

--- a/fastestimator/op/tensorop/meta/repeat.py
+++ b/fastestimator/op/tensorop/meta/repeat.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 import functools
 import inspect
-from typing import Any, Callable, Dict, List, Optional, Set, Tuple, TypeVar, Union
+from typing import Any, Callable, Dict, List, Optional, Set, Union
 
 import torch
 
@@ -22,8 +22,6 @@ from fastestimator.network import BaseNetwork
 from fastestimator.op.tensorop.tensorop import TensorOp
 from fastestimator.util.traceability_util import traceable
 
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor)
-Model = TypeVar('Model', tf.keras.Model, torch.nn.Module)
 
 
 @traceable()
@@ -94,7 +92,7 @@ class Repeat(TensorOp):
         self.op.build(framework, device)
         self.while_fn = self._torch_while
 
-    def get_fe_models(self) -> Set[Model]:
+    def get_fe_models(self) -> Set[torch.nn.Module]:
         return self.op.get_fe_models()
 
     def get_fe_loss_keys(self) -> Set[str]:
@@ -108,7 +106,7 @@ class Repeat(TensorOp):
     def __getstate__(self) -> Dict[str, List[Dict[Any, Any]]]:
         return {'ops': [elem.__getstate__() if hasattr(elem, '__getstate__') else {} for elem in self.ops]}
 
-    def forward(self, data: List[Tensor], state: Dict[str, Any]) -> List[Tensor]:
+    def forward(self, data: List[torch.Tensor], state: Dict[str, Any]) -> List[torch.Tensor]:
         # Set retain to true since might loop over a gradient aware op
         self.op.fe_retain_graph(True)
 

--- a/fastestimator/op/tensorop/meta/repeat.py
+++ b/fastestimator/op/tensorop/meta/repeat.py
@@ -16,8 +16,8 @@ import functools
 import inspect
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple, TypeVar, Union
 
-import tensorflow as tf
 import torch
+
 from fastestimator.network import BaseNetwork
 from fastestimator.op.tensorop.tensorop import TensorOp
 from fastestimator.util.traceability_util import traceable
@@ -61,6 +61,7 @@ class Repeat(TensorOp):
     Raises:
         ValueError: If `repeat`, `op`, or max_iter are invalid.
     """
+
     def __init__(self, op: TensorOp, repeat: Union[int, Callable[..., bool]] = 1,
                  max_iter: Optional[int] = None) -> None:
         self.repeat_inputs = []
@@ -91,15 +92,7 @@ class Repeat(TensorOp):
 
     def build(self, framework: str, device: Optional[torch.device] = None) -> None:
         self.op.build(framework, device)
-        # Below the while function is chosen based on framework
-        if framework == 'tf':
-            # For tensorflow the while function is decided based of object type of 'self.repeat'.
-            if isinstance(self.repeat, int):
-                self.while_fn = self._tf_while_int
-            else:
-                self.while_fn = self._tf_while
-        else:
-            self.while_fn = self._torch_while
+        self.while_fn = self._torch_while
 
     def get_fe_models(self) -> Set[Model]:
         return self.op.get_fe_models()
@@ -130,7 +123,7 @@ class Repeat(TensorOp):
 
         return [data[key] for key in self.outputs]
 
-    def _torch_while(self, data: Dict[str, Tensor], state: Dict[str, Any]) -> Dict[str, Tensor]:
+    def _torch_while(self, data: Dict[str, torch.Tensor], state: Dict[str, Any]) -> Dict[str, torch.Tensor]:
         """A helper function to invoke a loop.
 
         Args:
@@ -157,112 +150,3 @@ class Repeat(TensorOp):
                 BaseNetwork._forward_batch(data, state, self.ops)
                 i += 1
         return data
-
-    def _tf_while_int(self, data: Dict[str, Tensor], state: Dict[str, Any]) -> Dict[str, Tensor]:
-        """A helper function to invoke a while loop in case self.repeat is an integer.
-
-        Experiment were conducted to compare performance of tf.while_loop() with tf.range(), where tf.range outperformed
-        tf.while_loop() in most scenarios. But it was found that tensors cannot be overwritten inside the scope of
-        tf.range() and hence the RepeatOp failed on few Ops (eg: Ops which were updating the inputs). Creating a copy
-        of tensor in every iteration of tf.range() resolved this issue, but also dissolved all the advantages of
-        tf.range().
-
-        Args:
-            data: A data dictionary to be used during looping.
-            state: The state variables to be considered during looping.
-
-        Returns:
-            A reference to the updated data dictionary.
-        """
-        if self.repeat == 1:
-            # Let retain be whatever it was meant to be for the final sequence
-            # This is done right before the only forward pass to ensure accurate graph building in case
-            # we dont retain the graph
-            self.op.fe_retain_graph(self.retain_graph)
-            # Final round of ops
-            BaseNetwork._forward_batch(data, state, self.ops)
-        elif self.repeat == 2:
-            BaseNetwork._forward_batch(data, state, self.ops)
-            # Let retain be whatever it was meant to be for the final sequence
-            # This is done right before the last forward pass to ensure accurate graph building in case
-            # we dont retain the graph
-            self.op.fe_retain_graph(self.retain_graph)
-            # Final round of ops
-            BaseNetwork._forward_batch(data, state, self.ops)
-        else:
-            # Run a forward pass to ensure that data dictionary structure doesn't change during while loop execution
-            BaseNetwork._forward_batch(data, state, self.ops)
-            args = (tf.constant(1), data)
-            # Use functools.partial since state may contain objects which cannot be cast to tensors (ex. gradient tape)
-            args = tf.while_loop(self._tf_cond,
-                                 functools.partial(self._tf_body, state=state),
-                                 args,
-                                 maximum_iterations=self.max_iter)
-            # Let retain be whatever it was meant to be for the final sequence
-            # This is done right before the last forward pass to ensure accurate graph building in case
-            # we dont retain the graph
-            self.op.fe_retain_graph(self.retain_graph)
-            data = args[1]
-            # Final round of ops
-            BaseNetwork._forward_batch(data, state, self.ops)
-        return data
-
-    def _tf_while(self, data: Dict[str, Tensor], state: Dict[str, Any]) -> Dict[str, Tensor]:
-        """A helper function to invoke a while loop in case self.repeat is a callable function.
-
-        Args:
-            data: A data dictionary to be used during looping.
-            state: The state variables to be considered during looping.
-
-        Returns:
-            A reference to the updated data dictionary.
-        """
-        args = ([data[var_name] for var_name in self.repeat_inputs], data)
-        # Use functools.partial since state may contain objects which cannot be cast to tensors (ex. gradient tape)
-        args = tf.while_loop(self._tf_cond,
-                             functools.partial(self._tf_body, state=state),
-                             args,
-                             maximum_iterations=self.max_iter,
-                             parallel_iterations=1)
-        return args[1]
-
-    def _tf_cond(self, cnd: Union[List[Tensor], Tensor], data: Dict[str, Tensor]) -> bool:
-        """A helper function determine whether to keep invoking the while method.
-
-        Note that `data` and `state` are unused here, but required since tf.while_loop needs the cond and body to have
-        the same input argument signatures.
-
-        Args:
-            cnd: A list of arguments to be passed to the condition function.
-            data: A data dictionary to be used during looping.
-
-        Returns:
-            Whether to continue looping.
-        """
-        if isinstance(self.repeat, int):
-            # In this case we have 2 Forward calls for tf (one before and one after the while loop
-            # (For accurate Tf while loop functioning))
-            return tf.less(cnd, self.repeat - 1)
-        return self.repeat(*cnd)
-
-    def _tf_body(self, cnd: Union[List[Tensor], Tensor], data: Dict[str, Tensor],
-                 state: Dict[str, Any]) -> Tuple[Union[List[Tensor], Tensor], Dict[str, Tensor]]:
-        """A helper function to execute the body of a while method.
-
-        Note that `cnd` is unused here, but required since tf.while_loop needs the cond and body to have the same input
-        argument signatures.
-
-        Args:
-            cnd: A list of arguments to be passed to the condition function.
-            data: A data dictionary to be used during looping.
-            state: The state variables to be considered during looping.
-
-        Returns:
-            The updated `cnd` values, along with the modified data and state dictionaries.
-        """
-        # Run a round of ops
-        BaseNetwork._forward_batch(data, state, self.ops)
-        if isinstance(self.repeat, int):
-            # Updating the while condition
-            return tf.add(cnd, 1), data
-        return [data[var_name] for var_name in self.repeat_inputs], data

--- a/fastestimator/op/tensorop/meta/sometimes.py
+++ b/fastestimator/op/tensorop/meta/sometimes.py
@@ -14,15 +14,10 @@
 # ==============================================================================
 from typing import Any, Dict, List, Optional, Set, TypeVar
 
-import tensorflow as tf
-import tensorflow_probability as tfp
 import torch
 
 from fastestimator.op.tensorop.tensorop import TensorOp
 from fastestimator.util.traceability_util import traceable
-
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor)
-Model = TypeVar('Model', tf.keras.Model, torch.nn.Module)
 
 
 @traceable()
@@ -38,6 +33,7 @@ class Sometimes(TensorOp):
         tensor_op: The operator to be performed.
         prob: The probability of execution, which should be in the range: [0-1).
     """
+
     def __init__(self, tensor_op: TensorOp, prob: float = 0.5) -> None:
         # We're going to try to collect any missing output keys from the data dictionary so that they don't get
         # overridden when Sometimes chooses not to execute.
@@ -56,9 +52,7 @@ class Sometimes(TensorOp):
 
     def build(self, framework: str, device: Optional[torch.device] = None) -> None:
         self.op.build(framework, device)
-        if framework == 'tf':
-            self.prob_fn = tfp.distributions.Uniform()
-        elif framework == 'torch':
+        if framework == 'torch':
             self.prob_fn = torch.distributions.uniform.Uniform(low=0, high=1)
         else:
             raise ValueError("unrecognized framework: {}".format(framework))
@@ -66,7 +60,7 @@ class Sometimes(TensorOp):
     def get_fe_loss_keys(self) -> Set[str]:
         return self.op.get_fe_loss_keys()
 
-    def get_fe_models(self) -> Set[Model]:
+    def get_fe_models(self) -> Set[torch.nn.Module]:
         return self.op.get_fe_models()
 
     def fe_retain_graph(self, retain: Optional[bool] = None) -> Optional[bool]:
@@ -75,7 +69,7 @@ class Sometimes(TensorOp):
     def __getstate__(self) -> Dict[str, Dict[Any, Any]]:
         return {'op': self.op.__getstate__() if hasattr(self.op, '__getstate__') else {}}
 
-    def forward(self, data: List[Tensor], state: Dict[str, Any]) -> List[Tensor]:
+    def forward(self, data: List[torch.Tensor], state: Dict[str, Any]) -> List[torch.Tensor]:
         """Execute the wrapped operator a certain fraction of the time.
 
         Args:

--- a/fastestimator/op/tensorop/meta/sometimes.py
+++ b/fastestimator/op/tensorop/meta/sometimes.py
@@ -52,10 +52,7 @@ class Sometimes(TensorOp):
 
     def build(self, framework: str, device: Optional[torch.device] = None) -> None:
         self.op.build(framework, device)
-        if framework == 'torch':
-            self.prob_fn = torch.distributions.uniform.Uniform(low=0, high=1)
-        else:
-            raise ValueError("unrecognized framework: {}".format(framework))
+        self.prob_fn = torch.distributions.uniform.Uniform(low=0, high=1)
 
     def get_fe_loss_keys(self) -> Set[str]:
         return self.op.get_fe_loss_keys()

--- a/fastestimator/op/tensorop/model/model.py
+++ b/fastestimator/op/tensorop/model/model.py
@@ -16,7 +16,6 @@ import inspect
 from functools import partial
 from typing import Any, Dict, Iterable, List, Optional, Set, Tuple, Union
 
-import tensorflow as tf
 import torch
 
 from fastestimator.backend._feed_forward import feed_forward
@@ -71,32 +70,21 @@ class ModelOp(TensorOp):
             warn("Layer names / ids may be different between single-gpu and multi-gpu environments")
         for intermediate_layer in intermediate_layers:
             storage = {}
-            if isinstance(model, tf.keras.Model):
-                layers = list(model._flatten_layers(include_self=False, recursive=True))
-                if isinstance(intermediate_layer, int):
-                    intermediate_layer = layers[intermediate_layer]
-                else:
-                    layers = {layer.name: layer for layer in layers}
-                    intermediate_layer = layers[intermediate_layer]
-                if not hasattr(intermediate_layer, 'fe_original_call'):
-                    intermediate_layer.fe_original_call = intermediate_layer.call
-                    intermediate_layer.call = partial(_capture_call_tf, fe_storage=storage, fe_layer=intermediate_layer)
-            elif isinstance(model, torch.nn.Module):
-                layers = model.named_modules()
-                if get_num_devices() > 1:
-                    # Try to automatically adjust parameters for multi-gpu so that user doesn't need to change code
-                    layers2 = list(model.named_modules())  # It's a generator, so don't corrupt the other copy
-                    if isinstance(layers2[0][1], torch.nn.parallel.DataParallel):
-                        parallel_prefix = "module."
-                        if isinstance(intermediate_layer, str) and not intermediate_layer.startswith(parallel_prefix):
-                            intermediate_layer = parallel_prefix + intermediate_layer
-                        elif isinstance(intermediate_layer, int):
-                            layers = layers2[1:]
-                if isinstance(intermediate_layer, int):
-                    intermediate_layer = list(layers)[intermediate_layer][1]
-                else:
-                    intermediate_layer = dict(layers)[intermediate_layer]
-                intermediate_layer.register_forward_hook(partial(_capture_call_torch, fe_storage=storage))
+            layers = model.named_modules()
+            if get_num_devices() > 1:
+                # Try to automatically adjust parameters for multi-gpu so that user doesn't need to change code
+                layers2 = list(model.named_modules())  # It's a generator, so don't corrupt the other copy
+                if isinstance(layers2[0][1], torch.nn.parallel.DataParallel):
+                    parallel_prefix = "module."
+                    if isinstance(intermediate_layer, str) and not intermediate_layer.startswith(parallel_prefix):
+                        intermediate_layer = parallel_prefix + intermediate_layer
+                    elif isinstance(intermediate_layer, int):
+                        layers = layers2[1:]
+            if isinstance(intermediate_layer, int):
+                intermediate_layer = list(layers)[intermediate_layer][1]
+            else:
+                intermediate_layer = dict(layers)[intermediate_layer]
+            intermediate_layer.register_forward_hook(partial(_capture_call_torch, fe_storage=storage))
             self.intermediate_outputs.append(storage)
         self.model = model
         self.trainable = trainable
@@ -108,21 +96,19 @@ class ModelOp(TensorOp):
             assert self.gradients, "When model is trainable, the `gradients` must be True."
 
     def build(self, framework: str, device: Optional[torch.device] = None) -> None:
-        self.device = device or ''  # TF will just use empty string for device
-        if framework == "torch" and len(self.inputs) > 1:
+        self.device = device
+        if len(self.inputs) > 1:
             if hasattr(self.model, "module"):
                 # multi-gpu models have module attribute
                 self.multi_inputs = len(inspect.signature(self.model.module.forward).parameters.keys()) > 1
             else:
                 self.multi_inputs = len(inspect.signature(self.model.forward).parameters.keys()) > 1
-        elif framework == "tf" and "keras.src.engine" not in str(type(self.model)):
-            model_call_args = {x for x in inspect.signature(self.model.call).parameters.keys()}
-            self.multi_inputs = len(model_call_args) > 1
 
     def get_fe_models(self) -> Set[Model]:
         return {self.model}
 
-    def forward(self, data: Union[Tensor, List[Tensor]], state: Dict[str, Any]) -> Union[Tensor, List[Tensor]]:
+    def forward(self, data: Union[torch.Tensor, List[torch.Tensor]],
+                state: Dict[str, Any]) -> Union[torch.Tensor, List[torch.Tensor]]:
         training = state['mode'] == "train" and self.trainable
         if isinstance(self.model, torch.nn.Module) and self.epoch_spec != state['epoch']:
             # Gather model input specs for the sake of TensorBoard and Traceability
@@ -131,13 +117,8 @@ class ModelOp(TensorOp):
         if self.gradients:
             data = self._forward_pass(data, training=training)
         else:
-            if isinstance(self.model, torch.nn.Module):
-                with torch.no_grad():
-                    data = self._forward_pass(data, training=training)
-            else:
-                tape = state['tape']
-                with tape.stop_recording() if tape else NonContext():
-                    data = self._forward_pass(data, training=training)
+            with torch.no_grad():
+                data = self._forward_pass(data, training=training)
         intermediate_outputs = []
         for output in self.intermediate_outputs:
             intermediate_outputs.append(_unpack_output(output, self.device))
@@ -146,7 +127,8 @@ class ModelOp(TensorOp):
             data = to_list(data) + intermediate_outputs
         return data
 
-    def _forward_pass(self, data: Union[Tensor, List[Tensor]], training: bool) -> Union[Tensor, List[Tensor]]:
+    def _forward_pass(self, data: Union[torch.Tensor, List[torch.Tensor]],
+                      training: bool) -> Union[torch.Tensor, List[torch.Tensor]]:
         if self.multi_inputs:
             data = feed_forward(self.model, *data, training=training)
         else:
@@ -154,28 +136,7 @@ class ModelOp(TensorOp):
         return data
 
 
-def _capture_call_tf(input: tf.Tensor,
-                     fe_storage: Dict[Union[str, torch.device], Tensor],
-                     fe_layer: tf.keras.layers.Layer,
-                     **kwargs) -> tf.Tensor:
-    """A function to capture the output of a TF model layer.
-
-    Args:
-        input: The input tensor to the layer. Note that this must be the first argument in the method signature.
-        fe_storage: A place to store the output from the layer.
-        fe_layer: A tf layer such that fe_layer(input) -> output.
-        **kwargs: Any arguments to be passed along to the fe_layer call method.
-
-    Returns:
-        The output of the given layer for the specified input.
-    """
-    output = fe_layer.fe_original_call(input, **kwargs)
-    fe_storage[''] = output  # TF multi-gpu doesn't need to store separately per device
-    return output
-
-
-def _capture_call_torch(module: torch.nn.Module,
-                        input: Tuple[torch.Tensor, ...],
+def _capture_call_torch(input: Tuple[torch.Tensor, ...],
                         output: torch.Tensor,
                         fe_storage: Dict[Union[str, torch.device], Tensor]) -> None:
     """A callback function to capture the output of a torch model layer.
@@ -201,8 +162,5 @@ def _unpack_output(output_dict: Dict[Union[str, torch.device], Tensor], device: 
     Returns:
         A stacked representation of the tensor(s) in the output_dict.
     """
-    if isinstance(device, torch.device):
-        response = torch.vstack([t[1].to(device) for t in sorted(output_dict.items(), key=lambda x: x[0].index or 0)])
-    else:  # tf
-        response = output_dict[device]
+    response = torch.vstack([t[1].to(device) for t in sorted(output_dict.items(), key=lambda x: x[0].index or 0)])
     return response

--- a/fastestimator/op/tensorop/model/update.py
+++ b/fastestimator/op/tensorop/model/update.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 from typing import Any, Callable, Dict, Iterable, List, Optional, Set, TypeVar, Union
 
-import tensorflow as tf
 import torch
 
 from fastestimator.backend._get_gradient import get_gradient
@@ -24,9 +23,6 @@ from fastestimator.op.tensorop.tensorop import TensorOp
 from fastestimator.util.base_util import to_set, warn
 from fastestimator.util.traceability_util import traceable
 from fastestimator.util.util import get_num_gpus
-
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor)
-Model = TypeVar('Model', tf.keras.Model, torch.nn.Module)
 
 
 @traceable()
@@ -63,23 +59,19 @@ class UpdateOp(TensorOp):
     _old_defer: bool  # Used by the Network to automagically fix defer values
 
     def __init__(self,
-                 model: Union[tf.keras.Model, torch.nn.Module],
+                 model: torch.nn.Module,
                  loss_name: str,
                  gradients: Optional[str] = None,
                  mode: Union[None, str, Iterable[str]] = "train",
                  ds_id: Union[None, str, Iterable[str]] = None,
                  merge_grad: int = 1,
                  defer: bool = False):
-        self.extra_loss = isinstance(model, tf.keras.Model) and model.losses
         if gradients is None:
             super().__init__(inputs=loss_name, outputs=None, mode=mode, ds_id=ds_id)
         else:
             if model.mixed_precision:
                 raise ValueError("Mixed precision training cannot take input gradients, because the gradients need to "
                                  "be computed in this module")
-            if self.extra_loss:
-                warn("Extra model losses are detected and they will be ignored since the gradients are not computed " +
-                     "in UpdateOp class.")
             super().__init__(inputs=gradients, outputs=None, mode=mode, ds_id=ds_id)
 
         if get_num_gpus() > 1 and merge_grad > 1:
@@ -100,20 +92,16 @@ class UpdateOp(TensorOp):
         self.framework = None
 
     def build(self, framework: str, device: Optional[torch.device] = None) -> None:
-        if framework not in ["tf", "torch"]:
+        if framework not in ["torch"]:
             raise ValueError(f"Unrecognized framework {framework}")
 
         self.framework = framework
 
         if self.merge_grad > 1:
-            if framework == "tf":
-                self.step = tf.Variable(0, trainable=False, dtype=tf.int64)
-                self.grad_sum = [tf.Variable(tf.zeros_like(x), trainable=False) for x in self.model.trainable_variables]
-            else:  # framework == "torch"
-                self.step = torch.tensor(0, dtype=torch.int64).to(device)
-                self.grad_sum = [torch.zeros_like(x).to(device) for x in self.model.parameters() if x.requires_grad]
+            self.step = torch.tensor(0, dtype=torch.int64).to(device)
+            self.grad_sum = [torch.zeros_like(x).to(device) for x in self.model.parameters() if x.requires_grad]
 
-    def get_fe_models(self) -> Set[Model]:
+    def get_fe_models(self) -> Set[torch.nn.Module]:
         return {self.model}
 
     def get_fe_loss_keys(self) -> Set[str]:
@@ -124,13 +112,13 @@ class UpdateOp(TensorOp):
             self.retain_graph = retain
         return self.retain_graph
 
-    def forward(self, data: Union[Tensor, List[Tensor]], state: Dict[str, Any]) -> None:
+    def forward(self, data: Union[torch.Tensor, List[torch.Tensor]], state: Dict[str, Any]) -> None:
         if state["warmup"]:
             return
 
         if self.gradients is None:  # data is loss
             loss = self._loss_preprocess(data)
-            gradients = self._get_gradient(loss, state["tape"])
+            gradients = self._get_gradient(loss)
         else:  # data is gradients
             gradients = data
         gradients = self._gradient_postprocess(gradients)
@@ -140,7 +128,8 @@ class UpdateOp(TensorOp):
         else:
             update_model(model=self.model, gradients=gradients, defer=self.defer, deferred=state["deferred"])
 
-    def _loss_preprocess(self, loss: Union[Tensor, List[Tensor]]) -> Union[Tensor, List[Tensor]]:
+    def _loss_preprocess(self, loss: Union[torch.Tensor,
+                                           List[torch.Tensor]]) -> Union[torch.Tensor, List[torch.Tensor]]:
         """Loss preprocess for multi-GPU and mixed-precision training.
 
         Args:
@@ -149,28 +138,13 @@ class UpdateOp(TensorOp):
         Returns:
             Processed loss.
         """
-        if self.extra_loss:
-            loss = loss + tf.reduce_sum(self.model.losses)
         loss = reduce_mean(loss)
-
-        if self.framework == "tf":
+        if self.model.current_optimizer.scaler is not None:
             # scale up loss for mixed precision training to avoid underflow
-            if self.model.mixed_precision:
-                loss = self.model.current_optimizer.get_scaled_loss(loss)
-            # for multi-gpu training, the gradient will be combined by sum, normalize the loss
-            strategy = tf.distribute.get_strategy()
-            if isinstance(strategy, tf.distribute.MirroredStrategy):
-                loss = loss / strategy.num_replicas_in_sync
-
-        else:  # self.framework == "torch"
-            if self.model.current_optimizer.scaler is not None:
-                # scale up loss for mixed precision training to avoid underflow
-                loss = self.model.current_optimizer.scaler.scale(loss)
-
+            loss = self.model.current_optimizer.scaler.scale(loss)
         return loss
 
-    def _get_gradient(self, loss: Union[Tensor, List[Tensor]],
-                      tape: Optional[tf.GradientTape] = None) -> Union[Tensor, List[Tensor]]:
+    def _get_gradient(self, loss: Union[torch.Tensor, List[torch.Tensor]]) -> Union[torch.Tensor, List[torch.Tensor]]:
         """Get gradient from loss with repect to self.model.
 
         Args:
@@ -180,26 +154,22 @@ class UpdateOp(TensorOp):
         Returns:
             Computed gradients.
         """
-        if self.framework == "tf":
-            gradients = get_gradient(loss, self.model.trainable_variables, tape=tape)
-
-        else:  # self.framework == "torch"
-            trainable_params = [p for p in self.model.parameters() if p.requires_grad]
-            try:
-                gradients = get_gradient(loss, trainable_params, retain_graph=self.retain_graph)
-            except RuntimeError as err:
-                if err.args and isinstance(err.args[0], str) and err.args[0].startswith(
-                        'one of the variables needed for gradient computation has been modified by an inplace operation'
-                ):
-                    raise RuntimeError(
-                        "When computing gradients for '{}', some variables it relied on during the forward pass had"
-                        " been updated. Consider setting defer=True in earlier UpdateOps related to models which "
-                        "interact with this one.".format(self.model.model_name))
-                raise err
+        trainable_params = [p for p in self.model.parameters() if p.requires_grad]
+        try:
+            gradients = get_gradient(loss, trainable_params, retain_graph=self.retain_graph)
+        except RuntimeError as err:
+            if err.args and isinstance(err.args[0], str) and err.args[0].startswith(
+                    'one of the variables needed for gradient computation has been modified by an inplace operation'):
+                raise RuntimeError(
+                    "When computing gradients for '{}', some variables it relied on during the forward pass had"
+                    " been updated. Consider setting defer=True in earlier UpdateOps related to models which "
+                    "interact with this one.".format(self.model.model_name))
+            raise err
 
         return gradients
 
-    def _gradient_postprocess(self, gradients: Union[Tensor, List[Tensor]]) -> Union[Tensor, List[Tensor]]:
+    def _gradient_postprocess(
+            self, gradients: Union[torch.Tensor, List[torch.Tensor]]) -> Union[torch.Tensor, List[torch.Tensor]]:
         """Gradient postprocess for multi-GPU and mixed-precision training.
 
         Args:
@@ -208,21 +178,10 @@ class UpdateOp(TensorOp):
         Returns:
             Processed gradients.
         """
-        if self.framework == "tf":
-            if self.gradients is not None:  # when user provide gradients
-                strategy = tf.distribute.get_strategy()
-                # for multi-gpu training, the gradient will be combined by sum, normalize the gradient
-                if isinstance(strategy, tf.distribute.MirroredStrategy):
-                    gradients = [gs / strategy.num_replicas_in_sync for gs in gradients]
-
-            if self.model.mixed_precision:
-                # scale down gradient to balance scale-up loss
-                gradients = self.model.current_optimizer.get_unscaled_gradients(gradients)
-
         return gradients
 
     def _merge_grad_update(self,
-                           gradients: Union[Tensor, List[Tensor]],
+                           gradients: Union[torch.Tensor, List[torch.Tensor]],
                            deferred: Optional[Dict[str, List[Callable[[], None]]]] = None) -> None:
         """Accumulate gradients and update the model at certain frequency of invocation.
 
@@ -243,14 +202,11 @@ class UpdateOp(TensorOp):
             for gs in self.grad_sum:
                 self._assign_add(gs, -gs)  # zero the gradient in place
 
-    def _assign_add(self, a: Tensor, b: Tensor) -> None:
+    def _assign_add(self, a: torch.Tensor, b: torch.Tensor) -> None:
         """In-place addition for both Tensorflow and PyTorch. `a` = `a` + `b`
 
         Args:
             a: A tensor where in-place addition happens.
             b: Amount to be added.
         """
-        if self.framework == "tf":
-            a.assign_add(b)
-        else:  # self.framework == "torch"
-            a += b
+        a += b

--- a/fastestimator/op/tensorop/model/update.py
+++ b/fastestimator/op/tensorop/model/update.py
@@ -51,7 +51,7 @@ class UpdateOp(TensorOp):
 
     Raise:
         ValueError: When model is mixed-precision and `gradients` is provided.
-        ValueError: Network framework is not one of "tf" or "torch".
+        ValueError: Network framework is not "torch".
         ValueError: `merge_grad` is larger than 1 in multi-GPU configuration.
         RuntimeError: If attempting to modify a PyTorch model which relied on gradients within a different PyTorch model
             which has in turn already undergone a non-deferred update.

--- a/fastestimator/op/tensorop/normalize.py
+++ b/fastestimator/op/tensorop/normalize.py
@@ -15,14 +15,13 @@
 from typing import Any, Dict, Iterable, List, Sequence, TypeVar, Union
 
 import numpy as np
-import tensorflow as tf
 import torch
 
 from fastestimator.backend._tensor_normalize import normalize
 from fastestimator.op.tensorop.tensorop import TensorOp
 from fastestimator.util.traceability_util import traceable
 
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor, np.ndarray)
+Tensor = TypeVar('Tensor', torch.Tensor, np.ndarray)
 
 
 @traceable()
@@ -42,6 +41,7 @@ class Normalize(TensorOp):
         ds_id: What dataset id(s) to execute this Op in. To execute regardless of ds_id, pass None. To execute in all
             ds_ids except for a particular one, you can pass an argument like "!ds1".
     """
+
     def __init__(self,
                  inputs: Union[str, Iterable[str]],
                  outputs: Union[str, Iterable[str]],

--- a/fastestimator/op/tensorop/permute.py
+++ b/fastestimator/op/tensorop/permute.py
@@ -15,14 +15,13 @@
 from typing import Any, Dict, Iterable, List, Sequence, TypeVar, Union
 
 import numpy as np
-import tensorflow as tf
 import torch
 
 from fastestimator.backend._permute import permute
 from fastestimator.op.tensorop.tensorop import TensorOp
 from fastestimator.util.traceability_util import traceable
 
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor, np.ndarray)
+Tensor = TypeVar('Tensor', torch.Tensor, np.ndarray)
 
 
 @traceable()
@@ -39,6 +38,7 @@ class Permute(TensorOp):
         ds_id: What dataset id(s) to execute this Op in. To execute regardless of ds_id, pass None. To execute in all
             ds_ids except for a particular one, you can pass an argument like "!ds1".
     """
+
     def __init__(self,
                  inputs: Union[str, Iterable[str]],
                  outputs: Union[str, Iterable[str]],

--- a/fastestimator/op/tensorop/reshape.py
+++ b/fastestimator/op/tensorop/reshape.py
@@ -14,14 +14,11 @@
 # ==============================================================================
 from typing import Any, Dict, Iterable, List, Tuple, TypeVar, Union
 
-import tensorflow as tf
 import torch
 
 from fastestimator.backend._reshape import reshape
 from fastestimator.op.tensorop.tensorop import TensorOp
 from fastestimator.util.traceability_util import traceable
-
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor)
 
 
 @traceable()
@@ -38,6 +35,7 @@ class Reshape(TensorOp):
         ds_id: What dataset id(s) to execute this Op in. To execute regardless of ds_id, pass None. To execute in all
             ds_ids except for a particular one, you can pass an argument like "!ds1".
     """
+
     def __init__(self,
                  inputs: Union[str, List[str]],
                  outputs: Union[str, List[str]],
@@ -48,5 +46,5 @@ class Reshape(TensorOp):
         self.shape = list(shape)
         self.in_list, self.out_list = True, True
 
-    def forward(self, data: List[Tensor], state: Dict[str, Any]) -> List[Tensor]:
+    def forward(self, data: List[torch.Tensor], state: Dict[str, Any]) -> List[torch.Tensor]:
         return [reshape(elem, self.shape) for elem in data]

--- a/fastestimator/op/tensorop/resize3d.py
+++ b/fastestimator/op/tensorop/resize3d.py
@@ -14,15 +14,12 @@
 # ==============================================================================
 from typing import Any, Dict, Iterable, List, Sequence, TypeVar, Union
 
-import tensorflow as tf
 import torch
 
 from fastestimator.backend._resize3d import resize_3d
 from fastestimator.op.tensorop.tensorop import TensorOp
 from fastestimator.util.base_util import to_list
 from fastestimator.util.traceability_util import traceable
-
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor)
 
 
 @traceable()
@@ -43,6 +40,7 @@ class Resize3D(TensorOp):
             ds_id: What dataset id(s) to execute this Op in. To execute regardless of ds_id, pass None. To execute in all
                 ds_ids except for a particular one, you can pass an argument like "!ds1".
     """
+
     def __init__(self,
                  inputs: Union[str, Iterable[str]],
                  outputs: Union[str, Iterable[str]],
@@ -58,5 +56,5 @@ class Resize3D(TensorOp):
         self.output_shape = output_shape
         self.resize_mode = resize_mode
 
-    def forward(self, data: List[Tensor], state: Dict[str, Any]) -> Union[Tensor, List[Tensor]]:
+    def forward(self, data: List[torch.Tensor], state: Dict[str, Any]) -> Union[torch.Tensor, List[torch.Tensor]]:
         return [resize_3d(elem, self.output_shape, self.resize_mode) for elem in data]

--- a/fastestimator/op/tensorop/tensorop.py
+++ b/fastestimator/op/tensorop/tensorop.py
@@ -14,14 +14,10 @@
 # ==============================================================================
 from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, TypeVar, Union
 
-import tensorflow as tf
 import torch
 
 from fastestimator.op.op import Op
 from fastestimator.util.traceability_util import traceable
-
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor)
-Model = TypeVar('Model', tf.keras.Model, torch.nn.Module)
 
 
 @traceable()
@@ -30,7 +26,9 @@ class TensorOp(Op):
 
     These Operators are used in fe.Network to perform graph-based operations like neural network training.
     """
-    def forward(self, data: Union[Tensor, List[Tensor]], state: Dict[str, Any]) -> Union[Tensor, List[Tensor]]:
+
+    def forward(self, data: Union[torch.Tensor, List[torch.Tensor]],
+                state: Dict[str, Any]) -> Union[torch.Tensor, List[torch.Tensor]]:
         """A method which will be invoked in order to transform data.
 
         This method will be invoked on batches of data.
@@ -63,7 +61,7 @@ class TensorOp(Op):
     # ###########################################################################
 
     # noinspection PyMethodMayBeStatic
-    def get_fe_models(self) -> Set[Model]:
+    def get_fe_models(self) -> Set[torch.nn.Module]:
         """A method to get any models held by this Op.
 
         All users and most developers can safely ignore this method. This method may be invoked to gather and manipulate
@@ -119,6 +117,7 @@ class LambdaOp(TensorOp):
         ds_id: What dataset id(s) to execute this Op in. To execute regardless of ds_id, pass None. To execute in all
             ds_ids except for a particular one, you can pass an argument like "!ds1".
     """
+
     def __init__(self,
                  fn: Callable,
                  inputs: Union[None, str, Iterable[str]] = None,
@@ -129,7 +128,7 @@ class LambdaOp(TensorOp):
         self.fn = fn
         self.in_list = True
 
-    def forward(self, data: List[Tensor], state: Dict[str, Any]) -> Union[Tensor, List[Tensor]]:
+    def forward(self, data: List[torch.Tensor], state: Dict[str, Any]) -> Union[torch.Tensor, List[torch.Tensor]]:
         return self.fn(*data)
 
 
@@ -147,11 +146,12 @@ class Delete(TensorOp):
         ds_id: What dataset id(s) to execute this Op in. To execute regardless of ds_id, pass None. To execute in all
             ds_ids except for a particular one, you can pass an argument like "!ds1".
     """
+
     def __init__(self,
                  keys: Union[str, Sequence[str]],
                  mode: Union[None, str, Iterable[str]] = None,
                  ds_id: Union[None, str, Iterable[str]] = None) -> None:
         super().__init__(inputs=keys, mode=mode, ds_id=ds_id)
 
-    def forward(self, data: Union[Tensor, List[Tensor]], state: Dict[str, Any]) -> None:
+    def forward(self, data: Union[torch.Tensor, List[torch.Tensor]], state: Dict[str, Any]) -> None:
         pass

--- a/fastestimator/op/tensorop/un_hadamard.py
+++ b/fastestimator/op/tensorop/un_hadamard.py
@@ -74,9 +74,8 @@ class UnHadamard(TensorOp):
             np.array((self.code_length + 1) * math.pow((1.0 - max_prob) / (max_prob * (self.n_classes - 1)), 1 / power),
                      dtype=np.float32),
             target_type=framework)
-        if framework == "torch":
-            self.labels = self.labels.to(device)
-            self.eps = self.eps.to(device)
+        self.labels = self.labels.to(device)
+        self.eps = self.eps.to(device)
 
     def forward(self, data: List[torch.Tensor], state: Dict[str, Any]) -> List[torch.Tensor]:
         results = []

--- a/fastestimator/op/tensorop/un_hadamard.py
+++ b/fastestimator/op/tensorop/un_hadamard.py
@@ -16,7 +16,6 @@ import math
 from typing import Any, Dict, Iterable, List, Optional, TypeVar, Union
 
 import numpy as np
-import tensorflow as tf
 import torch
 from scipy.linalg import hadamard
 
@@ -26,8 +25,6 @@ from fastestimator.backend._reduce_sum import reduce_sum
 from fastestimator.backend._to_tensor import to_tensor
 from fastestimator.op.tensorop.tensorop import TensorOp
 from fastestimator.util.traceability_util import traceable
-
-Tensor = TypeVar('Tensor', tf.Tensor, torch.Tensor)
 
 
 @traceable()
@@ -45,6 +42,7 @@ class UnHadamard(TensorOp):
         ds_id: What dataset id(s) to execute this Op in. To execute regardless of ds_id, pass None. To execute in all
             ds_ids except for a particular one, you can pass an argument like "!ds1".
     """
+
     def __init__(self,
                  inputs: Union[str, List[str]],
                  outputs: Union[str, List[str]],
@@ -80,7 +78,7 @@ class UnHadamard(TensorOp):
             self.labels = self.labels.to(device)
             self.eps = self.eps.to(device)
 
-    def forward(self, data: List[Tensor], state: Dict[str, Any]) -> List[Tensor]:
+    def forward(self, data: List[torch.Tensor], state: Dict[str, Any]) -> List[torch.Tensor]:
         results = []
         for elem in data:
             # L1 Distance

--- a/test/PR_test/integration_test/op/numpyop/meta/test_fuse.py
+++ b/test/PR_test/integration_test/op/numpyop/meta/test_fuse.py
@@ -1,7 +1,7 @@
 import tempfile
 import unittest
 
-import tensorflow as tf
+import torch
 
 import fastestimator as fe
 from fastestimator.op.numpyop import Delete, NumpyOp
@@ -17,35 +17,7 @@ class TestNumpyOp(NumpyOp):
 class TestFuse(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.tf_data = tf.constant([[1., 2., 4.], [1., 2., 6.]])
-
-    def test_save_and_load_state_tf(self):
-        def instantiate_system():
-            system = sample_system_object()
-            system.pipeline.ops = [
-                fe.op.numpyop.meta.Fuse(ops=[
-                    TestNumpyOp(inputs="x", outputs="x", mode="train", var=1),
-                    TestNumpyOp(inputs="x", outputs="x", mode="train", var=1),
-                ])
-            ]
-            return system
-
-        system = instantiate_system()
-
-        # make some changes
-        new_var = 2
-        system.pipeline.ops[0].ops[0].var = new_var
-
-        # save the state
-        save_path = tempfile.mkdtemp()
-        system.save_state(save_path)
-
-        # reinstantiate system and load the state
-        system = instantiate_system()
-        system.load_state(save_path)
-        loaded_var = system.pipeline.ops[0].ops[0].var
-
-        self.assertEqual(loaded_var, new_var)
+        cls.tf_data = torch.tensor([[1., 2., 4.], [1., 2., 6.]])
 
     def test_delete_op(self):
         ops = fe.op.numpyop.meta.Fuse(

--- a/test/PR_test/integration_test/op/numpyop/meta/test_fuse.py
+++ b/test/PR_test/integration_test/op/numpyop/meta/test_fuse.py
@@ -17,19 +17,19 @@ class TestNumpyOp(NumpyOp):
 class TestFuse(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.tf_data = torch.tensor([[1., 2., 4.], [1., 2., 6.]])
+        cls.torch_data = torch.tensor([[1., 2., 4.], [1., 2., 6.]])
 
     def test_delete_op(self):
         ops = fe.op.numpyop.meta.Fuse(
             ops=[TestNumpyOp(inputs='x', outputs=['x'], mode="train", var=1), Delete(keys='x', mode='train')])
-        _ = ops.forward(data=[self.tf_data], state={})
+        _ = ops.forward(data=[self.torch_data], state={})
         self.assertEqual(ops.inputs, ['x'])
         self.assertEqual(ops.outputs, [])
 
     def test_delete_multi_outputs(self):
         ops = fe.op.numpyop.meta.Fuse(
             ops=[TestNumpyOp(inputs='x', outputs=['x', 'y'], mode="train", var=1), Delete(keys='y', mode='train')])
-        _ = ops.forward(data=[self.tf_data], state={})
+        _ = ops.forward(data=[self.torch_data], state={})
         self.assertEqual(ops.inputs, ['x'])
         self.assertEqual(ops.outputs, ['x'])
 

--- a/test/PR_test/integration_test/op/numpyop/meta/test_repeat.py
+++ b/test/PR_test/integration_test/op/numpyop/meta/test_repeat.py
@@ -7,38 +7,16 @@ from fastestimator.test.unittest_util import sample_system_object, sample_system
 
 
 class TestNumpyOp(NumpyOp):
+
     def __init__(self, inputs, outputs, mode, var):
         super().__init__(inputs=inputs, outputs=outputs, mode=mode)
         self.var = var
 
 
 class TestRepeat(unittest.TestCase):
-    def test_save_and_load_state_tf(self):
-        def instantiate_system():
-            system = sample_system_object()
-            system.pipeline.ops = [
-                fe.op.numpyop.meta.Repeat(op=TestNumpyOp(inputs="x", outputs="x", mode="train", var=1), repeat=2)
-            ]
-            return system
-
-        system = instantiate_system()
-
-        # make some changes
-        new_var = 2
-        system.pipeline.ops[0].ops[0].var = new_var
-
-        # save the state
-        save_path = tempfile.mkdtemp()
-        system.save_state(save_path)
-
-        # reinstantiate system and load the state
-        system = instantiate_system()
-        system.load_state(save_path)
-        loaded_var = system.pipeline.ops[0].ops[0].var
-
-        self.assertEqual(loaded_var, new_var)
 
     def test_save_and_load_state_torch(self):
+
         def instantiate_system():
             system = sample_system_object_torch()
             system.pipeline.ops = [

--- a/test/PR_test/integration_test/op/numpyop/meta/test_sometimes.py
+++ b/test/PR_test/integration_test/op/numpyop/meta/test_sometimes.py
@@ -7,38 +7,16 @@ from fastestimator.test.unittest_util import sample_system_object, sample_system
 
 
 class TestNumpyOp(NumpyOp):
+
     def __init__(self, inputs, outputs, mode, var):
         super().__init__(inputs=inputs, outputs=outputs, mode=mode)
         self.var = var
 
 
 class TestSometimes(unittest.TestCase):
-    def test_save_and_load_state_tf(self):
-        def instantiate_system():
-            system = sample_system_object()
-            system.pipeline.ops = [
-                fe.op.numpyop.meta.Sometimes(TestNumpyOp(inputs="x", outputs="x", mode="train", var=1))
-            ]
-            return system
-
-        system = instantiate_system()
-
-        # make some changes
-        new_var = 2
-        system.pipeline.ops[0].op.var = new_var
-
-        # save the state
-        save_path = tempfile.mkdtemp()
-        system.save_state(save_path)
-
-        # reinstantiate system and load the state
-        system = instantiate_system()
-        system.load_state(save_path)
-        loaded_var = system.pipeline.ops[0].op.var
-
-        self.assertEqual(loaded_var, new_var)
 
     def test_save_and_load_state_torch(self):
+
         def instantiate_system():
             system = sample_system_object_torch()
             system.pipeline.ops = [

--- a/test/PR_test/integration_test/op/tensorop/augmentation/test_cutmix_batch.py
+++ b/test/PR_test/integration_test/op/tensorop/augmentation/test_cutmix_batch.py
@@ -16,7 +16,6 @@ import os
 import unittest
 
 import numpy as np
-import tensorflow as tf
 import torch
 
 from fastestimator.op.tensorop.augmentation import CutMixBatch
@@ -25,37 +24,22 @@ from fastestimator.test.unittest_util import MockBetaDistribution, MockUniformDi
 
 
 class TestCutMixBatch(unittest.TestCase):
+
     @classmethod
     def setUpClass(cls):
-        cls.test_tf_bbox = tf.random.uniform((4, 32, 32, 3))
-        cls.tf_x = tf.constant([0.25])
-        cls.tf_y = tf.constant([0.25])
-        cls.tf_lam = tf.constant([0.5])
-        cls.tf_output_bbox = (tf.constant([0]), tf.constant([19]), tf.constant([0]), tf.constant([19]), 32, 32)
         cls.test_torch_bbox = torch.rand((4, 3, 32, 32))
         cls.torch_x = torch.tensor([0.25])
         cls.torch_y = torch.tensor([0.25])
         cls.torch_lam = torch.tensor([0.5])
         cls.torch_output_bbox = (torch.tensor([0]), torch.tensor([19]), torch.tensor([0]), torch.tensor([19]), 32, 32)
-        cls.tf_input = tf.stack([tf.ones((32, 32, 3)), tf.zeros((32, 32, 3))])
-        cls.tf_input_y = tf.stack([tf.ones((10)), tf.zeros((10))])
         cls.torch_input = torch.cat([torch.ones((1, 3, 32, 32)), torch.zeros((1, 3, 32, 32))], dim=0)
         cls.torch_input_y = torch.cat([torch.ones((1, 10)), torch.zeros((1, 10))], dim=0)
-        cls.tf_output_y = tf.stack([0.65 * tf.ones((10)), 0.35 * tf.ones((10))])
         cls.torch_output_y = torch.cat([0.65 * torch.ones((1, 10)), 0.35 * torch.ones((1, 10))], dim=0)
 
         cls.cutmix_output1 = os.path.abspath(
             os.path.join(__file__, "..", "..", "..", "..", "util", "resources", "test_cutmix1.png"))
         cls.cutmix_output2 = os.path.abspath(
             os.path.join(__file__, "..", "..", "..", "..", "util", "resources", "test_cutmix2.png"))
-
-    def test_tf_bbox_coordinates(self):
-        cutmix = CutMixBatch(inputs=["x", "y"], outputs=["x", "y"])
-        output = cutmix._get_patch_coordinates(tensor=self.test_tf_bbox, x=self.tf_x, y=self.tf_y, lam=self.tf_lam)
-        with self.subTest('Check length of output tuple'):
-            self.assertEqual(len(output), 6)
-        with self.subTest('Check output value'):
-            self.assertEqual(output, self.tf_output_bbox)
 
     def test_torch_bbox_coordinates(self):
         cutmix = CutMixBatch(inputs=["x", "y"], outputs=["x", "y"])
@@ -67,20 +51,6 @@ class TestCutMixBatch(unittest.TestCase):
             self.assertEqual(len(output), 6)
         with self.subTest('Check output value'):
             self.assertEqual(output, self.torch_output_bbox)
-
-    def test_tf_output(self):
-        cutmix = CutMixBatch(inputs=["x", "y"], outputs=["x", "y"])
-        cutmix.beta = MockBetaDistribution('tf')
-        cutmix.uniform = MockUniformDistribution('tf')
-        mixed_images = cutmix.forward(data=[self.tf_input, self.tf_input_y], state={})
-        images = mixed_images[0].numpy()
-        y = mixed_images[1].numpy()
-        with self.subTest('First mixed image'):
-            self.assertTrue(check_img_similar(images[0], img_to_rgb_array(self.cutmix_output1)))
-        with self.subTest('Second mixed image'):
-            self.assertTrue(check_img_similar(images[1], img_to_rgb_array(self.cutmix_output2)))
-        with self.subTest('lambda value'):
-            self.assertTrue(check_img_similar(np.round(np.float32(y), 2), self.tf_output_y.numpy()))
 
     def test_torch_output(self):
         cutmix = CutMixBatch(inputs=["x", "y"], outputs=["x", "y"])

--- a/test/PR_test/integration_test/op/tensorop/gradient/test_fgsm.py
+++ b/test/PR_test/integration_test/op/tensorop/gradient/test_fgsm.py
@@ -15,7 +15,6 @@
 import unittest
 
 import numpy as np
-import tensorflow as tf
 import torch
 
 from fastestimator.op.tensorop.gradient import FGSM
@@ -23,28 +22,11 @@ from fastestimator.test.unittest_util import is_equal
 
 
 class TestFGSM(unittest.TestCase):
+
     @classmethod
     def setUpClass(cls):
-        cls.tf_data = tf.Variable([1.0, 2.0, 4.0])
-        cls.tf_output = tf.constant([1.01, 2.01, 4])
         cls.torch_data = torch.tensor([1.0, 2.0, 4.0], requires_grad=True)
         cls.torch_output = torch.tensor([1.01, 2.01, 4])
-
-    def test_tf_input(self):
-        def run_single(tf_data, fgsm):
-            with tf.GradientTape(persistent=True) as tape:
-                x = tf_data * tf_data
-                output = fgsm.forward(data=[tf_data, x], state={'tape': tape})
-            return output
-
-        fgsm = FGSM(data='x', loss='loss', outputs='y')
-        strategy = tf.distribute.get_strategy()
-        if isinstance(strategy, tf.distribute.MirroredStrategy):
-            output = strategy.run(run_single, args=(self.tf_data, fgsm))
-            output = output.values[0]
-        else:
-            output = run_single(self.tf_data, fgsm)
-        self.assertTrue(np.array_equal(output, self.tf_output))
 
     def test_torch_input(self):
         fgsm = FGSM(data='x', loss='loss', outputs='y')

--- a/test/PR_test/integration_test/op/tensorop/gradient/test_gradientop.py
+++ b/test/PR_test/integration_test/op/tensorop/gradient/test_gradientop.py
@@ -15,38 +15,20 @@
 import unittest
 
 import numpy as np
-import tensorflow as tf
 import torch
 
-from fastestimator.backend._feed_forward import feed_forward
 from fastestimator.op.tensorop.gradient import GradientOp
 from fastestimator.test.unittest_util import OneLayerTorchModel, is_equal, one_layer_tf_model
 
 
 class TestGradientOp(unittest.TestCase):
+
     @classmethod
     def setUpClass(cls):
-        cls.tf_data = tf.Variable([1.0, 2.0, 4.0])
-        cls.tf_output = [tf.constant([2, 4, 8])]
         cls.torch_data = torch.tensor([1.0, 2.0, 4.0], requires_grad=True)
         cls.torch_output = [torch.tensor([2, 4, 8], dtype=torch.float32)]
         cls.tf_model = one_layer_tf_model()
         cls.torch_model = OneLayerTorchModel()
-
-    def test_tf_input(self):
-        def update_gradient(gradient):
-            with tf.GradientTape(persistent=True) as tape:
-                x = self.tf_data * self.tf_data
-                output = gradient.forward(data=[self.tf_data, x], state={'tape': tape})
-                self.assertTrue(is_equal(output, self.tf_output))
-
-        gradient = GradientOp(inputs='x', finals='x', outputs='y')
-        gradient.build("tf")
-        strategy = tf.distribute.get_strategy()
-        if isinstance(strategy, tf.distribute.MirroredStrategy):
-            strategy.run(update_gradient, args=(gradient, ))
-        else:
-            update_gradient(gradient)
 
     def test_torch_input(self):
         gradient = GradientOp(inputs='x', finals='x', outputs='y')
@@ -54,26 +36,3 @@ class TestGradientOp(unittest.TestCase):
         x = self.torch_data * self.torch_data
         output = gradient.forward(data=[self.torch_data, x], state={'tape': None})
         self.assertTrue(is_equal(output, self.torch_output))
-
-    def test_tf_model_input(self):
-        def update_gradient(gradient):
-            with tf.GradientTape(persistent=True) as tape:
-                pred = feed_forward(self.tf_model, tf.constant([[1.0, 1.0, 1.0], [1.0, -1.0, -0.5]]))
-                output = gradient.forward(data=[pred], state={"tape": tape})
-                self.assertTrue(is_equal(output[0][0].numpy(), np.array([[2.0], [0.0], [0.5]], dtype="float32")))
-
-        gradient = GradientOp(finals="pred", outputs="grad", model=self.tf_model)
-        gradient.build("tf")
-        strategy = tf.distribute.get_strategy()
-        if isinstance(strategy, tf.distribute.MirroredStrategy):
-            strategy.run(update_gradient, args=(gradient, ))
-        else:
-            update_gradient(gradient)
-
-    def test_torch_model_input(self):
-        gradient = GradientOp(finals="pred", outputs="grad", model=self.torch_model)
-        gradient.build("torch")
-        with tf.GradientTape(persistent=True) as tape:
-            pred = feed_forward(self.torch_model, torch.tensor([[1.0, 1.0, 1.0], [1.0, -1.0, -0.5]]))
-            output = gradient.forward(data=[pred], state={"tape": tape})
-        self.assertTrue(is_equal(output[0][0].numpy(), np.array([[2.0, 0.0, 0.5]], dtype="float32")))

--- a/test/PR_test/integration_test/op/tensorop/gradient/test_watch.py
+++ b/test/PR_test/integration_test/op/tensorop/gradient/test_watch.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 import unittest
 
-import tensorflow as tf
 import torch
 
 from fastestimator.op.tensorop.gradient import Watch
@@ -22,25 +21,11 @@ from fastestimator.test.unittest_util import is_equal
 
 
 class TestWatch(unittest.TestCase):
+
     @classmethod
     def setUpClass(cls):
-        cls.tf_data = tf.Variable([1., 2., 4.])
-        cls.tf_output = [tf.Variable([1., 2., 4.], dtype=tf.float32), tf.constant([1, 4, 16], dtype=tf.float32)]
         cls.torch_data = torch.tensor([1., 2., 4.], requires_grad=True)
         cls.torch_output = [torch.tensor([1, 2, 4], dtype=torch.float32), torch.tensor([1, 4, 16], dtype=torch.float32)]
-
-    def test_tf_input(self):
-        def run_watch():
-            with tf.GradientTape(persistent=True) as tape:
-                x = self.tf_data * self.tf_data
-                output = watch.forward(data=[self.tf_data, x], state={'tape': tape})
-                self.assertTrue(is_equal(output, self.tf_output))
-        watch = Watch(inputs='x')
-        strategy = tf.distribute.get_strategy()
-        if isinstance(strategy, tf.distribute.MirroredStrategy):
-            strategy.run(run_watch)
-        else:
-            run_watch()
 
     def test_torch_input(self):
         watch = Watch(inputs='x')

--- a/test/PR_test/integration_test/op/tensorop/loss/test_cross_entropy.py
+++ b/test/PR_test/integration_test/op/tensorop/loss/test_cross_entropy.py
@@ -15,71 +15,56 @@
 import unittest
 
 import numpy as np
-import tensorflow as tf
 import torch
 
 from fastestimator.op.tensorop.loss import CrossEntropy
 
 
 class TestCrossEntropy(unittest.TestCase):
+
     @classmethod
     def setUpClass(cls):
-        # binary ce
-        cls.tf_true_binary = tf.constant([[1.0], [2.0], [4.0]])
-        cls.tf_pred_binary = tf.constant([[1.0], [3.0], [4.5]])
-        cls.tf_binary_weights = {2: 2.0, 4: 3.0}
         # torch binary ce
         cls.torch_true_binary = torch.tensor([[1], [0], [1], [0]])
         cls.torch_pred_binary = torch.tensor([[0.9], [0.3], [0.8], [0.1]])
         cls.torch_binary_weights = {1: 2.0}
         # categorical ce
-        cls.tf_true_cat = tf.constant([[0, 1, 0], [1, 0, 0], [0, 0, 1]])
-        cls.tf_pred_cat = tf.constant([[0.1, 0.8, 0.1], [0.9, 0.05, 0.05], [0.1, 0.2, 0.7]])
-        cls.tf_cat_weights = {1: 2.0, 2: 3.0}
+        cls.torch_true_cat = torch.tensor([[0, 1, 0], [1, 0, 0], [0, 0, 1]])
+        cls.torch_pred_cat = torch.tensor([[0.1, 0.8, 0.1], [0.9, 0.05, 0.05], [0.1, 0.2, 0.7]])
+        cls.torch_cat_weights = {1: 2.0, 2: 3.0}
         # sparse categorical ce
-        cls.tf_true_sparse = tf.constant([[0], [1], [0]])
-        cls.tf_pred_sparse = tf.constant([[0.1, 0.8, 0.1], [0.9, 0.05, 0.05], [0.1, 0.2, 0.7]])
-        cls.tf_sparse_weights = {1: 2.0, 2: 3.0}
-
-    def test_binary_crossentropy(self):
-        ce = CrossEntropy(inputs='x', outputs='x')
-        output = ce.forward(data=[self.tf_pred_binary, self.tf_true_binary], state={})
-        self.assertTrue(np.allclose(output.numpy(), -20.444319))
-
-    def test_binary_crossentropy_weights(self):
-        ce = CrossEntropy(inputs='x', outputs='x', class_weights=self.tf_binary_weights)
-        ce.build('tf')
-        output = ce.forward(data=[self.tf_pred_binary, self.tf_true_binary], state={})
-        self.assertTrue(np.allclose(output.numpy(), -56.221874))
+        cls.torch_true_sparse = torch.tensor([[0], [1], [0]])
+        cls.torch_pred_sparse = torch.tensor([[0.1, 0.8, 0.1], [0.9, 0.05, 0.05], [0.1, 0.2, 0.7]])
+        cls.torch_sparse_weights = {1: 2.0, 2: 3.0}
 
     def test_categorical_crossentropy(self):
         ce = CrossEntropy(inputs='x', outputs='x')
-        output = ce.forward(data=[self.tf_pred_cat, self.tf_true_cat], state={})
+        output = ce.forward(data=[self.torch_pred_cat, self.torch_true_cat], state={})
         self.assertTrue(np.allclose(output.numpy(), 0.22839302))
 
     def test_categorical_crossentropy_weights(self):
-        ce = CrossEntropy(inputs='x', outputs='x', class_weights=self.tf_cat_weights)
-        ce.build('tf')
-        output = ce.forward(data=[self.tf_pred_cat, self.tf_true_cat], state={})
+        ce = CrossEntropy(inputs='x', outputs='x', class_weights=self.torch_cat_weights)
+        ce.build('torch')
+        output = ce.forward(data=[self.torch_pred_cat, self.torch_true_cat], state={})
         self.assertTrue(np.allclose(output.numpy(), 0.54055756))
 
     def test_sparse_categorical_crossentropy(self):
         ce = CrossEntropy(inputs='x', outputs='x')
-        output = ce.forward(data=[self.tf_pred_sparse, self.tf_true_sparse], state={})
+        output = ce.forward(data=[self.torch_pred_sparse, self.torch_true_sparse], state={})
         self.assertTrue(np.allclose(output.numpy(), 2.5336342))
 
     def test_sparse_categorical_crossentropy_weights(self):
-        ce = CrossEntropy(inputs='x', outputs='x', class_weights=self.tf_sparse_weights)
-        ce.build('tf')
-        output = ce.forward(data=[self.tf_pred_sparse, self.tf_true_sparse], state={})
+        ce = CrossEntropy(inputs='x', outputs='x', class_weights=self.torch_sparse_weights)
+        ce.build('torch')
+        output = ce.forward(data=[self.torch_pred_sparse, self.torch_true_sparse], state={})
         self.assertTrue(np.allclose(output.numpy(), 3.532212))
 
-    def test_torch_input(self):
+    def test_binary_crossentropy(self):
         ce = CrossEntropy(inputs='x', outputs='x')
         output = ce.forward(data=[self.torch_pred_binary, self.torch_true_binary], state={})
         self.assertTrue(np.allclose(output.detach().numpy(), 0.1976349))
 
-    def test_torch_input_weights(self):
+    def test_binary_crossentropy_weights(self):
         ce = CrossEntropy(inputs='x', outputs='x', class_weights=self.torch_binary_weights)
         ce.build('torch')
         output = ce.forward(data=[self.torch_pred_binary, self.torch_true_binary], state={})

--- a/test/PR_test/integration_test/op/tensorop/loss/test_hinge.py
+++ b/test/PR_test/integration_test/op/tensorop/loss/test_hinge.py
@@ -15,22 +15,12 @@
 import unittest
 
 import numpy as np
-import tensorflow as tf
 import torch
 
 from fastestimator.op.tensorop.loss import Hinge
 
 
 class TestHinge(unittest.TestCase):
-    def test_tf(self):
-        true = tf.constant([[-1, 1, 1, -1], [1, 1, 1, 1], [-1, -1, 1, -1], [1, -1, -1, -1]])
-        pred = tf.constant([[0.1, 0.9, 0.05, 0.05], [0.1, -0.2, 0.0, -0.7], [0.0, 0.15, 0.8, 0.05],
-                            [1.0, -1.0, -1.0, -1.0]])
-        hinge = Hinge(inputs=('x1', 'x2'), outputs='x')
-        hinge.build('tf', None)
-        output = hinge.forward(data=[pred, true], state={})
-        self.assertTrue(np.allclose(output.numpy(), 0.7125))
-
     def test_torch(self):
         true = torch.tensor([[-1, 1, 1, -1], [1, 1, 1, 1], [-1, -1, 1, -1], [1, -1, -1, -1]])
         pred = torch.tensor([[0.1, 0.9, 0.05, 0.05], [0.1, -0.2, 0.0, -0.7], [0.0, 0.15, 0.8, 0.05],

--- a/test/PR_test/integration_test/op/tensorop/loss/test_l1_loss.py
+++ b/test/PR_test/integration_test/op/tensorop/loss/test_l1_loss.py
@@ -15,19 +15,15 @@
 import unittest
 
 import numpy as np
-import tensorflow as tf
 import torch
 
 from fastestimator.op.tensorop.loss import L1_Loss
 
 
 class Test_L1_Loss(unittest.TestCase):
+
     @classmethod
     def setUpClass(cls):
-        # TensorFlow
-        cls.tf_true = tf.constant([[0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0], [1, 0, 0, 0]])
-        cls.tf_pred = tf.constant([[0.1, 0.9, 0.05, 0.05], [0.1, 0.2, 0.0, 0.7], [0.0, 0.15, 0.8, 0.05],
-                                   [1.0, 0.0, 0.0, 0.0]])
         # PyTorch
         cls.torch_true = torch.tensor([[0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0], [1, 0, 0, 0]])
         cls.torch_pred = torch.tensor([[0.1, 0.9, 0.05, 0.05], [0.1, 0.2, 0.0, 0.7], [0.0, 0.15, 0.8, 0.05],
@@ -35,30 +31,15 @@ class Test_L1_Loss(unittest.TestCase):
         # State Definition
         cls.state = {'warmup': False, 'epoch': 1, 'mode': 'train'}
 
-    def test_L1_tf(self):
-        l1 = L1_Loss(inputs='x', outputs='x')
-        output = l1.forward(data=[self.tf_pred, self.tf_true], state={})
-        self.assertTrue(np.allclose(output.numpy(), 0.081250004))
-
     def test_L1_torch(self):
         l1 = L1_Loss(inputs='x', outputs='x')
         output = l1.forward(data=[self.torch_pred, self.torch_true], state={})
         self.assertTrue(np.allclose(output.detach().numpy(), 0.081250004))
 
-    def test_Smooth_L1_tf(self):
-        smooth_l1 = L1_Loss(inputs='x', outputs='x', loss_type='Smooth', beta=0.65)
-        output = smooth_l1.forward(data=[self.tf_pred, self.tf_true], state={})
-        self.assertTrue(np.allclose(output.numpy(), 0.011057693))
-
     def test_Smooth_L1_torch(self):
         smooth_l1 = L1_Loss(inputs='x', outputs='x', loss_type='Smooth', beta=0.65)
         output = smooth_l1.forward(data=[self.torch_pred, self.torch_true], state={})
         self.assertTrue(np.allclose(output.detach().numpy(), 0.011057693))
-
-    def test_Huber_tf(self):
-        Huber = L1_Loss(inputs='x', outputs='x', loss_type='Huber', beta=0.65)
-        output = Huber.forward(data=[self.tf_pred, self.tf_true], state={})
-        self.assertTrue(np.allclose(output.numpy(), 0.0071875006))
 
     def test_Huber_torch(self):
         Huber = L1_Loss(inputs='x', outputs='x', loss_type='Huber', beta=0.65)

--- a/test/PR_test/integration_test/op/tensorop/loss/test_l2_regularization.py
+++ b/test/PR_test/integration_test/op/tensorop/loss/test_l2_regularization.py
@@ -16,11 +16,9 @@ import unittest
 from typing import Tuple
 
 import numpy as np
-import tensorflow as tf
 import torch
 import torch.nn as nn
 import torch.nn.functional as fn
-from tensorflow.keras import Sequential, initializers, layers
 
 import fastestimator as fe
 from fastestimator.dataset.data import mnist
@@ -64,40 +62,6 @@ class MyNet_torch(torch.nn.Module):
         return x
 
 
-def MyNet_tf(input_shape: Tuple[int, int, int] = (28, 28, 1), classes: int = 10) -> tf.keras.Model:
-    """A standard DNN implementation in TensorFlow.
-
-    The MyNet model has 3 dense layers.
-
-    Args:
-        input_shape: shape of the input data (height, width, channels).
-        classes: The number of outputs the model should generate.
-
-    Returns:
-        A TensorFlow MyNet model.
-    """
-    #_check_input_shape(input_shape)
-    model = Sequential()
-    model.add(layers.Flatten(input_shape=(28, 28)))
-    model.add(
-        layers.Dense(units=300,
-                     kernel_initializer=initializers.Constant(0.01),
-                     bias_initializer=initializers.Zeros(),
-                     activation='relu'))
-    model.add(
-        layers.Dense(units=64,
-                     kernel_initializer=initializers.Constant(0.01),
-                     bias_initializer=initializers.Zeros(),
-                     activation='relu'))
-    model.add(
-        layers.Dense(units=classes,
-                     kernel_initializer=initializers.Constant(0.01),
-                     bias_initializer=initializers.Zeros(),
-                     activation='softmax'))
-
-    return model
-
-
 class TestL2Regularization(unittest.TestCase):
 
     @classmethod
@@ -111,12 +75,6 @@ class TestL2Regularization(unittest.TestCase):
         output = l2.forward(data=torch.tensor([0.0]), state={})
         output = output.detach()
         self.assertTrue(np.allclose(output.numpy(), 0.12751994))
-
-    def test_l2_regularization_tensorflow(self):
-        tf_l2 = fe.build(model_fn=MyNet_tf, optimizer_fn="adam")
-        l2 = L2Regularizaton(inputs='x', outputs='x', model=tf_l2)
-        output = l2.forward(data=tf.constant([0.0]), state={})
-        self.assertTrue(np.allclose(output.numpy(), 0.1275205))
 
     def test_pytorch_weight_decay_vs_l2(self):
         # Get Data
@@ -170,78 +128,5 @@ class TestL2Regularization(unittest.TestCase):
         count = 0
         for wt, l2 in zip(pytorch_wd.parameters(), pytorch_l2.parameters()):
             if ((wt - l2).abs()).sum() < torch.tensor(10**-3):
-                count += 1
-        self.assertEqual(count, 6)
-
-    def test_pytorch_l2_vs_tensorflow_l2(self):
-        # Get Data
-        train_data, eval_data = mnist.load_data()
-        t_d = train_data.split(128)
-        # Initializing Pytorch model
-        pytorch_l2 = fe.build(model_fn=MyNet_torch, optimizer_fn=lambda x: torch.optim.SGD(params=x, lr=0.01))
-        # Initialize Pytorch pipeline
-        pipeline = fe.Pipeline(train_data=t_d,
-                               eval_data=eval_data,
-                               batch_size=128,
-                               ops=[ExpandDims(inputs="x", outputs="x", axis=0), Minmax(inputs="x", outputs="x")])
-        # Initialize Pytorch Network
-        network_l2 = fe.Network(ops=[
-            ModelOp(model=pytorch_l2, inputs="x", outputs="y_pred"),
-            CrossEntropy(inputs=("y_pred", "y"), outputs="ce"),
-            L2Regularizaton(inputs="ce", outputs="l2", model=pytorch_l2, beta=self.beta),
-            UpdateOp(model=pytorch_l2, loss_name="l2")
-        ])
-        # step 3
-        traces = [Accuracy(true_key="y", pred_key="y_pred")]
-        # Initialize Pytorch estimator
-        estimator_l2 = fe.Estimator(pipeline=pipeline,
-                                    network=network_l2,
-                                    epochs=1,
-                                    traces=traces,
-                                    train_steps_per_epoch=1,
-                                    monitor_names=["ce", "l2"])
-        print('********************************Pytorch L2 Regularization training************************************')
-        estimator_l2.fit()
-
-        # Converting Pytorch weights to numpy
-        torch_wt = []
-        for _, param in pytorch_l2.named_parameters():
-            if param.requires_grad:
-                torch_wt.append(param.detach().numpy())
-
-        # step 1
-        pipeline = fe.Pipeline(train_data=t_d,
-                               eval_data=eval_data,
-                               batch_size=128,
-                               ops=[ExpandDims(inputs="x", outputs="x"), Minmax(inputs="x", outputs="x")])
-        # step 2
-        model_tf = fe.build(model_fn=MyNet_tf, optimizer_fn=lambda: tf.keras.optimizers.legacy.SGD(learning_rate=0.01))
-        network = fe.Network(ops=[
-            ModelOp(model=model_tf, inputs="x", outputs="y_pred"),
-            CrossEntropy(inputs=("y_pred", "y"), outputs="ce"),
-            L2Regularizaton(inputs="ce", outputs="l2", model=model_tf, beta=self.beta),
-            UpdateOp(model=model_tf, loss_name="l2")
-        ])
-        # step 3
-        traces = [Accuracy(true_key="y", pred_key="y_pred")]
-        estimator = fe.Estimator(pipeline=pipeline,
-                                 network=network,
-                                 epochs=1,
-                                 traces=traces,
-                                 train_steps_per_epoch=1,
-                                 monitor_names=["ce", "l2"])
-        print('*******************************Tensorflow L2 Regularization training***********************************')
-        estimator.fit()
-
-        # Converting TF weights to numpy
-        tf_wt = []
-        for layer in model_tf.layers:
-            for w in layer.trainable_variables:
-                tf_wt.append(w.numpy())
-
-        # testing weights
-        count = 0
-        for tf_t, tr in zip(tf_wt, torch_wt):
-            if np.sum(np.abs(tf_t - np.transpose(tr))) < (10**-3):
                 count += 1
         self.assertEqual(count, 6)

--- a/test/PR_test/integration_test/op/tensorop/loss/test_mean_squared_error.py
+++ b/test/PR_test/integration_test/op/tensorop/loss/test_mean_squared_error.py
@@ -15,20 +15,12 @@
 import unittest
 
 import numpy as np
-import tensorflow as tf
 import torch
 
 from fastestimator.op.tensorop.loss import MeanSquaredError
 
 
 class TestMeanSquaredError(unittest.TestCase):
-    def test_tf(self):
-        tf_true = tf.constant([[0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0], [1, 0, 0, 0]])
-        tf_pred = tf.constant([[0.1, 0.9, 0.05, 0.05], [0.1, 0.2, 0.0, 0.7], [0.0, 0.15, 0.8, 0.05],
-                               [1.0, 0.0, 0.0, 0.0]])
-        mse = MeanSquaredError(inputs='x', outputs='x')
-        output = mse.forward(data=[tf_pred, tf_true], state={})
-        self.assertTrue(np.allclose(output.numpy(), 0.014375001))
 
     def test_torch(self):
         torch_true = torch.tensor([[0, 1, 0, 0], [0, 0, 0, 1], [0, 0, 1, 0], [1, 0, 0, 0]])

--- a/test/PR_test/integration_test/op/tensorop/loss/test_super_loss.py
+++ b/test/PR_test/integration_test/op/tensorop/loss/test_super_loss.py
@@ -16,7 +16,6 @@ import tempfile
 import unittest
 
 import numpy as np
-import tensorflow as tf
 import torch
 
 import fastestimator as fe
@@ -27,6 +26,7 @@ from fastestimator.util.util import get_device
 
 
 class TestSuperLoss(unittest.TestCase):
+
     @classmethod
     def setUpClass(cls):
         device = get_device()
@@ -34,67 +34,16 @@ class TestSuperLoss(unittest.TestCase):
         cls.torch_true_binary = torch.tensor([[1], [0], [1], [0]]).to(device)
         cls.torch_pred_binary = torch.tensor([[0.9], [0.3], [0.8], [0.1]]).to(device)
         # categorical ce
-        cls.tf_true_cat = tf.constant([[0, 1, 0], [1, 0, 0], [0, 0, 1]])
-        cls.tf_pred_cat = tf.constant([[0.1, 0.8, 0.1], [0.9, 0.05, 0.05], [0.1, 0.2, 0.7]])
         cls.torch_true_cat = torch.tensor([[0, 1, 0], [1, 0, 0], [0, 0, 1]]).to(device)
         cls.torch_pred_cat = torch.tensor([[0.1, 0.8, 0.1], [0.9, 0.05, 0.05], [0.1, 0.2, 0.7]]).to(device)
         # sparse categorical ce
-        cls.tf_true_sparse = tf.constant([[0], [1], [0]])
-        cls.tf_pred_sparse = tf.constant([[0.1, 0.8, 0.1], [0.9, 0.05, 0.05], [0.1, 0.2, 0.7]])
         cls.state = {'warmup': False, 'epoch': 1, 'mode': 'train'}
-
-    @staticmethod
-    @tf.function
-    def do_forward(op, data, state):
-        return op.forward(data, state)
-
-    def test_tf_superloss_categorical_ce(self):
-        sl = SuperLoss(CrossEntropy(inputs=['y_pred', 'y'], outputs='ce'))
-        sl.build(framework="tf", device=None)
-        output = sl.forward(data=[self.tf_pred_cat, self.tf_true_cat], state=self.state)
-        self.assertTrue(np.allclose(output.numpy(), -0.0026386082))
-
-    def test_tf_static_superloss_categorical_ce(self):
-        sl = SuperLoss(CrossEntropy(inputs=['y_pred', 'y'], outputs='ce'))
-        sl.build(framework="tf", device=None)
-        output = self.do_forward(sl, data=[self.tf_pred_cat, self.tf_true_cat], state=self.state)
-        self.assertTrue(np.allclose(output.numpy(), -0.0026386082))
-
-    def test_tf_superloss_sparse_categorical_ce(self):
-        sl = SuperLoss(CrossEntropy(inputs=['y_pred', 'y'], outputs='ce'))
-        sl.build(framework="tf", device=None)
-        output = sl.forward(data=[self.tf_pred_sparse, self.tf_true_sparse], state=self.state)
-        self.assertTrue(np.allclose(output.numpy(), -0.024740249))
-
-    def test_tf_static_superloss_sparse_categorical_ce(self):
-        sl = SuperLoss(CrossEntropy(inputs=['y_pred', 'y'], outputs='ce'))
-        sl.build(framework="tf", device=None)
-        output = self.do_forward(sl, data=[self.tf_pred_sparse, self.tf_true_sparse], state=self.state)
-        self.assertTrue(np.allclose(output.numpy(), -0.024740249))
 
     def test_torch_superloss_binary_ce(self):
         sl = SuperLoss(CrossEntropy(inputs=['y_pred', 'y'], outputs='ce'))
         sl.build(framework="torch", device="cuda:0" if torch.cuda.is_available() else "cpu")
         output = sl.forward(data=[self.torch_pred_binary, self.torch_true_binary], state=self.state)
         self.assertTrue(np.allclose(output.detach().to("cpu").numpy(), -0.0026238672))
-
-    def test_tf_superloss_hinge(self):
-        true = tf.constant([[-1, 1, 1, -1], [1, 1, 1, 1], [-1, -1, 1, -1], [1, -1, -1, -1]])
-        pred = tf.constant([[0.1, 0.9, 0.05, 0.05], [0.1, -0.2, 0.0, -0.7], [0.0, 0.15, 0.8, 0.05],
-                            [1.0, -1.0, -1.0, -1.0]])
-        sl = SuperLoss(Hinge(inputs=('x1', 'x2'), outputs='x'))
-        sl.build('tf', None)
-        output = sl.forward(data=[pred, true], state=self.state)
-        self.assertTrue(np.allclose(output.numpy(), -0.072016776))
-
-    def test_tf_static_superloss_hinge(self):
-        true = tf.constant([[-1, 1, 1, -1], [1, 1, 1, 1], [-1, -1, 1, -1], [1, -1, -1, -1]])
-        pred = tf.constant([[0.1, 0.9, 0.05, 0.05], [0.1, -0.2, 0.0, -0.7], [0.0, 0.15, 0.8, 0.05],
-                            [1.0, -1.0, -1.0, -1.0]])
-        sl = SuperLoss(Hinge(inputs=('x1', 'x2'), outputs='x'))
-        sl.build('tf', None)
-        output = self.do_forward(sl, data=[pred, true], state=self.state)
-        self.assertTrue(np.allclose(output.numpy(), -0.072016776))
 
     def test_torch_superloss_hinge(self):
         true = torch.tensor([[-1, 1, 1, -1], [1, 1, 1, 1], [-1, -1, 1, -1],
@@ -106,38 +55,8 @@ class TestSuperLoss(unittest.TestCase):
         output = sl.forward(data=[pred, true], state=self.state)
         self.assertTrue(np.allclose(output.to("cpu").numpy(), -0.072016776))
 
-    def test_save_and_load_state_tf(self):
-        def instantiate_system():
-            system = sample_system_object()
-            model = fe.build(model_fn=fe.architecture.tensorflow.LeNet, optimizer_fn='adam', model_name='tf')
-            system.network = fe.Network(ops=[
-                ModelOp(model=model, inputs="x_out", outputs="y_pred"),
-                SuperLoss(CrossEntropy(inputs=['y_pred', 'y'], outputs='ce'))
-            ])
-            return system
-
-        system = instantiate_system()
-
-        # make some changes
-        system.network.ops[1].forward(data=[self.tf_pred_cat, self.tf_true_cat], state=self.state)
-
-        # save the state
-        save_path = tempfile.mkdtemp()
-        system.save_state(save_path)
-
-        # re-instantiate system and load the state
-        system = instantiate_system()
-        system.load_state(save_path)
-
-        loaded_op = system.network.ops[1]
-        with self.subTest("Initialization Flags"):
-            self.assertEqual(loaded_op.initialized['train'].numpy(), True)
-            self.assertEqual(loaded_op.initialized['eval'].numpy(), False)
-        with self.subTest("Mean Values"):
-            self.assertTrue(np.allclose(loaded_op.tau['train'].numpy(), 0.22839302))
-            self.assertTrue(np.allclose(loaded_op.tau['eval'].numpy(), 0.0))
-
     def test_save_and_load_state_torch(self):
+
         def instantiate_system():
             system = sample_system_object()
             model = fe.build(model_fn=fe.architecture.pytorch.LeNet, optimizer_fn='adam', model_name='tf')

--- a/test/PR_test/integration_test/op/tensorop/meta/test_fuse.py
+++ b/test/PR_test/integration_test/op/tensorop/meta/test_fuse.py
@@ -4,47 +4,20 @@ import unittest
 import fastestimator as fe
 from fastestimator.op.tensorop import TensorOp
 from fastestimator.op.tensorop.model import ModelOp
-from fastestimator.test.unittest_util import sample_system_object, sample_system_object_torch
+from fastestimator.test.unittest_util import sample_system_object_torch
 
 
 class TestTensorOp(TensorOp):
+
     def __init__(self, inputs, outputs, mode, var):
         super().__init__(inputs=inputs, outputs=outputs, mode=mode)
         self.var = var
 
 
 class TestFuse(unittest.TestCase):
-    def test_save_and_load_state_tf(self):
-        def instantiate_system():
-            system = sample_system_object()
-            model = fe.build(model_fn=fe.architecture.tensorflow.LeNet, optimizer_fn='adam', model_name='tf')
-            system.network = fe.Network(ops=[
-                fe.op.tensorop.meta.Fuse(ops=[
-                    TestTensorOp(inputs="x_out", outputs="x_out", mode="train", var=1),
-                    TestTensorOp(inputs="x_out", outputs="x_out", mode="train", var=1)
-                ]),
-                ModelOp(model=model, inputs="x_out", outputs="y_pred")
-            ])
-            return system
-
-        system = instantiate_system()
-
-        # make some changes
-        new_var = 2
-        system.network.ops[0].ops[0].var = new_var
-
-        # save the state
-        save_path = tempfile.mkdtemp()
-        system.save_state(save_path)
-
-        # reinstantiate system and load the state
-        system = instantiate_system()
-        system.load_state(save_path)
-        loaded_var = system.network.ops[0].ops[0].var
-
-        self.assertEqual(loaded_var, new_var)
 
     def test_save_and_load_state_torch(self):
+
         def instantiate_system():
             system = sample_system_object_torch()
             model = fe.build(model_fn=fe.architecture.pytorch.LeNet, optimizer_fn='adam', model_name='torch')

--- a/test/PR_test/integration_test/op/tensorop/meta/test_one_of.py
+++ b/test/PR_test/integration_test/op/tensorop/meta/test_one_of.py
@@ -4,45 +4,20 @@ import unittest
 import fastestimator as fe
 from fastestimator.op.tensorop import TensorOp
 from fastestimator.op.tensorop.model import ModelOp
-from fastestimator.test.unittest_util import sample_system_object, sample_system_object_torch
+from fastestimator.test.unittest_util import sample_system_object_torch
 
 
 class TestTensorOp(TensorOp):
+
     def __init__(self, inputs, outputs, mode, var):
         super().__init__(inputs=inputs, outputs=outputs, mode=mode)
         self.var = var
 
 
 class TestOneOf(unittest.TestCase):
-    def test_save_and_load_state_tf(self):
-        def instantiate_system():
-            system = sample_system_object()
-            model = fe.build(model_fn=fe.architecture.tensorflow.LeNet, optimizer_fn='adam', model_name='tf')
-            system.network = fe.Network(ops=[
-                fe.op.tensorop.meta.OneOf(TestTensorOp(inputs="x_out", outputs="x_out", mode="train", var=1),
-                                          TestTensorOp(inputs="x_out", outputs="x_out", mode="train", var=1)),
-                ModelOp(model=model, inputs="x_out", outputs="y_pred")
-            ])
-            return system
-
-        system = instantiate_system()
-
-        # make some changes
-        new_var = 2
-        system.network.ops[0].ops[0].var = new_var
-
-        # save the state
-        save_path = tempfile.mkdtemp()
-        system.save_state(save_path)
-
-        # reinstantiate system and load the state
-        system = instantiate_system()
-        system.load_state(save_path)
-        loaded_var = system.network.ops[0].ops[0].var
-
-        self.assertEqual(loaded_var, new_var)
 
     def test_save_and_load_state_torch(self):
+
         def instantiate_system():
             system = sample_system_object_torch()
             model = fe.build(model_fn=fe.architecture.pytorch.LeNet, optimizer_fn='adam', model_name='torch')

--- a/test/PR_test/integration_test/op/tensorop/meta/test_repeat.py
+++ b/test/PR_test/integration_test/op/tensorop/meta/test_repeat.py
@@ -4,45 +4,20 @@ import unittest
 import fastestimator as fe
 from fastestimator.op.tensorop import TensorOp
 from fastestimator.op.tensorop.model import ModelOp
-from fastestimator.test.unittest_util import sample_system_object, sample_system_object_torch
+from fastestimator.test.unittest_util import sample_system_object_torch
 
 
 class TestTensorOp(TensorOp):
+
     def __init__(self, inputs, outputs, mode, var):
         super().__init__(inputs=inputs, outputs=outputs, mode=mode)
         self.var = var
 
 
 class TestRepeat(unittest.TestCase):
-    def test_save_and_load_state_tf(self):
-        def instantiate_system():
-            system = sample_system_object()
-            model = fe.build(model_fn=fe.architecture.tensorflow.LeNet, optimizer_fn='adam', model_name='tf')
-            system.network = fe.Network(ops=[
-                fe.op.tensorop.meta.Repeat(op=TestTensorOp(inputs="x_out", outputs="x_out", mode="train", var=1),
-                                           repeat=2),
-                ModelOp(model=model, inputs="x_out", outputs="y_pred")
-            ])
-            return system
-
-        system = instantiate_system()
-
-        # make some changes
-        new_var = 2
-        system.network.ops[0].op.var = new_var
-
-        # save the state
-        save_path = tempfile.mkdtemp()
-        system.save_state(save_path)
-
-        # reinstantiate system and load the state
-        system = instantiate_system()
-        system.load_state(save_path)
-        loaded_var = system.network.ops[0].op.var
-
-        self.assertEqual(loaded_var, new_var)
 
     def test_save_and_load_state_torch(self):
+
         def instantiate_system():
             system = sample_system_object_torch()
             model = fe.build(model_fn=fe.architecture.pytorch.LeNet, optimizer_fn='adam', model_name='torch')

--- a/test/PR_test/integration_test/op/tensorop/meta/test_sometimes.py
+++ b/test/PR_test/integration_test/op/tensorop/meta/test_sometimes.py
@@ -4,44 +4,20 @@ import unittest
 import fastestimator as fe
 from fastestimator.op.tensorop import TensorOp
 from fastestimator.op.tensorop.model import ModelOp
-from fastestimator.test.unittest_util import sample_system_object, sample_system_object_torch
+from fastestimator.test.unittest_util import sample_system_object_torch
 
 
 class TestTensorOp(TensorOp):
+
     def __init__(self, inputs, outputs, mode, var):
         super().__init__(inputs=inputs, outputs=outputs, mode=mode)
         self.var = var
 
 
 class TestSometimes(unittest.TestCase):
-    def test_save_and_load_state_tf(self):
-        def instantiate_system():
-            system = sample_system_object()
-            model = fe.build(model_fn=fe.architecture.tensorflow.LeNet, optimizer_fn='adam', model_name='tf')
-            system.network = fe.Network(ops=[
-                fe.op.tensorop.meta.Sometimes(TestTensorOp(inputs="x_out", outputs="x_out", mode="train", var=1)),
-                ModelOp(model=model, inputs="x_out", outputs="y_pred")
-            ])
-            return system
-
-        system = instantiate_system()
-
-        # make some changes
-        new_var = 2
-        system.network.ops[0].op.var = new_var
-
-        # save the state
-        save_path = tempfile.mkdtemp()
-        system.save_state(save_path)
-
-        # reinstantiate system and load the state
-        system = instantiate_system()
-        system.load_state(save_path)
-        loaded_var = system.network.ops[0].op.var
-
-        self.assertEqual(loaded_var, new_var)
 
     def test_save_and_load_state_torch(self):
+
         def instantiate_system():
             system = sample_system_object_torch()
             model = fe.build(model_fn=fe.architecture.pytorch.LeNet, optimizer_fn='adam', model_name='torch')

--- a/test/PR_test/integration_test/op/tensorop/model/test_modelop.py
+++ b/test/PR_test/integration_test/op/tensorop/model/test_modelop.py
@@ -15,7 +15,6 @@
 import unittest
 
 import numpy as np
-import tensorflow as tf
 import torch
 
 import fastestimator as fe
@@ -26,68 +25,16 @@ from fastestimator.test.unittest_util import MultiLayerTorchModel, OneLayerTorch
 
 
 class TestModelOp(unittest.TestCase):
+
     @classmethod
     def setUpClass(cls):
         cls.state = {'mode': 'train', 'epoch': 1, 'tape': None}
-        cls.tf_input_data = tf.constant([[1.0, 1.0, 1.0], [1.0, -1.0, -0.5]])
         cls.torch_input_data = torch.Tensor([[1.0, 1.0, 1.0], [1.0, -1.0, -0.5]])
         cls.output = np.array([[6.0], [-2.5]])
         # Big inputs
-        cls.tf_input_data_big = tf.constant([[1.0, 1.0, 1.0, 1.0], [0.6, -0.5, -0.8, 1.2]])
         cls.torch_input_data_big = torch.Tensor([[1.0, 1.0, 1.0, 1.0], [0.6, -0.5, -0.8, 1.2]])
         cls.output_big = np.array([[40.0], [9.4]])
         cls.embedding_output = np.array([[10.0, 15.0], [2.0, 3.7]])
-
-    def test_tf_input(self):
-        model = fe.build(model_fn=one_layer_tf_model, optimizer_fn="adam")
-        op = ModelOp(inputs='x', outputs='x', model=model)
-        op.build(framework='tf', device=None)
-        with self.subTest("Eager"):
-            output = op.forward(data=self.tf_input_data, state=self.state)
-            self.assertTrue(is_equal(output.numpy(), self.output))
-        forward_fn = tf.function(op.forward)
-        with self.subTest("Static Call 1"):
-            output = forward_fn(data=self.tf_input_data, state=self.state)
-            self.assertTrue(is_equal(output.numpy(), self.output))
-        with self.subTest("Static Call 2"):
-            output = forward_fn(data=self.tf_input_data, state=self.state)
-            self.assertTrue(is_equal(output.numpy(), self.output))
-
-    def test_tf_multi_output_str(self):
-        model = fe.build(model_fn=multi_layer_tf_model, optimizer_fn="adam")
-        op = ModelOp(inputs='x', outputs=['y', 'embedding'], model=model, intermediate_layers='fc1')
-        op.build(framework='tf', device=None)
-        with self.subTest("Eager"):
-            y, embedding = op.forward(data=self.tf_input_data_big, state=self.state)
-            self.assertTrue(np.allclose(y.numpy(), self.output_big, atol=1e-4))
-            self.assertTrue(np.allclose(embedding.numpy(), self.embedding_output, atol=1e-4))
-        forward_fn = tf.function(op.forward)
-        with self.subTest("Static Call 1"):
-            y, embedding = forward_fn(data=self.tf_input_data_big, state=self.state)
-            self.assertTrue(np.allclose(y.numpy(), self.output_big, atol=1e-4))
-            self.assertTrue(np.allclose(embedding.numpy(), self.embedding_output, atol=1e-4))
-        with self.subTest("Static Call 2"):
-            y, embedding = forward_fn(data=self.tf_input_data_big, state=self.state)
-            self.assertTrue(np.allclose(y.numpy(), self.output_big, atol=1e-4))
-            self.assertTrue(np.allclose(embedding.numpy(), self.embedding_output, atol=1e-4))
-
-    def test_tf_multi_output_int(self):
-        model = fe.build(model_fn=multi_layer_tf_model, optimizer_fn="adam")
-        op = ModelOp(inputs='x', outputs=['y', 'embedding'], model=model, intermediate_layers=1)
-        op.build(framework='tf', device=None)
-        with self.subTest("Eager"):
-            y, embedding = op.forward(data=self.tf_input_data_big, state=self.state)
-            self.assertTrue(np.allclose(y.numpy(), self.output_big, atol=1e-4))
-            self.assertTrue(np.allclose(embedding.numpy(), self.embedding_output, atol=1e-4))
-        forward_fn = tf.function(op.forward)
-        with self.subTest("Static Call 1"):
-            y, embedding = forward_fn(data=self.tf_input_data_big, state=self.state)
-            self.assertTrue(np.allclose(y.numpy(), self.output_big, atol=1e-4))
-            self.assertTrue(np.allclose(embedding.numpy(), self.embedding_output, atol=1e-4))
-        with self.subTest("Static Call 2"):
-            y, embedding = forward_fn(data=self.tf_input_data_big, state=self.state)
-            self.assertTrue(np.allclose(y.numpy(), self.output_big, atol=1e-4))
-            self.assertTrue(np.allclose(embedding.numpy(), self.embedding_output, atol=1e-4))
 
     def test_torch_input(self):
         model = fe.build(model_fn=OneLayerTorchModel, optimizer_fn="adam")
@@ -122,51 +69,6 @@ class TestModelOp(unittest.TestCase):
         embedding = embedding.to('cpu')
         self.assertTrue(np.allclose(y.detach().numpy(), self.output_big, atol=1e-4))
         self.assertTrue(np.allclose(embedding.detach().numpy(), self.embedding_output, atol=1e-4))
-
-    @unittest.skipIf(torch.cuda.device_count() > 1, "single gpu or cpu only")
-    def test_tf_with_gradients(self):
-        model = fe.build(model_fn=one_layer_tf_model, optimizer_fn=None)
-        op = ModelOp(inputs='x', outputs='x', model=model, gradients=True)
-        op.build(framework='tf', device=None)
-        grad = self.single_forward_backward_tf(op, model, self.tf_input_data)
-        self.assertTrue(np.allclose(grad[0].numpy(), np.array([[2.0], [0.0], [0.5]])))
-
-    @unittest.skipIf(torch.cuda.device_count() < 2, "multigpu only")
-    def test_tf_with_gradients_multigpu(self):
-        model = fe.build(model_fn=one_layer_tf_model, optimizer_fn=None)
-        op = ModelOp(inputs='x', outputs='x', model=model, gradients=True)
-        op.build(framework='tf', device=None)
-        strategy = tf.distribute.get_strategy()
-        tf_input_data = next(
-            iter(strategy.experimental_distribute_dataset(tf.data.Dataset.from_tensors(self.tf_input_data))))
-        grad = strategy.run(self.single_forward_backward_tf, args=(op, model, tf_input_data))
-        grad = tf.reduce_sum(tuple(d for d in grad[0].values), axis=0)
-        self.assertTrue(np.allclose(grad.numpy(), np.array([[2.0], [0.0], [0.5]])))
-
-    @unittest.skipIf(torch.cuda.device_count() > 1, "single gpu or cpu only")
-    def test_tf_disable_gradients(self):
-        model = fe.build(model_fn=one_layer_tf_model, optimizer_fn=None)
-        op = ModelOp(inputs='x', outputs='x', model=model, gradients=False, trainable=False)
-        op.build(framework='tf', device=None)
-        grad = self.single_forward_backward_tf(op, model, self.tf_input_data)
-        self.assertIsNone(grad[0])
-
-    @unittest.skipIf(torch.cuda.device_count() < 2, "multigpu only")
-    def test_tf_disable_gradients_multigpu(self):
-        model = fe.build(model_fn=one_layer_tf_model, optimizer_fn=None)
-        op = ModelOp(inputs='x', outputs='x', model=model, gradients=False, trainable=False)
-        op.build(framework='tf', device=None)
-        strategy = tf.distribute.get_strategy()
-        tf_input_data = next(
-            iter(strategy.experimental_distribute_dataset(tf.data.Dataset.from_tensors(self.tf_input_data))))
-        grad = strategy.run(self.single_forward_backward_tf, args=(op, model, tf_input_data))
-        self.assertIsNone(grad[0])
-
-    def single_forward_backward_tf(self, op, model, inputs):
-        with tf.GradientTape(persistent=True) as tape:
-            output = op.forward(data=inputs, state={"tape": tape, 'mode': 'train', 'epoch': 1})
-            grad = get_gradient(tf.reduce_sum(output), model.trainable_variables, tape=tape)
-        return grad
 
     def test_torch_with_gradients(self):
         model = fe.build(model_fn=OneLayerTorchModel, optimizer_fn=None)

--- a/test/PR_test/integration_test/op/tensorop/model/test_updateop.py
+++ b/test/PR_test/integration_test/op/tensorop/model/test_updateop.py
@@ -18,7 +18,6 @@ from collections import deque
 from copy import deepcopy
 
 import numpy as np
-import tensorflow as tf
 import torch
 
 import fastestimator as fe
@@ -63,28 +62,15 @@ class CheckNetworkWeight(fe.trace.Trace):
         self.lrs = lrs
         self.work_intervals = work_intervals
         self.n_gpu = torch.cuda.device_count()
-        if self.framework == "tf":
-            self.previous_weights = [x.numpy() for x in model.trainable_variables]
-        else:
-            self.previous_weights = [
-                deepcopy(x).cpu().detach().numpy() for x in self.model.parameters() if x.requires_grad
-            ]
+        self.previous_weights = [
+            deepcopy(x).cpu().detach().numpy() for x in self.model.parameters() if x.requires_grad
+        ]
         self.gradients = deque(maxlen=merge_grad)
         self.new_weight = None
 
     def on_batch_end(self, data):
-        if self.framework == "tf":
-            if self.n_gpu > 1:
-                # the data[self.key] shape is self.n_gpu times large on axis 0 and need to be folded
-                gradients = [self.fold(x.numpy()) for x in data[self.grad_key]]
-            else:
-                gradients = [x.numpy() for x in data[self.grad_key]]
-
-            self.gradients.append(gradients)
-            self.new_weight = [x.numpy() for x in self.model.trainable_variables]
-        else:
-            self.gradients.append([x.cpu().detach().numpy() for x in data[self.grad_key]])
-            self.new_weight = [deepcopy(x).cpu().detach().numpy() for x in self.model.parameters() if x.requires_grad]
+        self.gradients.append([x.cpu().detach().numpy() for x in data[self.grad_key]])
+        self.new_weight = [deepcopy(x).cpu().detach().numpy() for x in self.model.parameters() if x.requires_grad]
 
         lr = self.get_lr()  # if lr is False, don't need to do the check
         if lr:
@@ -144,58 +130,6 @@ class TestUpdateOp(unittest.TestCase):
     def setUpClass(cls):
         cls.train_data, _ = mnist.load_data()
 
-    def test_tf_end_to_end(self):
-        """This test cover the all combination of:
-            - mixed-precision / not
-            - merge_grad / not
-            - gradient input / loss input
-        """
-
-        def run_test(mixed_precision, merge_grad, gradient):
-            lr = 0.1
-            pipeline = fe.Pipeline(train_data=self.train_data,
-                                   batch_size=4,
-                                   ops=[ExpandDims(inputs="x", outputs="x"), Minmax(inputs="x", outputs="x")])
-
-            model = fe.build(model_fn=LeNet_tf,
-                             optimizer_fn=lambda: tf.keras.optimizers.legacy.SGD(lr),
-                             mixed_precision=mixed_precision)
-            network = fe.Network(ops=[
-                ModelOp(model=model, inputs="x", outputs="y_pred"),
-                CrossEntropy(inputs=("y_pred", "y"), outputs="ce"),
-                GradientOp(model=model, finals="ce", outputs="grad"),
-                UpdateOp(model=model, loss_name="ce", gradients=gradient, merge_grad=merge_grad),
-            ])
-
-            traces = [
-                CheckNetworkWeight(model=model,
-                                   grad_key="grad",
-                                   merge_grad=merge_grad,
-                                   test_self=self,
-                                   lrs=lr,
-                                   framework="tf")
-            ]
-            estimator = fe.Estimator(pipeline=pipeline,
-                                     network=network,
-                                     epochs=2,
-                                     traces=traces,
-                                     train_steps_per_epoch=2)
-            estimator.fit(warmup=False)
-
-        for mixed_precision in [True, False]:
-            for merge_grad in [1, 2]:
-                for gradient in ["grad", None]:
-                    with self.subTest("mixed_precision: {}, merge_grad: {}, take: {}".format(
-                            mixed_precision, merge_grad, "gradient" if gradient else "loss")):
-                        if mixed_precision and sys.platform == 'darwin':
-                            self.skipTest("Mixed Precision is not yet supported on Mac")
-                        if (mixed_precision and gradient) or (torch.cuda.device_count() > 1 and merge_grad > 1):
-                            with self.assertRaises(ValueError):
-                                run_test(mixed_precision, merge_grad, gradient)
-
-                        else:
-                            run_test(mixed_precision, merge_grad, gradient)
-
     def test_torch_end_to_end(self):
         """This test cover the all combination of:
             - mixed-precision / not
@@ -230,64 +164,6 @@ class TestUpdateOp(unittest.TestCase):
             estimator = fe.Estimator(pipeline=pipeline,
                                      network=network,
                                      epochs=2,
-                                     traces=traces,
-                                     train_steps_per_epoch=2)
-            estimator.fit(warmup=False)
-
-        for mixed_precision in [True, False]:
-            for merge_grad in [1, 2]:
-                for gradient in ["grad", None]:
-                    with self.subTest("mixed_precision: {}, merge_grad: {}, take: {}".format(
-                            mixed_precision, merge_grad, "gradient" if gradient else "loss")):
-                        if mixed_precision and sys.platform == 'darwin':
-                            self.skipTest("Mixed Precision is not yet supported on Mac")
-                        if (mixed_precision and gradient) or (torch.cuda.device_count() > 1 and merge_grad > 1):
-                            with self.assertRaises(ValueError):
-                                run_test(mixed_precision, merge_grad, gradient)
-                        else:
-                            run_test(mixed_precision, merge_grad, gradient)
-
-    def test_tf_multi_optimizer_with_epoch_scheduler(self):
-        """This test cover the all combination of:
-            - mixed-precision / not
-            - merge_grad / not
-            - gradient input / loss input
-        """
-
-        def run_test(mixed_precision, merge_grad, gradient):
-            lr = 0.1
-            lr2 = 0.01
-            lr3 = 0.001
-            pipeline = fe.Pipeline(train_data=self.train_data,
-                                   batch_size=4,
-                                   ops=[ExpandDims(inputs="x", outputs="x"), Minmax(inputs="x", outputs="x")])
-
-            optimizer_fn = EpochScheduler({
-                1: lambda: tf.keras.optimizers.legacy.SGD(lr),
-                2: lambda: tf.keras.optimizers.legacy.SGD(lr2),
-                3: lambda: tf.keras.optimizers.legacy.SGD(lr3)
-            })
-
-            model = fe.build(model_fn=LeNet_tf, optimizer_fn=optimizer_fn, mixed_precision=mixed_precision)
-            network = fe.Network(ops=[
-                ModelOp(model=model, inputs="x", outputs="y_pred"),
-                CrossEntropy(inputs=("y_pred", "y"), outputs="ce"),
-                GradientOp(model=model, finals="ce", outputs="grad"),
-                UpdateOp(model=model, loss_name="ce", gradients=gradient, merge_grad=merge_grad),
-            ])
-
-            traces = [
-                CheckNetworkWeight(model=model,
-                                   grad_key="grad",
-                                   merge_grad=merge_grad,
-                                   test_self=self,
-                                   framework="tf",
-                                   lrs=[lr, lr2, lr3],
-                                   work_intervals=[[1, 2], [2, 3], [3, 4]])
-            ]
-            estimator = fe.Estimator(pipeline=pipeline,
-                                     network=network,
-                                     epochs=3,
                                      traces=traces,
                                      train_steps_per_epoch=2)
             estimator.fit(warmup=False)
@@ -346,60 +222,6 @@ class TestUpdateOp(unittest.TestCase):
             estimator = fe.Estimator(pipeline=pipeline,
                                      network=network,
                                      epochs=3,
-                                     traces=traces,
-                                     train_steps_per_epoch=2)
-            estimator.fit(warmup=False)
-
-        for mixed_precision in [True, False]:
-            for merge_grad in [1, 2]:
-                for gradient in ["grad", None]:
-                    with self.subTest("mixed_precision: {}, merge_grad: {}, take: {}".format(
-                            mixed_precision, merge_grad, "gradient" if gradient else "loss")):
-                        if mixed_precision and sys.platform == 'darwin':
-                            self.skipTest("Mixed Precision is not yet supported on Mac")
-                        if (mixed_precision and gradient) or (torch.cuda.device_count() > 1 and merge_grad > 1):
-                            with self.assertRaises(ValueError):
-                                run_test(mixed_precision, merge_grad, gradient)
-                        else:
-                            run_test(mixed_precision, merge_grad, gradient)
-
-    def test_tf_multi_optimizer_with_repeat_scheduler(self):
-        """This test cover the all combination of:
-            - mixed-precision / not
-            - merge_grad / not
-            - gradient input / loss input
-        """
-
-        def run_test(mixed_precision, merge_grad, gradient):
-            lr = 0.1
-            lr2 = 0.01
-            pipeline = fe.Pipeline(train_data=self.train_data,
-                                   batch_size=4,
-                                   ops=[ExpandDims(inputs="x", outputs="x"), Minmax(inputs="x", outputs="x")])
-
-            optimizer_fn = RepeatScheduler(
-                [lambda: tf.keras.optimizers.legacy.SGD(lr), lambda: tf.keras.optimizers.legacy.SGD(lr2)])
-
-            model = fe.build(model_fn=LeNet_tf, optimizer_fn=optimizer_fn, mixed_precision=mixed_precision)
-            network = fe.Network(ops=[
-                ModelOp(model=model, inputs="x", outputs="y_pred"),
-                CrossEntropy(inputs=("y_pred", "y"), outputs="ce"),
-                GradientOp(model=model, finals="ce", outputs="grad"),
-                UpdateOp(model=model, loss_name="ce", gradients=gradient, merge_grad=merge_grad),
-            ])
-
-            traces = [
-                CheckNetworkWeight(model=model,
-                                   grad_key="grad",
-                                   merge_grad=merge_grad,
-                                   test_self=self,
-                                   framework="tf",
-                                   lrs=[lr, lr2, lr, lr2],
-                                   work_intervals=[[1, 2], [2, 3], [3, 4], [4, 5]])
-            ]
-            estimator = fe.Estimator(pipeline=pipeline,
-                                     network=network,
-                                     epochs=4,
                                      traces=traces,
                                      train_steps_per_epoch=2)
             estimator.fit(warmup=False)

--- a/test/PR_test/integration_test/op/tensorop/test_argmax.py
+++ b/test/PR_test/integration_test/op/tensorop/test_argmax.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 import unittest
 
-import tensorflow as tf
 import torch
 
 from fastestimator.op.tensorop.argmax import Argmax
@@ -22,17 +21,11 @@ from fastestimator.test.unittest_util import is_equal
 
 
 class TestArgmax(unittest.TestCase):
+
     @classmethod
     def setUpClass(cls):
-        cls.tf_data = tf.constant([1., 2., 4.])
-        cls.tf_output = [tf.convert_to_tensor(2, dtype=tf.int64)]
         cls.torch_data = torch.tensor([1., 2., 4.], requires_grad=True)
         cls.torch_output = [torch.tensor(2, dtype=torch.long)]
-
-    def test_tf_input(self):
-        argmax = Argmax(inputs='x', outputs='x')
-        output = argmax.forward(data=[self.tf_data], state={})
-        self.assertTrue(is_equal(output, self.tf_output))
 
     def test_torch_input(self):
         argmax = Argmax(inputs='x', outputs='x')

--- a/test/PR_test/integration_test/op/tensorop/test_average.py
+++ b/test/PR_test/integration_test/op/tensorop/test_average.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 import unittest
 
-import tensorflow as tf
 import torch
 
 from fastestimator.op.tensorop.average import Average
@@ -22,17 +21,11 @@ from fastestimator.test.unittest_util import is_equal
 
 
 class TestAverage(unittest.TestCase):
+
     @classmethod
     def setUpClass(cls):
-        cls.tf_data = [tf.constant([1., 2., 4.]), tf.constant([1., 4., 5.])]
-        cls.tf_output = tf.constant([1., 3., 4.5])
         cls.torch_data = [torch.tensor([1., 2., 4.]), torch.tensor([1., 4., 5.])]
         cls.torch_output = torch.tensor([1., 3., 4.5])
-
-    def test_tf_input(self):
-        average = Average(inputs='x', outputs='x')
-        output = average.forward(data=self.tf_data, state={})
-        self.assertTrue(is_equal(output, self.tf_output))
 
     def test_torch_input(self):
         average = Average(inputs='x', outputs='x')

--- a/test/PR_test/integration_test/op/tensorop/test_delete.py
+++ b/test/PR_test/integration_test/op/tensorop/test_delete.py
@@ -17,20 +17,14 @@ import unittest
 import numpy as np
 import torch
 import torch.nn as nn
-from tensorflow.keras.layers import Input
-from tensorflow.keras.models import Model
 
 import fastestimator as fe
 from fastestimator.op.tensorop import Delete, LambdaOp
 from fastestimator.op.tensorop.model import ModelOp
 
 
-def _TFModel():
-    inputs = Input((1, 1))
-    return Model(inputs=inputs, outputs=inputs)
-
-
 class _TorchModel(nn.Module):
+
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
         self.dense = nn.Linear(in_features=1, out_features=1)
@@ -62,29 +56,11 @@ def _torch_model():
     )
 
 
-def _tf_model():
-    return fe.build(
-        model_fn=_TFModel,
-        optimizer_fn="adam",
-    )
-
-
 def _batch():
     return {"x": np.ones((4, 1), dtype=np.float32), "y": np.zeros((4, 1), dtype=np.uint8)}
 
 
 class TestSlicer(unittest.TestCase):
-    def test_delete_new_key_transform_tf(self):
-        result = _new_key_network(model=_tf_model()).transform(data=_batch(), mode="test")
-        self.assertIn("x", result)
-        np.testing.assert_array_almost_equal(result['x'], np.array([[2], [2], [2], [2]]))
-        self.assertNotIn("y_pred", result)
-
-    def test_delete_old_key_transform_tf(self):
-        result = _old_key_network(model=_tf_model()).transform(data=_batch(), mode="test")
-        # X will still be in the response, but it's value should be the old input value rather than the updated value
-        np.testing.assert_array_almost_equal(result["x"], np.array([[1], [1], [1], [1]]))
-        self.assertIn("y_pred", result)
 
     def test_delete_new_key_transform_torch(self):
         result = _new_key_network(model=_torch_model()).transform(data=_batch(), mode="test")

--- a/test/PR_test/integration_test/op/tensorop/test_reshape.py
+++ b/test/PR_test/integration_test/op/tensorop/test_reshape.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 import unittest
 
-import tensorflow as tf
 import torch
 
 from fastestimator.op.tensorop.reshape import Reshape
@@ -24,15 +23,8 @@ from fastestimator.test.unittest_util import is_equal
 class TestReshape(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
-        cls.tf_data = tf.constant([[1., 2., 4.], [1., 2., 6.]])
-        cls.tf_output = tf.constant([[1., 2., 4., 1., 2., 6.]])
         cls.torch_data = torch.tensor([[1., 2., 4.], [1., 2., 6.]])
         cls.torch_output = torch.tensor([[1., 2., 4., 1., 2., 6.]])
-
-    def test_tf_input(self):
-        reshape = Reshape(inputs='x', outputs='x', shape=(1, 6))
-        output = reshape.forward(data=[self.tf_data], state={})
-        self.assertTrue(is_equal(output[0], self.tf_output))
 
     def test_torch_input(self):
         reshape = Reshape(inputs='x', outputs='x', shape=(1, 6))

--- a/test/PR_test/integration_test/op/tensorop/test_un_hadamard.py
+++ b/test/PR_test/integration_test/op/tensorop/test_un_hadamard.py
@@ -15,7 +15,6 @@
 import unittest
 
 import numpy as np
-import tensorflow as tf
 import torch
 
 from fastestimator.op.tensorop.un_hadamard import UnHadamard
@@ -23,32 +22,6 @@ from fastestimator.test.unittest_util import is_equal
 
 
 class TestUnHadamard(unittest.TestCase):
-    def test_tf_4class(self):
-        fromhadamard = UnHadamard(inputs='y', outputs='y', n_classes=4)
-        fromhadamard.build('tf')
-        output = fromhadamard.forward(
-            data=[
-                tf.constant([[1., -1., -1., 1.], [-1., 1., -1., -1.], [-1., 1., -1., -1.], [-1., 1., -1., -1.],
-                             [-1., 1., 1., 1.]])
-            ],
-            state={})[0]
-        output = np.argmax(output, axis=-1)
-        self.assertTrue(is_equal(output, np.array([3, 2, 2, 2, 0])))
-
-    def test_tf_10class_16code(self):
-        fromhadamard = UnHadamard(inputs='y', outputs='y', n_classes=10, code_length=16)
-        fromhadamard.build('tf')
-        output = fromhadamard.forward(
-            data=[
-                tf.constant([[-1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.,
-                              1.], [1., -1., 1., -1., 1., -1., 1., -1., 1., -1., 1., -1., 1., -1., 1.,
-                                    -1.], [1., -1., 1., -1., 1., -1., 1., -1., -1., 1., -1., 1., -1., 1., -1.,
-                                           1.], [-1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1., 1.],
-                             [-1., 1., 1., 1., -1., -1., -1., -1., 1., 1., 1., 1., -1., -1., -1., -1.]])
-            ],
-            state={})[0]
-        output = np.argmax(output, axis=-1)
-        self.assertTrue(is_equal(output, np.array([0, 1, 9, 0, 4])))
 
     def test_torch_4class(self):
         fromhadamard = UnHadamard(inputs='y', outputs='y', n_classes=4)

--- a/test/PR_test/unit_test/op/loss/test_focal_loss.py
+++ b/test/PR_test/unit_test/op/loss/test_focal_loss.py
@@ -15,7 +15,6 @@
 import unittest
 
 import numpy as np
-import tensorflow as tf
 import torch
 
 from fastestimator.backend import binary_crossentropy
@@ -42,28 +41,6 @@ class TestFocalLoss(unittest.TestCase):
                                      [[[0.9], [0.3], [0.5], [0.3]], [[0.4], [0.8], [0.2], [0.3]],
                                       [[0.7], [0.1], [0.2], [0.5]], [[0.4], [0.6], [0.3], [0.4]]]],
                                     dtype=np.float32)
-
-    def test_focal_loss_tf(self):
-        fl = focal_loss(
-            y_pred=tf.constant(self.pred),
-            y_true=tf.constant(self.true),
-            gamma=2.0,
-            alpha=0.25,
-        )
-        self.assertAlmostEqual(0.112, fl, delta=0.01)
-
-    def test_focal_loss_tf_3d(self):
-        fl = focal_loss(y_pred=tf.constant(self.pred_tf_seg),
-                        y_true=tf.constant(self.true_tf_seg),
-                        gamma=2.0,
-                        alpha=0.25)
-        self.assertAlmostEqual(0.142, fl, delta=0.01)
-
-    def test_focal_loss_tf_4d(self):
-        true = tf.reshape(tf.constant(self.true_tf_seg), (2, 1, 4, 4, 1))
-        pred = tf.reshape(tf.constant(self.pred_tf_seg), (2, 1, 4, 4, 1))
-        fl = focal_loss(y_pred=pred, y_true=true, gamma=2.0, alpha=0.25)
-        self.assertAlmostEqual(0.142, fl, delta=0.01)
 
     def test_focal_loss_torch(self):
         fl = focal_loss(y_pred=torch.tensor(self.pred), y_true=torch.tensor(self.true), gamma=2.0, alpha=0.25)

--- a/test/PR_test/unit_test/op/numpyop/test_numpyop.py
+++ b/test/PR_test/unit_test/op/numpyop/test_numpyop.py
@@ -15,13 +15,14 @@
 import unittest
 
 import numpy as np
-import tensorflow as tf
+import torch
 
 from fastestimator.op.numpyop import LambdaOp
 from fastestimator.test.unittest_util import is_equal
 
 
 class TestLambdaOp(unittest.TestCase):
+
     def test_single_input(self):
         op = LambdaOp(fn=np.sum)
         data = op.forward(data=[[1, 2, 3]], state={})
@@ -34,6 +35,6 @@ class TestLambdaOp(unittest.TestCase):
 
     def test_batch_forward(self):
         op = LambdaOp(fn=np.sum)
-        data = tf.convert_to_tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+        data = torch.tensor([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
         result = op.forward_batch(data=[data], state={})
         self.assertEqual(result, 45)

--- a/test/PR_test/unit_test/op/tensorop/augmentation/test_mixup_batch.py
+++ b/test/PR_test/unit_test/op/tensorop/augmentation/test_mixup_batch.py
@@ -14,49 +14,20 @@
 # ==============================================================================
 import unittest
 
-import tensorflow as tf
 import torch
 
 from fastestimator.op.tensorop.augmentation.mixup_batch import MixUpBatch
 from fastestimator.test.unittest_util import is_equal
 
 
-class MyTFBeta:
-    @staticmethod
-    def sample(sample_shape=(1, )):
-        return 0.5 * tf.ones(shape=sample_shape)
-
-
 class MyTorchBeta:
+
     @staticmethod
     def sample(sample_shape=(1, )):
         return 0.5 * torch.ones(size=sample_shape)
 
 
 class TestMixUpBatch(unittest.TestCase):
-    def test_tf_shared_beta(self):
-        data_x = tf.stack([tf.ones((32, 32, 3)), tf.zeros((32, 32, 3))])
-        data_y = tf.stack([tf.ones((10)), tf.zeros((10))])
-        expected_x = tf.stack([0.5 * tf.ones((32, 32, 3)), 0.5 * tf.ones((32, 32, 3))])
-        expected_y = tf.stack([0.5 * tf.ones((10)), 0.5 * tf.ones((10))])
-        mu = MixUpBatch(inputs=["x", "y"], outputs=["x", "y"], alpha=1.0, mode="train", shared_beta=True)
-        mu.build('tf')
-        mu.beta = MyTFBeta()
-        output = mu.forward(data=[data_x, data_y], state={})
-        self.assertTrue(is_equal(output[0], expected_x))
-        self.assertTrue(is_equal(output[1], expected_y))
-
-    def test_tf_different_beta(self):
-        data_x = tf.stack([tf.ones((32, 32, 3)), tf.zeros((32, 32, 3))])
-        data_y = tf.stack([tf.ones((10)), tf.zeros((10))])
-        expected_x = tf.stack([0.5 * tf.ones((32, 32, 3)), 0.5 * tf.ones((32, 32, 3))])
-        expected_y = tf.stack([0.5 * tf.ones((10)), 0.5 * tf.ones((10))])
-        mu = MixUpBatch(inputs=["x", "y"], outputs=["x", "y"], alpha=1.0, mode="train", shared_beta=False)
-        mu.build('tf')
-        mu.beta = MyTFBeta()
-        output = mu.forward(data=[data_x, data_y], state={})
-        self.assertTrue(is_equal(output[0], expected_x))
-        self.assertTrue(is_equal(output[1], expected_y))
 
     def test_torch_shared_beta(self):
         data_x = torch.cat([torch.ones((1, 3, 32, 32)), torch.zeros((1, 3, 32, 32))], dim=0)

--- a/test/PR_test/unit_test/op/tensorop/meta/test_fuse.py
+++ b/test/PR_test/unit_test/op/tensorop/meta/test_fuse.py
@@ -14,19 +14,20 @@
 # ==============================================================================
 import unittest
 
-import tensorflow as tf
+import torch
 
 from fastestimator.op.tensorop import LambdaOp
 from fastestimator.op.tensorop.meta import Fuse
 
 
 class TestFuse(unittest.TestCase):
+
     @classmethod
     def setUpClass(cls):
         cls.output_shape = (28, 28, 3)
-        cls.multi_input_tf = [tf.random.uniform(shape=(28, 28, 3)), tf.random.uniform(shape=(28, 28, 3))]
+        cls.multi_input_tf = [torch.rand(28, 28, 3), torch.rand(28, 28, 3)]
 
-    def test_single_input_tf(self):
+    def test_single_input_torch(self):
         a = LambdaOp(inputs='x', outputs='y', fn=lambda x: x + 1, mode='test')
         b = LambdaOp(inputs=['y', 'z'], outputs='w', fn=lambda x, y: x + y, mode='test')
         fuse = Fuse([a, b])
@@ -42,8 +43,7 @@ class TestFuse(unittest.TestCase):
         with self.subTest('Check output image shape'):
             self.assertEqual(output[0].shape, self.output_shape)
 
-    @tf.function
-    def test_single_input_tf_static(self):
+    def test_single_input_torch_static(self):
         a = LambdaOp(inputs='x', outputs='y', fn=lambda x: x + 1, mode='test')
         b = LambdaOp(inputs=['y', 'z'], outputs='w', fn=lambda x, y: x + y, mode='test')
         fuse = Fuse([a, b])

--- a/test/PR_test/unit_test/op/tensorop/meta/test_one_of.py
+++ b/test/PR_test/unit_test/op/tensorop/meta/test_one_of.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 import unittest
 
-import tensorflow as tf
 import torch
 
 from fastestimator.op.tensorop import LambdaOp
@@ -22,67 +21,12 @@ from fastestimator.op.tensorop.meta import OneOf
 
 
 class TestOneOf(unittest.TestCase):
+
     @classmethod
     def setUpClass(cls):
         cls.output_shape = (28, 28, 3)
-        cls.single_input_tf = [tf.random.uniform(shape=(28, 28, 3))]
-        cls.multi_input_tf = [tf.random.uniform(shape=(28, 28, 3)), tf.random.uniform(shape=(28, 28, 3))]
         cls.single_input_torch = [torch.ones(size=(28, 28, 3))]
         cls.multi_input_torch = [torch.ones(size=(28, 28, 3)), torch.ones(size=(28, 28, 3))]
-
-    def test_single_input_tf(self):
-        a = LambdaOp(inputs='x', outputs='x', fn=lambda x: x + 1)
-        b = LambdaOp(inputs='x', outputs='x', fn=lambda x: x + 5)
-        oneof = OneOf(a, b)
-        oneof.build('tf')
-        output = oneof.forward(data=self.single_input_tf, state={})
-        with self.subTest('Check output type'):
-            self.assertTrue(tf.is_tensor(output))
-        with self.subTest('Check output image shape'):
-            self.assertEqual(output.shape, self.output_shape)
-
-    def test_multi_input_tf(self):
-        a = LambdaOp(inputs=['x', 'y'], outputs=['y', 'z'], fn=lambda x, y: [x + y, x - y])
-        b = LambdaOp(inputs=['x', 'y'], outputs=['y', 'z'], fn=lambda x, y: [x * y, x + y])
-        c = LambdaOp(inputs=['x', 'y'], outputs=['y', 'z'], fn=lambda x, y: [y, x])
-        oneof = OneOf(a, b, c)
-        oneof.build('tf')
-        output = oneof.forward(data=self.multi_input_tf, state={})
-        with self.subTest('Check output type'):
-            self.assertEqual(type(output), list)
-        with self.subTest('Check output list length'):
-            self.assertEqual(len(output), 2)
-        for img_output in output:
-            with self.subTest('Check output image shape'):
-                self.assertEqual(img_output.shape, self.output_shape)
-
-    @tf.function
-    def test_single_input_tf_static(self):
-        a = LambdaOp(inputs='x', outputs='x', fn=lambda x: x + 1)
-        b = LambdaOp(inputs='x', outputs='x', fn=lambda x: x + 5)
-        oneof = OneOf(a, b)
-        oneof.build('tf')
-        output = oneof.forward(data=self.single_input_tf, state={})
-        with self.subTest('Check output type'):
-            self.assertTrue(tf.is_tensor(output))
-        with self.subTest('Check output image shape'):
-            self.assertEqual(output.shape, self.output_shape)
-
-    @tf.function
-    def test_multi_input_tf_static(self):
-        a = LambdaOp(inputs=['x', 'y'], outputs=['y', 'z'], fn=lambda x, y: [x + y, x - y])
-        b = LambdaOp(inputs=['x', 'y'], outputs=['y', 'z'], fn=lambda x, y: [x * y, x + y])
-        c = LambdaOp(inputs=['x', 'y'], outputs=['y', 'z'], fn=lambda x, y: [y, x])
-        oneof = OneOf(a, b, c)
-        oneof.build('tf')
-        output = oneof.forward(data=self.multi_input_tf, state={})
-        with self.subTest('Check output type'):
-            self.assertEqual(type(output), list)
-        with self.subTest('Check output list length'):
-            self.assertEqual(len(output), 2)
-        for img_output in output:
-            with self.subTest('Check output image shape'):
-                self.assertEqual(img_output.shape, self.output_shape)
 
     def test_single_input_torch(self):
         a = LambdaOp(inputs='x', outputs='x', fn=lambda x: x + 1)
@@ -109,25 +53,6 @@ class TestOneOf(unittest.TestCase):
         for img_output in output:
             with self.subTest('Check output image shape'):
                 self.assertEqual(img_output.shape, self.output_shape)
-
-
-    def test_probability_left_tf(self):
-        op1 = LambdaOp(fn=lambda x: tf.convert_to_tensor(1.0), inputs="x", outputs="x")
-        op2 = LambdaOp(fn=lambda x: tf.convert_to_tensor(2.0), inputs="x", outputs="x")
-        oneof = OneOf(op1, op2, probs=[1.0, 0])
-        oneof.build('tf')
-        outputs = set(oneof.forward(data=self.single_input_tf, state={}).numpy() for _ in range(10))
-        self.assertEqual(len(outputs), 1)
-        self.assertEqual(outputs.pop(), 1.0)
-
-    def test_probability_right_tf(self):
-        op1 = LambdaOp(fn=lambda x: tf.convert_to_tensor(1.0), inputs="x", outputs="x")
-        op2 = LambdaOp(fn=lambda x: tf.convert_to_tensor(2.0), inputs="x", outputs="x")
-        oneof = OneOf(op1, op2, probs=[0, 1.0])
-        oneof.build('tf')
-        outputs = set(oneof.forward(data=self.single_input_tf, state={}).numpy() for _ in range(10))
-        self.assertEqual(len(outputs), 1)
-        self.assertEqual(outputs.pop(), 2.0)
 
     def test_probability_left_torch(self):
         op1 = LambdaOp(fn=lambda x: torch.zeros(1), inputs="x", outputs="x")

--- a/test/PR_test/unit_test/op/tensorop/meta/test_repeat.py
+++ b/test/PR_test/unit_test/op/tensorop/meta/test_repeat.py
@@ -14,209 +14,13 @@
 # ==============================================================================
 import unittest
 
-import tensorflow as tf
+import torch
 
 from fastestimator.op.tensorop import LambdaOp
 from fastestimator.op.tensorop.meta import Repeat
 
 
 class TestRepeat(unittest.TestCase):
-    def test_single_repeat_int_tf(self):
-        add_op = LambdaOp(inputs='x', outputs=('x', 'y'), fn=lambda x: (x + 1, x * x), mode='eval')
-        repeat_op = Repeat(add_op, repeat=1)
-        repeat_op.build('tf')
-        with self.subTest('Check op inputs'):
-            self.assertListEqual(repeat_op.inputs, ['x'])
-        with self.subTest('Check op outputs'):
-            self.assertListEqual(repeat_op.outputs, ['x', 'y'])
-        with self.subTest('Check op mode'):
-            self.assertSetEqual(repeat_op.mode, {'eval'})
-        output = repeat_op.forward(data=[tf.ones([1])], state={"deferred": {}, "mode": "eval"})
-        with self.subTest('Check output type'):
-            self.assertEqual(type(output), list)
-        with self.subTest('Check output value (x)'):
-            self.assertEqual(2, output[0])
-        with self.subTest('Check output value (y)'):
-            self.assertEqual(1, output[1])
-
-    def test_multi_repeat_int_tf(self):
-        add_op = LambdaOp(inputs='x', outputs=('x', 'y'), fn=lambda x: (x + 1, x * x), mode='eval')
-        repeat_op = Repeat(add_op, repeat=5)
-        repeat_op.build('tf')
-        with self.subTest('Check op inputs'):
-            self.assertListEqual(repeat_op.inputs, ['x'])
-        with self.subTest('Check op outputs'):
-            self.assertListEqual(repeat_op.outputs, ['x', 'y'])
-        with self.subTest('Check op mode'):
-            self.assertSetEqual(repeat_op.mode, {'eval'})
-        output = repeat_op.forward(data=[tf.ones([1])], state={"deferred": {}, "mode": "eval"})
-        with self.subTest('Check output type'):
-            self.assertEqual(type(output), list)
-        with self.subTest('Check output value (x)'):
-            self.assertEqual(6, output[0])
-        with self.subTest('Check output value (y)'):
-            self.assertEqual(25, output[1])
-
-    def test_single_repeat_fn_interior_value_tf(self):
-        add_op = LambdaOp(inputs='x', outputs=('x', 'y'), fn=lambda x: (x + 1, x * x), mode='eval')
-        repeat_op = Repeat(add_op, repeat=lambda y: y < 1)
-        repeat_op.build('tf')
-        with self.subTest('Check op inputs'):
-            self.assertListEqual(repeat_op.inputs, ['x'])
-        with self.subTest('Check op outputs'):
-            self.assertListEqual(repeat_op.outputs, ['x', 'y'])
-        with self.subTest('Check op mode'):
-            self.assertSetEqual(repeat_op.mode, {'eval'})
-        output = repeat_op.forward(data=[tf.ones([1])], state={"deferred": {}, "mode": "eval"})
-        with self.subTest('Check output type'):
-            self.assertEqual(type(output), list)
-        with self.subTest('Check output value (x)'):
-            self.assertEqual(2, output[0])
-        with self.subTest('Check output value (y)'):
-            self.assertEqual(1, output[1])
-
-    def test_multi_repeat_fn_interior_value_tf(self):
-        add_op = LambdaOp(inputs='x', outputs=('x', 'y'), fn=lambda x: (x + 1, x * x), mode='eval')
-        repeat_op = Repeat(add_op, repeat=lambda y: y < 25)
-        repeat_op.build('tf')
-        with self.subTest('Check op inputs'):
-            self.assertListEqual(repeat_op.inputs, ['x'])
-        with self.subTest('Check op outputs'):
-            self.assertListEqual(repeat_op.outputs, ['x', 'y'])
-        with self.subTest('Check op mode'):
-            self.assertSetEqual(repeat_op.mode, {'eval'})
-        output = repeat_op.forward(data=[tf.ones([1])], state={"deferred": {}, "mode": "eval"})
-        with self.subTest('Check output type'):
-            self.assertEqual(type(output), list)
-        with self.subTest('Check output value (x)'):
-            self.assertEqual(6, output[0])
-        with self.subTest('Check output value (y)'):
-            self.assertEqual(25, output[1])
-
-    def test_repeat_fn_exterior_value_tf(self):
-        add_op = LambdaOp(inputs='x', outputs=('x', 'y'), fn=lambda x: (x + 1, x * x), mode='eval')
-        repeat_op = Repeat(add_op, repeat=lambda y, z: y + z < 25)
-        repeat_op.build('tf')
-        with self.subTest('Check op inputs'):
-            self.assertListEqual(repeat_op.inputs, ['x', 'z'])
-        with self.subTest('Check op outputs'):
-            self.assertListEqual(repeat_op.outputs, ['x', 'y'])
-        with self.subTest('Check op mode'):
-            self.assertSetEqual(repeat_op.mode, {'eval'})
-        with tf.GradientTape(persistent=True) as tape:
-            output = repeat_op.forward(data=[tf.ones([1]), 10 + tf.ones([1])],
-                                       state={"deferred": {}, "mode": "eval", "tape": tape})
-        with self.subTest('Check output type'):
-            self.assertEqual(type(output), list)
-        with self.subTest('Check output value (x)'):
-            self.assertEqual(5, output[0])
-        with self.subTest('Check output value (y)'):
-            self.assertEqual(16, output[1])
-
-    def test_single_repeat_int_static(self):
-        add_op = LambdaOp(inputs='x', outputs=('x', 'y'), fn=lambda y: (y + 1, y * y), mode='eval')
-        repeat_op = Repeat(add_op, repeat=1)
-        repeat_op.build('tf')
-        with self.subTest('Check op inputs'):
-            self.assertListEqual(repeat_op.inputs, ['x'])
-        with self.subTest('Check op outputs'):
-            self.assertListEqual(repeat_op.outputs, ['x', 'y'])
-        with self.subTest('Check op mode'):
-            self.assertSetEqual(repeat_op.mode, {'eval'})
-        x = [tf.ones([1])]
-        output = tf.function(lambda y: repeat_op.forward(data=y, state={"deferred": {}, "mode": "eval"}))
-        output(x)  # build the graph
-        output = output(x)
-        with self.subTest('Check output type'):
-            self.assertEqual(type(output), list)
-        with self.subTest('Check output value (x)'):
-            self.assertEqual(2, output[0])
-        with self.subTest('Check output value (y)'):
-            self.assertEqual(1, output[1])
-
-    def test_multi_repeat_int_static(self):
-        add_op = LambdaOp(inputs='x', outputs=('x', 'y'), fn=lambda z: (z + 1, z * z), mode='eval')
-        repeat_op = Repeat(add_op, repeat=5)
-        repeat_op.build('tf')
-        with self.subTest('Check op inputs'):
-            self.assertListEqual(repeat_op.inputs, ['x'])
-        with self.subTest('Check op outputs'):
-            self.assertListEqual(repeat_op.outputs, ['x', 'y'])
-        with self.subTest('Check op mode'):
-            self.assertSetEqual(repeat_op.mode, {'eval'})
-        x = [tf.ones([1])]
-        output = tf.function(lambda y: repeat_op.forward(data=y, state={"deferred": {}, "mode": "eval"}))
-        output(x)  # build the graph
-        output = output(x)
-        with self.subTest('Check output type'):
-            self.assertEqual(type(output), list)
-        with self.subTest('Check output value (x)'):
-            self.assertEqual(6, output[0])
-        with self.subTest('Check output value (y)'):
-            self.assertEqual(25, output[1])
-
-    def test_single_repeat_fn_interior_value_static(self):
-        add_op = LambdaOp(inputs='x', outputs=('x', 'y'), fn=lambda z: (z + 1, z * z), mode='eval')
-        repeat_op = Repeat(add_op, repeat=lambda y: y < 1)
-        repeat_op.build('tf')
-        with self.subTest('Check op inputs'):
-            self.assertListEqual(repeat_op.inputs, ['x'])
-        with self.subTest('Check op outputs'):
-            self.assertListEqual(repeat_op.outputs, ['x', 'y'])
-        with self.subTest('Check op mode'):
-            self.assertSetEqual(repeat_op.mode, {'eval'})
-        x = [tf.ones([1])]
-        output = tf.function(lambda y: repeat_op.forward(data=y, state={"deferred": {}, "mode": "eval"}))
-        output(x)  # build the graph
-        output = output(x)
-        with self.subTest('Check output type'):
-            self.assertEqual(type(output), list)
-        with self.subTest('Check output value (x)'):
-            self.assertEqual(2, output[0])
-        with self.subTest('Check output value (y)'):
-            self.assertEqual(1, output[1])
-
-    def test_multi_repeat_fn_interior_value_static(self):
-        add_op = LambdaOp(inputs='x', outputs=('x', 'y'), fn=lambda z: (z + 1, z * z), mode='eval')
-        repeat_op = Repeat(add_op, repeat=lambda y: y < 25)
-        repeat_op.build('tf')
-        with self.subTest('Check op inputs'):
-            self.assertListEqual(repeat_op.inputs, ['x'])
-        with self.subTest('Check op outputs'):
-            self.assertListEqual(repeat_op.outputs, ['x', 'y'])
-        with self.subTest('Check op mode'):
-            self.assertSetEqual(repeat_op.mode, {'eval'})
-        x = [tf.ones([1])]
-        output = tf.function(lambda y: repeat_op.forward(data=y, state={"deferred": {}, "mode": "eval"}))
-        output(x)
-        output = output(x)
-        with self.subTest('Check output type'):
-            self.assertEqual(type(output), list)
-        with self.subTest('Check output value (x)'):
-            self.assertEqual(6, output[0])
-        with self.subTest('Check output value (y)'):
-            self.assertEqual(25, output[1])
-
-    def test_repeat_fn_exterior_value_static(self):
-        add_op = LambdaOp(inputs='x', outputs=('x', 'y'), fn=lambda w: (w + 1, w * w), mode='eval')
-        repeat_op = Repeat(add_op, repeat=lambda y, z: y + z < 25)
-        repeat_op.build('tf')
-        with self.subTest('Check op inputs'):
-            self.assertListEqual(repeat_op.inputs, ['x', 'z'])
-        with self.subTest('Check op outputs'):
-            self.assertListEqual(repeat_op.outputs, ['x', 'y'])
-        with self.subTest('Check op mode'):
-            self.assertSetEqual(repeat_op.mode, {'eval'})
-        x = [tf.ones([1]), 10 + tf.ones([1])]
-        output = tf.function(lambda y: repeat_op.forward(data=y, state={"deferred": {}, "mode": "eval"}))
-        output(x)
-        output = output(x)
-        with self.subTest('Check output type'):
-            self.assertEqual(type(output), list)
-        with self.subTest('Check output value (x)'):
-            self.assertEqual(5, output[0])
-        with self.subTest('Check output value (y)'):
-            self.assertEqual(16, output[1])
 
     def test_single_repeat_int_torch(self):
         add_op = LambdaOp(inputs='x', outputs=('x', 'y'), fn=lambda x: (x + 1, x * x), mode='eval')
@@ -228,7 +32,7 @@ class TestRepeat(unittest.TestCase):
             self.assertListEqual(repeat_op.outputs, ['x', 'y'])
         with self.subTest('Check op mode'):
             self.assertSetEqual(repeat_op.mode, {'eval'})
-        output = repeat_op.forward(data=[tf.ones([1])], state={"deferred": {}, "mode": "eval"})
+        output = repeat_op.forward(data=[torch.ones([1])], state={"deferred": {}, "mode": "eval"})
         with self.subTest('Check output type'):
             self.assertEqual(type(output), list)
         with self.subTest('Check output value (x)'):
@@ -246,7 +50,7 @@ class TestRepeat(unittest.TestCase):
             self.assertListEqual(repeat_op.outputs, ['x', 'y'])
         with self.subTest('Check op mode'):
             self.assertSetEqual(repeat_op.mode, {'eval'})
-        output = repeat_op.forward(data=[tf.ones([1])], state={"deferred": {}, "mode": "eval"})
+        output = repeat_op.forward(data=[torch.ones([1])], state={"deferred": {}, "mode": "eval"})
         with self.subTest('Check output type'):
             self.assertEqual(type(output), list)
         with self.subTest('Check output value (x)'):
@@ -264,7 +68,7 @@ class TestRepeat(unittest.TestCase):
             self.assertListEqual(repeat_op.outputs, ['x', 'y'])
         with self.subTest('Check op mode'):
             self.assertSetEqual(repeat_op.mode, {'eval'})
-        output = repeat_op.forward(data=[tf.ones([1])], state={"deferred": {}, "mode": "eval"})
+        output = repeat_op.forward(data=[torch.ones([1])], state={"deferred": {}, "mode": "eval"})
         with self.subTest('Check output type'):
             self.assertEqual(type(output), list)
         with self.subTest('Check output value (x)'):
@@ -282,7 +86,7 @@ class TestRepeat(unittest.TestCase):
             self.assertListEqual(repeat_op.outputs, ['x', 'y'])
         with self.subTest('Check op mode'):
             self.assertSetEqual(repeat_op.mode, {'eval'})
-        output = repeat_op.forward(data=[tf.ones([1])], state={"deferred": {}, "mode": "eval"})
+        output = repeat_op.forward(data=[torch.ones([1])], state={"deferred": {}, "mode": "eval"})
         with self.subTest('Check output type'):
             self.assertEqual(type(output), list)
         with self.subTest('Check output value (x)'):
@@ -300,7 +104,7 @@ class TestRepeat(unittest.TestCase):
             self.assertListEqual(repeat_op.outputs, ['x', 'y'])
         with self.subTest('Check op mode'):
             self.assertSetEqual(repeat_op.mode, {'eval'})
-        output = repeat_op.forward(data=[tf.ones([1]), 10 + tf.ones([1])], state={"deferred": {}, "mode": "eval"})
+        output = repeat_op.forward(data=[torch.ones([1]), 10 + torch.ones([1])], state={"deferred": {}, "mode": "eval"})
         with self.subTest('Check output type'):
             self.assertEqual(type(output), list)
         with self.subTest('Check output value (x)'):

--- a/test/PR_test/unit_test/op/tensorop/meta/test_sometimes.py
+++ b/test/PR_test/unit_test/op/tensorop/meta/test_sometimes.py
@@ -14,7 +14,6 @@
 # ==============================================================================
 import unittest
 
-import tensorflow as tf
 import torch
 
 from fastestimator.op.tensorop import LambdaOp
@@ -22,61 +21,12 @@ from fastestimator.op.tensorop.meta import Sometimes
 
 
 class TestSometimes(unittest.TestCase):
+
     @classmethod
     def setUpClass(cls):
         cls.output_shape = (28, 28, 3)
-        cls.single_input_tf = [tf.random.uniform(shape=(28, 28, 3))]
-        cls.multi_input_tf = [tf.random.uniform(shape=(28, 28, 3)), tf.random.uniform(shape=(28, 28, 3))]
         cls.single_input_torch = [torch.ones(size=(28, 28, 3))]
         cls.multi_input_torch = [torch.ones(size=(28, 28, 3)), torch.ones(size=(28, 28, 3))]
-
-    def test_single_input_tf(self):
-        a = LambdaOp(inputs='x', outputs='x', fn=lambda x: x + 1)
-        sometimes = Sometimes(a, prob=0.75)
-        sometimes.build('tf')
-        output = sometimes.forward(data=self.single_input_tf, state={})
-        with self.subTest('Check output type'):
-            self.assertEqual(type(output), list)
-        with self.subTest('Check output image shape'):
-            self.assertEqual(output[0].shape, self.output_shape)
-
-    def test_multi_input_tf(self):
-        a = LambdaOp(inputs=['x', 'y'], outputs=['y', 'x'], fn=lambda x, y: [x + y, x - y])
-        sometimes = Sometimes(a)
-        sometimes.build('tf')
-        output = sometimes.forward(data=self.multi_input_tf, state={})
-        with self.subTest('Check output type'):
-            self.assertEqual(type(output), list)
-        with self.subTest('Check output list length'):
-            self.assertEqual(len(output), 2)
-        for img_output in output:
-            with self.subTest('Check output image shape'):
-                self.assertEqual(img_output.shape, self.output_shape)
-
-    @tf.function
-    def test_single_input_tf_static(self):
-        a = LambdaOp(inputs='x', outputs='x', fn=lambda x: x + 1)
-        sometimes = Sometimes(a, prob=0.75)
-        sometimes.build('tf')
-        output = sometimes.forward(data=self.single_input_tf, state={})
-        with self.subTest('Check output type'):
-            self.assertEqual(type(output), list)
-        with self.subTest('Check output image shape'):
-            self.assertEqual(output[0].shape, self.output_shape)
-
-    @tf.function
-    def test_multi_input_tf_static(self):
-        a = LambdaOp(inputs=['x', 'y'], outputs=['y', 'x'], fn=lambda x, y: [x + y, x - y])
-        sometimes = Sometimes(a)
-        sometimes.build('tf')
-        output = sometimes.forward(data=self.multi_input_tf, state={})
-        with self.subTest('Check output type'):
-            self.assertEqual(type(output), list)
-        with self.subTest('Check output list length'):
-            self.assertEqual(len(output), 2)
-        for img_output in output:
-            with self.subTest('Check output image shape'):
-                self.assertEqual(img_output.shape, self.output_shape)
 
     def test_single_input_torch(self):
         a = LambdaOp(inputs='x', outputs='x', fn=lambda x: x + 1)

--- a/test/PR_test/unit_test/op/tensorop/test_normalize.py
+++ b/test/PR_test/unit_test/op/tensorop/test_normalize.py
@@ -15,7 +15,6 @@
 import unittest
 
 import numpy as np
-import tensorflow as tf
 
 from fastestimator.backend import to_tensor
 from fastestimator.op.tensorop.normalize import Normalize
@@ -45,21 +44,6 @@ class TestNormalize(unittest.TestCase):
         self.numpy_array_int_torch = np.moveaxis(self.numpy_array_int, -1, 1)
         self.expected_result_torch = np.moveaxis(self.expected_result, -1, 1)
         self.expected_result_multi_torch = np.moveaxis(self.expected_result_multi, -1, 1)
-
-
-    def test_normalize_tf_int(self):
-        op = Normalize(inputs="image", outputs="image", mean=0.482, std=0.289, max_pixel_value=27)
-        data = op.forward(data=[tf.convert_to_tensor(self.numpy_array)], state={})
-        np.testing.assert_array_almost_equal(data[0].numpy(), self.expected_result, 2)
-
-    def test_normalize_tf_multi_int(self):
-        op = Normalize(inputs="image",
-                       outputs="image",
-                       mean=(0.44, 0.48, 0.52),
-                       std=(0.287, 0.287, 0.287),
-                       max_pixel_value=27)
-        data = op.forward(data=[tf.convert_to_tensor(self.numpy_array)], state={})
-        np.testing.assert_array_almost_equal(data[0].numpy(), self.expected_result_multi, 2)
 
     def test_normalize_torch(self):
         op = Normalize(inputs="image", outputs="image", mean=0.482, std=0.289, max_pixel_value=27.0)

--- a/test/PR_test/unit_test/op/tensorop/test_tensorop.py
+++ b/test/PR_test/unit_test/op/tensorop/test_tensorop.py
@@ -14,19 +14,20 @@
 # ==============================================================================
 import unittest
 
-import tensorflow as tf
+import torch
 
 from fastestimator.op.tensorop import LambdaOp
 from fastestimator.test.unittest_util import is_equal
 
 
 class TestLambdaOp(unittest.TestCase):
+
     def test_single_input(self):
-        op = LambdaOp(fn=tf.reduce_sum)
-        data = op.forward(data=tf.convert_to_tensor([[1, 2, 3]]), state={})
+        op = LambdaOp(fn=torch.sum)
+        data = op.forward(data=torch.tensor([[1, 2, 3]]), state={})
         self.assertEqual(data, 6)
 
     def test_multi_input(self):
-        op = LambdaOp(fn=tf.reshape)
-        data = op.forward(data=[tf.convert_to_tensor([1, 2, 3, 4]), (2, 2)], state={})
-        self.assertTrue(is_equal(data, tf.convert_to_tensor([[1, 2], [3, 4]])))
+        op = LambdaOp(fn=torch.reshape)
+        data = op.forward(data=[torch.tensor([1, 2, 3, 4]), (2, 2)], state={})
+        self.assertTrue(is_equal(data, torch.tensor([[1, 2], [3, 4]])))


### PR DESCRIPTION
Remove tensorflow backend dependency from the Ops. Also modify the test scripts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Removed all TensorFlow support from tensor operations, models, and augmentations. The framework now exclusively supports PyTorch for all tensor operations and model handling.
  - Type annotations and internal logic were updated to use only PyTorch tensors and models.
- **Tests**
  - Removed all TensorFlow-based test cases and data from integration and unit tests.
  - Updated tests to use PyTorch tensors and models exclusively, ensuring continued coverage for PyTorch workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->